### PR TITLE
AWS SES - Simple Email Service example

### DIFF
--- a/extend/.gitignore
+++ b/extend/.gitignore
@@ -2,3 +2,4 @@
 *
 # Except this file
 !.gitignore
+!aws_ses.example.js


### PR DESCRIPTION
Example of emailing via AWS SES.
Maybe a good idea is to mention it in the documentation under https://resources.count.ly/docs/installing-countly-server#section-using-a-3rd-party-email-server as a separate section called "using a 3rd party email SERVICE"