### PR TITLE
Added hall-of-fame to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,15 @@ Countly is extensible using the [plugin architecture](https://count.ly/plugins).
 
 Also, you are encouraged to read an extended contribution section on [how to contribute to Countly](https://github.com/Countly/countly-server/blob/master/CONTRIBUTING.md)
 
+[![0](https://sourcerer.io/fame/ar2rsawseen/Countly/countly-server/images/0)](https://sourcerer.io/fame/ar2rsawseen/Countly/countly-server/links/0)
+[![1](https://sourcerer.io/fame/ar2rsawseen/Countly/countly-server/images/1)](https://sourcerer.io/fame/ar2rsawseen/Countly/countly-server/links/1)
+[![2](https://sourcerer.io/fame/ar2rsawseen/Countly/countly-server/images/2)](https://sourcerer.io/fame/ar2rsawseen/Countly/countly-server/links/2)
+[![3](https://sourcerer.io/fame/ar2rsawseen/Countly/countly-server/images/3)](https://sourcerer.io/fame/ar2rsawseen/Countly/countly-server/links/3)
+[![4](https://sourcerer.io/fame/ar2rsawseen/Countly/countly-server/images/4)](https://sourcerer.io/fame/ar2rsawseen/Countly/countly-server/links/4)
+[![5](https://sourcerer.io/fame/ar2rsawseen/Countly/countly-server/images/5)](https://sourcerer.io/fame/ar2rsawseen/Countly/countly-server/links/5)
+[![6](https://sourcerer.io/fame/ar2rsawseen/Countly/countly-server/images/6)](https://sourcerer.io/fame/ar2rsawseen/Countly/countly-server/links/6)
+[![7](https://sourcerer.io/fame/ar2rsawseen/Countly/countly-server/images/7)](https://sourcerer.io/fame/ar2rsawseen/Countly/countly-server/links/7)
+
 ## Badges
 
 If you liked Countly, [why not use one of our badges](https://count.ly/brand-assets) and give a link back to us, so others know about this wonderful platform? 


### PR DESCRIPTION
As discussed with @ar2rsawseen by email.

Hall-of-fame is a widget that helps you recognize new/trending/top contributors in your repo. It is designed to be very visual, and change frequently. It autoupdates every hour and requires no maintenance.

Note that by accepting this PR, you will make me a contributor, which means my face will be featured as ’new’ on your Hall-of-fame for one week.

Also note that the widget uses @ar2rsawseen GitHub account to update stats, and makes 10-15 requests to GitHub API per hour (GitHub rate limit is 5,000 per hour).