### PR TITLE
[frontend] used width instead of max-width to resize the data column

### DIFF
--- a/frontend/express/public/stylesheets/main.css
+++ b/frontend/express/public/stylesheets/main.css
@@ -2232,8 +2232,8 @@ h4 + .mgmt-plugins-row {
 #report-manager-view .ui-tabs .ui-tabs-nav li.ui-tabs-selected a{color:#333; border-bottom: 2px solid #19cc63 !important;}
 #report-manager-view .ui-tabs .ui-tabs-nav li {border-bottom:none !important; width: auto; margin-right: 30px;}
 #report-manager-view .ui-tabs .ui-tabs-nav {margin-top:0px; margin-top:10px; margin-bottom: 10px}
-.report-manager-data-col { width: 100%; max-width: 15%; }
-.report-manager-data-col.report-manager-automatically-created { max-width: 55%; }
+.report-manager-data-col { width: 15%; }
+.report-manager-data-col.report-manager-automatically-created { width: 55%; }
 .extable-link i { margin-right:10px; font-size:13px !important; line-height: 18px !important;}
 
 .dashboard-summary .item .bar .bar-inner-new-e{


### PR DESCRIPTION
Replaced `max-width` with `width` in the `.report-manager-data-col` parts of the CSS.

> CSS 2.1 leaves the behavior of max-width with table undefined. Firefox supports applying max-width to table elements.