### PR TITLE
Add www to prevent wget error because of domain redirection

### DIFF
--- a/bin/scripts/install.nghttp2.sh
+++ b/bin/scripts/install.nghttp2.sh
@@ -29,7 +29,7 @@ elif [ -n "$(command -v yum)" ]; then
     fi
 
     yum install -y git make binutils autoconf automake makedepend libtool pkgconfig zlib-devel libxml2-devel python-setuptools
-    wget https://openssl.org/source/openssl-1.0.2h.tar.gz
+    wget https://www.openssl.org/source/openssl-1.0.2h.tar.gz
     tar -zxvf openssl-1.0.2h.tar.gz -C /usr/local/src
     cd /usr/local/src/openssl-1.0.2h
     ./config --prefix=/usr


### PR DESCRIPTION
https://openssl.org is redirecting to https://www.openssl.org and `wget` can't handle this redirection and can't install openssl-1.0.2h.