### PR TITLE
[frontend] fixed countlyLocation not drawing a map when geochart is already initialized

### DIFF
--- a/frontend/express/public/javascripts/countly/countly.location.js
+++ b/frontend/express/public/javascripts/countly/countly.location.js
@@ -76,7 +76,12 @@
 
     countlyLocation.refreshGeoChart = function(metric) {
         if (google.visualization) {
-            reDraw(metric);
+            if (_chart === undefined) {
+                draw(metric);
+            }
+            else {
+                reDraw(metric);
+            }
         }
         else {
             google.load('visualization', '1', {


### PR DESCRIPTION
I ran into this while developing another plugin. I *think* it's caused by `google.visualization` being already initialized but I'm not sure. Either way, this fixes it by making sure there is a `_chart` to `.draw` before it calls `reDraw`.