### PR TITLE
Add --ignore-installed flag to installation of supervisor

### DIFF
--- a/bin/countly.install_rhel.sh
+++ b/bin/countly.install_rhel.sh
@@ -63,7 +63,7 @@ else
     pip install pip --upgrade
 fi
 yum install -y python-meld3
-pip install supervisor
+pip install supervisor --ignore-installed meld3
 
 #install sendmail
 yum -y install sendmail


### PR DESCRIPTION
Add --ignore-installed flag to installation of supervisor to prevent meld3 conflict.