### PR TITLE
Allow low memory instances < 2GB with swap

### DIFF
--- a/bin/countly.install.sh
+++ b/bin/countly.install.sh
@@ -1,11 +1,16 @@
 #!/bin/bash
-totalm=$(free -m | awk '/^Mem:/{print $2}')
-if [ "$totalm" -lt "1800" ]; then
-    echo "Countly requires at least 2Gb of RAM" 
-    exit 1
-fi
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 DATE=`date +%Y-%m-%d:%H:%M:%S`
+totalm=$(free -m | awk '/^Mem:/{print $2}')
+if [ "$totalm" -lt "1800" ]; then
+    echo "Countly requires at least 2Gb of RAM"
+    if [ "$COUNTLY_OVERWRITE_MEM_REQUIREMENT" != "1" ]; then
+        exit 1
+    else
+        echo "COUNTLY_OVERWRITE_MEM_REQUIREMENT set, running make.swap.sh"
+        bash $DIR/scripts/make.swap.sh 2>&1 | tee $DIR/../log/countly-install-$DATE.log
+    fi
+fi
 if [ -f $DIR/offline_installer.sh ]; then
     bash $DIR/offline_installer.sh 2>&1 | tee $DIR/../log/countly-install-$DATE.log
 elif [ -f /etc/lsb-release ]; then

--- a/bin/scripts/make.swap.sh
+++ b/bin/scripts/make.swap.sh
@@ -4,14 +4,18 @@ set -e
 # and writes to /etc/fstab so that swap is enabled each time your instance is rebooted.
 # Run it if your instance has a small memory (e.g less than 2GB) so it doesn't 
 # go out of RAM.
+if free | awk '/^Swap:/ {exit !$2}'; then
+    echo "Swap space already exists, skipping make.swap.sh"
+    exit 1
+fi
 
 #amount in GB
 AMOUNT=${1:-4}
 echo "Attempting to create $AMOUNT Gb swap file"
 echo "Reserving space, may take a while"
 
-#create file
-dd if=/dev/zero of=/swapfile bs=1G count=$AMOUNT
+#create file with small bs setting to allow the dd on low mem instances
+dd if=/dev/zero of=/swapfile bs=1024 count=$(($AMOUNT*1048576))
 chmod 600 /swapfile
 
 #make file a swap file


### PR DESCRIPTION
When MongoDB is placed on different instances, there is no hard limitation that would prevent instances with less than 2GB of memory to be used. Script that creates a swap file has been modified to work on smaller VMs (blocksize was reduced so it does not need 1GB of free memory just to create a swap file) and added a check to see if swap space already exists.

Result: using environment variable COUNTLY_OVERWRITE_MEM_REQUIREMENT, you can bypass the warning that 2GB of memory is required and still install countly (it will create a swap file if it does not already exist).
Countly can run on a 1GB node with local MongoDB or even on a 512MB instance if: 
1. MongoDB runs on a different instance
2. A max of 1 api worker by adding "workers: 1" in api/config.js