### PR TITLE
Bugfix to prevent error in slimscroll. 

### DIFF
--- a/frontend/express/public/javascripts/dom/slimScroll.min.js
+++ b/frontend/express/public/javascripts/dom/slimScroll.min.js
@@ -361,8 +361,8 @@
                 {
                     if (window.addEventListener)
                     {
-                        target.addEventListener('DOMMouseScroll', _onWheel, false );
-                        target.addEventListener('mousewheel', _onWheel, false );
+                        this.addEventListener('DOMMouseScroll', _onWheel, { capture: false, passive: false } );
+                        this.addEventListener('mousewheel', _onWheel, { capture: false, passive: false } );
                     }
                     else
                     {


### PR DESCRIPTION
Preventing error: "Unable to preventDefault inside passive event listener due to target being treated as passive".