### PR TITLE
Subsite countly

### DIFF
--- a/frontend/express/app.js
+++ b/frontend/express/app.js
@@ -17,7 +17,7 @@ var http = require('http'),
 console.log('Server running on port ' + countlyConfig.web.port);
 
 var redirect = function(res, url) {
-    res.redirect(countlyConfig.web.base +  url);
+	res.redirect(countlyConfig.web.base +  url);
 }
 
 function sha1Hash(str, addSalt) {
@@ -80,8 +80,8 @@ app.configure(function() {
 	app.use(express.methodOverride());
 	app.use(express.csrf());
 	app.use(app.router);
-    var oneYear = 31557600000;
-    app.use(express.static(__dirname + '/public'), { maxAge: oneYear });
+	var oneYear = 31557600000;
+	app.use(express.static(__dirname + '/public'), { maxAge: oneYear });
 });
 
 app.configure('development', function() {
@@ -98,11 +98,11 @@ app.get('/', function(req, res, next) {
 
 app.get('/logout', function(req, res, next) {
   if (req.session) {
-    req.session.uid = null;
+	req.session.uid = null;
 	req.session.gadm = null;
-    res.clearCookie('uid');
+	res.clearCookie('uid');
 	res.clearCookie('gadm');
-    req.session.destroy(function() {});
+	req.session.destroy(function() {});
   }
   redirect(res, 'login');
 });
@@ -211,7 +211,7 @@ app.get('/dashboard', function(req, res, next) {
 								username: member["username"],
 								global_admin: (member["global_admin"] == true)
 							},
-                            base: countlyConfig.web.base
+							base: countlyConfig.web.base
 						});
 					});
 				}


### PR DESCRIPTION
This is related to Issue #19 as I wanted to try out countly on my VPS without getting another domain name.

Here's the nginx config I used:

```
server {
        listen   80;
        server_name  127.0.0.1;

        access_log  off;

        location = /ct/i {
                rewrite /ct/(.*) /$1 break;
                proxy_pass http://127.0.0.1:3001;
                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
                proxy_set_header X-Real-IP $remote_addr;
        }

        location = /ct/o {
                rewrite /ct/(.*) /$1 break;
                proxy_pass http://127.0.0.1:3001;
        }

        location /ct/ {
                rewrite /ct/(.*) /$1 break;
                proxy_pass http://127.0.0.1:6001;
                proxy_set_header Host $http_host;
        }
}
```

Notice the rewrites make countly believe it's a root app. Most of the work was rewiring the html, css, js and images to play nice with <base>. I didn't thoroughly test this patch, but I did find that prefixfree has a bug which breaks some CSS https://github.com/LeaVerou/prefixfree/issues/134 and other than that it works for me.
