### PR TITLE
"End session" method being called before "session duration" method

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -32,12 +32,12 @@ function validateAppForWriteAPI(params) {
 
         if (params.qstring.events) {
             countlyApi.data.events.processEvents(params);
+        } else if (params.qstring.end_session) {
+            countlyApi.data.usage.endUserSession(params);
         } else if (params.qstring.session_duration) {
             countlyApi.data.usage.processSessionDuration(params);
         } else if (params.qstring.begin_session) {
             countlyApi.data.usage.beginUserSession(params);
-        } else if (params.qstring.end_session) {
-            countlyApi.data.usage.endUserSession(params);
         } else {
             return false;
         }


### PR DESCRIPTION
Changed event processing order, so that end_session will be called before session duration.

The way it was implemented, end_session method would never be called as the mobile always sent session_duration method with end_session, as well.

So, the request would be treated by session_duration and end_session would never be updated.
