### PR TITLE
Add Vagrant-based integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@ api/config.js
 frontend/express/config.js
 frontend/express/public/javascripts/countly/countly.config.js
 closure-compiler.jar
+
+# Vagrant-related & test data
+.vagrant/
+log/
+bin/config/nginx.default.backup
+

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,24 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+# Installer script to set up Countly on the box
+# run in noninteractive mode because of packages asking "dialog" questions
+installer_script = <<SCRIPT
+  export DEBIAN_FRONTEND=noninteractive
+  /vagrant/bin/countly.install.sh
+SCRIPT
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # Every Vagrant virtual environment requires a box to build off of.
+  config.vm.box = "ubuntu/trusty64"
+
+  config.vm.provision :shell, inline: installer_script
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+end

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/tests/integration/post-install.coffee
+++ b/tests/integration/post-install.coffee
@@ -1,0 +1,41 @@
+# This test checks that everything is set up correctly
+# after running the countly.install.sh script
+
+assert = require 'assert'
+http = require 'http'
+expect = require('chai').expect
+
+check_http = (done, port_num, expected_http_code, path = '/') ->
+  req = http.request(
+     hostname: 'localhost',
+     port: port_num,
+     path: path
+  , (res) ->
+    expect(res.statusCode).to.equal(expected_http_code)
+    done()
+  )
+  req.on 'error', (e) ->
+    done(e)
+  req.end()
+
+describe 'Countly', () ->
+  describe 'API', () ->
+    describe 'runs on port 3001', () ->
+      it 'responds to /i', (done) ->
+        # will complain about missing API key
+        check_http(done, 3001, 400, '/i')
+      it 'responds to /o', (done) ->
+        check_http(done, 3001, 400, '/o')
+
+  describe 'Frontend', () ->
+    it 'runs on port 6001', (done) ->
+      # will redirect to login or setup
+      check_http(done, 6001, 302)
+
+  describe 'Web-Proxy', () ->
+    it 'runs on port 80', (done) ->
+      check_http(done, 80, 302)
+    it 'responds to /i', (done) ->
+      check_http(done, 80, 400, '/i')
+    it 'responds to /o', (done) ->
+      check_http(done, 80, 400, '/o')

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# if not running in vagrant, run in vagrant :)
+if [ ! -d /vagrant ]; then
+  vagrant up
+  vagrant ssh -c "/vagrant/tests/run_tests.sh"
+  exit $?
+fi
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+pushd $DIR > /dev/null
+
+# check & install dependencies as required
+for DEP in coffee-script mocha chai; do
+  if [ ! -d node_modules/$DEP ]; then
+    npm install $DEP
+  fi
+done
+
+# run integration tests
+PATH=$(npm bin):$PATH mocha --compilers coffee:coffee-script/register --recursive integration/
+
+popd > /dev/null


### PR DESCRIPTION
As a prerequisite for some modifications to the installer script, I created a simple Vagrant setup to provision a box with Countly and a test script to check whether all ports are open as expected.

Looking forward to any feedback!