### PR TITLE
Session frequency consolidation changed

### DIFF
--- a/api/parts/data/usage.js
+++ b/api/parts/data/usage.js
@@ -188,18 +188,22 @@ var usage = {},
                 updateSessions[params.time.hourly + '.' + common.dbMap['unique']] = 1;
             }
 
+            //If user is not tracked today, update totals
             if (userLastSeenTimestamp <= (params.time.timestamp - secInHour)) {
                 uniqueLevels[uniqueLevels.length] = params.time.daily;
-            }
-
-            if (userLastSeenTimestamp <= (params.time.timestamp - secInMonth)) {
                 uniqueLevels[uniqueLevels.length] = params.time.monthly;
-            }
-
-            if (userLastSeenTimestamp < (params.time.timestamp - secInMonth)) {
                 uniqueLevels[uniqueLevels.length] = params.time.yearly;
             }
 
+            // if (userLastSeenTimestamp <= (params.time.timestamp - secInMonth)) {
+            //     uniqueLevels[uniqueLevels.length] = params.time.monthly;
+            // }
+            // 
+            // if (userLastSeenTimestamp < (params.time.timestamp - secInMonth)) {
+            //     uniqueLevels[uniqueLevels.length] = params.time.yearly;
+            // }
+            
+            
             for (var i = 0; i < uniqueLevels.length; i++) {
                 updateSessions[uniqueLevels[i] + '.' + common.dbMap['unique']] = 1;
                 updateLocations[uniqueLevels[i] + '.' + params.user.country + '.' + common.dbMap['unique']] = 1;


### PR DESCRIPTION
When the day passes, it should update the totals for month and years. Otherwise, the total range for month and year would be outdated. In this case, all the users would be included in the first range. 

It would also impact the results in frontend, when the data is refreshed and the last day retrieved from the server.
