### PR TITLE
Fixed version matching regular expression and version sorting

### DIFF
--- a/bin/scripts/checking_versions.js
+++ b/bin/scripts/checking_versions.js
@@ -38,7 +38,7 @@ else {
 }
 
 //reading version numbers from upgrade folder
-var pattern = new RegExp(/^(([0-9])*\.)*[0-9]*$/);
+var pattern = new RegExp(/^\d{1,2}(\.\d{1,2}){0,3}$/);
 try {
     var dir_items = fs.readdirSync(__dirname + "/../upgrade");
     for (var i = 0; i < dir_items.length; i++) {
@@ -59,7 +59,26 @@ try {
 catch (error) {
     process.stdout.write(error);
 }
-versions = versions.sort();
+
+function compareVersions(a, b) {
+    var aParts = a.split('.');
+    var bParts = b.split('.');
+
+    for (var i = 0; i < aParts.length && i < bParts.length; i++) {
+        var aPartNum = parseInt(aParts[i], 10);
+        var bPartNum = parseInt(bParts[i], 10);
+
+        const cmp = Math.sign(aPartNum - bPartNum);
+
+        if (cmp !== 0) {
+            return cmp;
+        }
+    }
+
+    return Math.sign(a.length - b.length);
+}
+
+versions = versions.sort(compareVersions);
 
 var from = 0;
 var til = versions.length - 1;


### PR DESCRIPTION
This PR contains 2 changes:
1. Version matching regular expression
2. Version sorting

### Version matching regular expression

The current expression allows pretty much any version, whereas some script comment clearly stats that version numbers must not be larger than 2 digits.

Considering the following test code:
```
const pattern = new RegExp(/^(([0-9])*\.)*[0-9]*$/);

const tests = [
    '9',
    '9.3',
    '16',
    '16.1',
    '16.01',
    '16.1.2',
    '16.1.2.3',
    '16.11.22.33',
    '16.111',
    '16.1.222.3',
    '16.',
    '16..',
    '16..123456',
    '16.1.2.3.4.5.6.7',
];

for (const t of tests) {
    console.log(`${t}: ${pattern.test(t)}`);
}
```

Hereafter is the result with current pattern:
```
9: true
9.3: true
16: true
16.1: true
16.01: true
16.1.2: true
16.1.2.3: true
16.11.22.33: true
16.111: true
16.1.222.3: true
16.: true
16..: true
16..123456: true
16.1.2.3.4.5.6.7: true
```
Everything matches, not ideal.

Hereafter is the result with the new pattern:
```
9: true
9.3: true
16: true
16.1: true
16.01: true
16.1.2: true
16.1.2.3: true
16.11.22.33: true
16.111: false
16.1.222.3: false
16.: false
16..: false
16..123456: false
16.1.2.3.4.5.6.7: false
```
Closer to what we really want.

If the first version part (major) has be to be 2 digits, the pattern can be tweaked as follow: `/^\d{2}(\.\d{1,2}){0,3}$/`.

### Version sorting

The current code incorrectly sorts folders when two (or more) versions have the same major and minor but also have a revision number.

For example, the case with `19.02.2` and `19.02.11`, with default sorting logic (lexicographic) the sorting is wrong is produces the following:

```
...;19.02.11;19.02.2;...
```

With the version centric sorting logic, this problem is solved and we get the following:

```
...;19.02.2;19.02.11;...
```
