### PR TITLE
Fix for fetch.js fetchEvents function

### DIFF
--- a/api/parts/data/fetch.js
+++ b/api/parts/data/fetch.js
@@ -650,7 +650,10 @@ var fetch = {},
                 try{
                     params.qstring.events = JSON.parse(params.qstring.events);
                 }
-                catch(ex){}
+                catch(ex){
+		    common.returnMessage(params, 400, 'Must provide valid array with event keys as events param.');
+                    return false;
+		}
             }
             if(Array.isArray(params.qstring.events)){
                 var data = {};


### PR DESCRIPTION
The former version omits the JSON parse exceptions. Since the type of "params.qstring.events" still a string after the parse attempt, the if block doesn't get executed, and the function exits silently. Naturally, the system doesn't generate a response for requests that contain bad "events" querystring, and leads to a timeout.