### PR TITLE
[frontend] the data column in the report manager now adjusts its width accordingly

### DIFF
--- a/frontend/express/public/javascripts/countly/countly.views.js
+++ b/frontend/express/public/javascripts/countly/countly.views.js
@@ -5012,9 +5012,11 @@ window.LongTaskView = countlyView.extend({
         }
         if (self.taskCreatedBy === 'manually') {
             $("#report-manager-graph-description").text(jQuery.i18n.map['taskmanager.manually-table-remind']);
+            $(".report-manager-data-col").removeClass("report-manager-automatically-created");
         }
         else {
             $("#report-manager-graph-description").text(jQuery.i18n.map['taskmanager.automatically-table-remind']);
+            $(".report-manager-data-col").addClass("report-manager-automatically-created");
         }
         var manuallyColumns = [true, true, true, false, true, true, true, true, true, false, false];
         var automaticallyColumns = [false, false, true, true, true, false, false, false, false, true, true];
@@ -5058,7 +5060,7 @@ window.LongTaskView = countlyView.extend({
             },
             {
                 "mData": function(row) {
-                    return "<span class=\"report-manager-data-content\">" + (row.name || row.meta || "") + "</span>";
+                    return row.name || row.meta || "";
                 },
                 "sType": "string",
                 "sTitle": jQuery.i18n.map["report-manager.data"],

--- a/frontend/express/public/stylesheets/main.css
+++ b/frontend/express/public/stylesheets/main.css
@@ -2232,8 +2232,8 @@ h4 + .mgmt-plugins-row {
 #report-manager-view .ui-tabs .ui-tabs-nav li.ui-tabs-selected a{color:#333; border-bottom: 2px solid #19cc63 !important;}
 #report-manager-view .ui-tabs .ui-tabs-nav li {border-bottom:none !important; width: auto; margin-right: 30px;}
 #report-manager-view .ui-tabs .ui-tabs-nav {margin-top:0px; margin-top:10px; margin-bottom: 10px}
-.report-manager-data-col { width: 65%; }
-.report-data-content { display: inline-block; width: 95%; }
+.report-manager-data-col { width: 100%; max-width: 15%; }
+.report-manager-data-col.report-manager-automatically-created { max-width: 55%; }
 .extable-link i { margin-right:10px; font-size:13px !important; line-height: 18px !important;}
 
 .dashboard-summary .item .bar .bar-inner-new-e{


### PR DESCRIPTION
It seems that while I fixed the data column for automatically created reports in #812, I botched it for manually created ones. The data column in the report manager now adjusts its width accordingly to the table type i.e. manually or automatically created.