### PR TITLE
Altered creation of connections to mongo to allow for replications sets to be defined in config.js

### DIFF
--- a/api/config.sample.js
+++ b/api/config.sample.js
@@ -5,6 +5,17 @@ var countlyConfig = {
         port: 27017,
         max_pool_size: 1000
     },
+/*  or for a replication set
+    mongodb: {
+          replSetServers : [  '192.168.3.1:27017/?auto_reconnect=true',
+                            '192.168.3.2:27017/?auto_reconnect=true' ],
+        db: "countly",
+        max_pool_size: 1000
+    },
+*/
+/*  or define as a url
+    mongodb: "localhost:27017/countly?auto_reconnect=true"
+*/
     api: {
         workers: 0,
         port: 3001,

--- a/api/utils/common.js
+++ b/api/utils/common.js
@@ -39,8 +39,17 @@ var common = {},
         'has_ongoing_session': 'hos'
     };
 
-    var connectionString = (typeof countlyConfig.mongodb === "string")? countlyConfig.mongodb : (countlyConfig.mongodb.host + ':' + countlyConfig.mongodb.port + '/' + countlyConfig.mongodb.db + '?auto_reconnect=true');
-    common.db = mongo.db(connectionString, {safe:false, maxPoolSize: countlyConfig.mongodb.max_pool_size || 1000});
+    var dbName;
+    var dbOptions = { safe:false, maxPoolSize: countlyConfig.mongodb.max_pool_size || 1000 };
+    if  (typeof countlyConfig.mongodb === "string" ){
+        dbName = countlyConfig.mongodb;
+    } else if ( typeof countlyConfig.mongodb.replSetServers === 'object'){
+        dbName = countlyConfig.mongodb.replSetServers;
+        dbOptions.database = countlyConfig.mongodb.db || 'countly';
+    } else {
+        dbName = (countlyConfig.mongodb.host + ':' + countlyConfig.mongodb.port + '/' + countlyConfig.mongodb.db + '?auto_reconnect=true');
+    } 
+    common.db = mongo.db(dbName, dbOptions);
 
     common.config = countlyConfig;
 

--- a/frontend/express/app.js
+++ b/frontend/express/app.js
@@ -9,9 +9,19 @@ var http = require('http'),
     request = require('request'),
     countlyMail = require('../../api/parts/mgmt/mail.js'),
     countlyStats = require('../../api/parts/data/stats.js'),
-    countlyConfig = require('./config'),
-    connectionString = (typeof countlyConfig.mongodb === "string")? countlyConfig.mongodb : (countlyConfig.mongodb.host + ':' + countlyConfig.mongodb.port + '/' + countlyConfig.mongodb.db + '?auto_reconnect=true&safe=true'),
-    countlyDb = mongo.db(connectionString, {safe:true});
+    countlyConfig = require('./config');
+    
+var dbName;
+var dbOptions = { safe:true };
+if  (typeof countlyConfig.mongodb === "string" ){
+    dbName = countlyConfig.mongodb;
+} else if ( typeof countlyConfig.mongodb.replSetServers === 'object'){
+    dbName = countlyConfig.mongodb.replSetServers;
+    dbOptions.database = countlyConfig.mongodb.db || 'countly';
+} else {
+    dbName = (countlyConfig.mongodb.host + ':' + countlyConfig.mongodb.port + '/' + countlyConfig.mongodb.db + '?auto_reconnect=true');
+} 
+var countlyDb = mongo.db(dbName, dbOptions);
 
 function sha1Hash(str, addSalt) {
     var salt = (addSalt) ? new Date().getTime() : "";

--- a/frontend/express/config.sample.js
+++ b/frontend/express/config.sample.js
@@ -4,6 +4,16 @@ var countlyConfig = {
         db: "countly",
         port: 27017
     },
+/*  or for a replication set
+    mongodb: {
+          replSetServers : [  '192.168.3.1:27017/?auto_reconnect=true',
+                            '192.168.3.2:27017/?auto_reconnect=true' ],
+        db: "countly",
+    },
+*/
+/*  or define as a url
+    mongodb: "localhost:27017/countly?auto_reconnect=true"
+*/
     web: {
         port: 6001,
         host: "localhost",


### PR DESCRIPTION
This is a response to the Onur's port on Aug 21, 2013 at http://support.count.ly/discussions/problems/150-problem-upgrading-to-latest-version-1306-error-cannot-find-module-homeoilcountly-serverfrontendexpressappjs 

I was also unable to find a connection string that would accomplish this.  The changes were based on documentation at https://github.com/kissjs/node-mongoskin#dbserverurls-dboptions-replicasetoptions and the existing county code.
