### PR TITLE
Does not work in Fedora 22

### DIFF
--- a/bin/scripts/countly.install.plugins.sh
+++ b/bin/scripts/countly.install.plugins.sh
@@ -1,3 +1,3 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-nodejs $DIR/install_plugins
+node $DIR/install_plugins


### PR DESCRIPTION
Seems that Fedora nodesource rpm has no "nodejs>node" symlink