### PR TITLE
Allow zero value in the badge parameter

### DIFF
--- a/plugins/push/api/parts/pushly/message.js
+++ b/plugins/push/api/parts/pushly/message.js
@@ -291,7 +291,7 @@ module.exports.Message = function (apps, names) {
                     content.sound = this.sound;
                 }
 
-                if (this.badge) {
+                if (_.isNumber(this.badge)) {
                     content.badge = this.badge;
                 }
 


### PR DESCRIPTION
We should be able to send a badge equals zero to clear the iOS notification center and badge count.

The if statement was bypassing the parameter, since it was testing a falsey value.