### PR TITLE
Report Manager UI tweaks

### DIFF
--- a/frontend/express/public/javascripts/countly/countly.task.manager.js
+++ b/frontend/express/public/javascripts/countly/countly.task.manager.js
@@ -15,7 +15,6 @@
             data: {
                 "app_id": countlyCommon.ACTIVE_APP_ID,
                 "query": JSON.stringify(query || {}),
-                "period": countlyCommon.getPeriodForAjax(),
                 "display_loader": !isRefresh
             },
             dataType: "json",

--- a/frontend/express/public/javascripts/countly/countly.views.js
+++ b/frontend/express/public/javascripts/countly/countly.views.js
@@ -5169,7 +5169,7 @@ window.LongTaskView = countlyView.extend({
             "aoColumns": tableColumns
         }));
         this.dtable.stickyTableHeaders();
-        this.dtable.fnSort([ [3, 'desc'] ]);
+        this.dtable.fnSort([ [9, 'desc'] ]);
         $(this.el).append('<div class="cly-button-menu tasks-menu" tabindex="1">' +
             '<a class="item view-task" href="" data-localize="common.view"></a>' +
             '<a class="item rerun-task" data-localize="taskmanager.rerun"></a>' +

--- a/frontend/express/public/javascripts/countly/countly.views.js
+++ b/frontend/express/public/javascripts/countly/countly.views.js
@@ -5058,12 +5058,12 @@ window.LongTaskView = countlyView.extend({
             },
             {
                 "mData": function(row) {
-                    return row.name || row.meta || "";
+                    return "<span class=\"report-manager-data-content\">" + (row.name || row.meta || "") + "</span>";
                 },
                 "sType": "string",
                 "sTitle": jQuery.i18n.map["report-manager.data"],
                 "bSortable": false,
-                "sClass": "break"
+                "sClass": "break report-manager-data-col"
             },
             {
                 "mData": function(row) {

--- a/frontend/express/public/stylesheets/main.css
+++ b/frontend/express/public/stylesheets/main.css
@@ -2232,6 +2232,8 @@ h4 + .mgmt-plugins-row {
 #report-manager-view .ui-tabs .ui-tabs-nav li.ui-tabs-selected a{color:#333; border-bottom: 2px solid #19cc63 !important;}
 #report-manager-view .ui-tabs .ui-tabs-nav li {border-bottom:none !important; width: auto; margin-right: 30px;}
 #report-manager-view .ui-tabs .ui-tabs-nav {margin-top:0px; margin-top:10px; margin-bottom: 10px}
+.report-manager-data-col { width: 65%; }
+.report-data-content { display: inline-block; width: 95%; }
 .extable-link i { margin-right:10px; font-size:13px !important; line-height: 18px !important;}
 
 .dashboard-summary .item .bar .bar-inner-new-e{

--- a/frontend/express/views/dashboard.html
+++ b/frontend/express/views/dashboard.html
@@ -1935,7 +1935,6 @@
                     </div>
                     {{/if}}
 				</div>
-				{{> date-selector }}
 			</div>
 			{{#if graph-description}}
 			<div id="report-manager-graph-description" class="graph-description" style="border-bottom-width: 0px;">{{graph-description}}</div>


### PR DESCRIPTION
- Reports are now sorted by their start time with the newest at the top.
- Set a maximum width for the data column and its contents in the report manager so it doesn't squeeze the other columns into an unreadable size.
- Removed the date picker from the report manager, it lists all reports at once now.