### PR TITLE
[common] common.returnOutput add apiCallback support

### DIFF
--- a/api/utils/common.js
+++ b/api/utils/common.js
@@ -776,6 +776,9 @@ var common = {},
     * @param {object} headers - headers to add to the output
     */
     common.returnOutput = function (params, output, noescape, heads) {
+        if(params && params.APICallback && typeof params.APICallback === 'function'){
+            return params.APICallback(output);
+        }
         //set provided in configuration headers
         var headers = {'Content-Type': 'application/json; charset=utf-8', 'Access-Control-Allow-Origin':'*'};
         var add_headers = (plugins.getConfig("security").api_additional_headers || "").replace(/\r\n|\r|\n|\/n/g, "\n").split("\n");


### PR DESCRIPTION
The default returnOutput will response to client side.
Now add support to resoonse to a callbackfunction when a plugin api call  countly core functions.