### PR TITLE
respond with 400 if events or metrics JSON data is not properly formatted

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -329,6 +329,8 @@ if (cluster.isMaster) {
 
                     } catch (SyntaxError) {
                         console.log('Parse metrics JSON failed');
+                        common.returnMessage(params, 400, 'metrics JSON is not properly formed');
+                        return false
                     }
                 }
 
@@ -337,6 +339,8 @@ if (cluster.isMaster) {
                         params.qstring.events = JSON.parse(params.qstring.events);
                     } catch (SyntaxError) {
                         console.log('Parse events JSON failed');
+                        common.returnMessage(params, 400, 'events JSON is not properly formed');
+                        return false;
                     }
                 }
 
@@ -425,6 +429,8 @@ if (cluster.isMaster) {
                                 params.qstring.events = JSON.parse(params.qstring.events);
                             } catch (SyntaxError) {
                                 console.log('Parse events array failed');
+                                common.returnMessage(params, 400, 'events JSON is not properly formed');
+                                break;
                             }
 
                             validateUserForDataReadAPI(params, countlyApi.data.fetch.fetchMergedEventData);


### PR DESCRIPTION
Use Case: Every now and then (been fairly difficult for us to reproduce) the iOS SDK sends improperly formatted JSON data in the events parameter.

example: `/i?app_key=key&device_id=id&timestamp=1398821482&events=[{"key":"eventKey","count":1,"segmentation":{"ProductIds":}]`

We were tipped off to this by funny data in our mongoDB collections 
`{"2014": {
    "": {
      "c": 31
    } ...`
where one would expect the day or month instead of an empty parameter.  We saw a similar request to the above query string in our nginx logs during testing.  Following the api code path it seems that the try catch blocks surrounding the JSON.parse calls really just swallow the exception and don't do anything about it, allowing the request to make it through to the data access layer.  So I'm proposing a 400 response immediately after a bad JSON.parse
