### PR TITLE
Fix for fetch.js fetchEvents function

### DIFF
--- a/api/parts/data/fetch.js
+++ b/api/parts/data/fetch.js
@@ -648,9 +648,15 @@ var fetch = {},
         else if(params.qstring.events && params.qstring.events.length){
             if(typeof params.qstring.events === "string"){
                 try{
-                    params.qstring.events = JSON.parse(params.qstring.events);
+                   params.qstring.events = JSON.parse(params.qstring.events);
+                   if(typeof params.qstring.events === "string"){
+                      params.qstring.events=[params.qstring.events]
+                   }
                 }
-                catch(ex){}
+                catch(ex){
+                   common.returnMessage(params, 400, 'Must provide valid array with event keys as events param.');
+                   return false;
+                }
             }
             if(Array.isArray(params.qstring.events)){
                 var data = {};


### PR DESCRIPTION
The former version omits the JSON parse exceptions. Since the type of "params.qstring.events" still a string after the parse attempt, the if block doesn't get executed, and the function exits silently. Naturally, the system doesn't generate a response for requests that contain bad "events" querystring, and leads to a timeout. Also even the input is parsed without any problems, the parsed input still can be a string, this fix also handles that case.