### PR TITLE
Made versions comparison mathematically correct

### DIFF
--- a/bin/scripts/checking_versions.js
+++ b/bin/scripts/checking_versions.js
@@ -75,7 +75,24 @@ function compareVersions(a, b) {
         }
     }
 
-    return Math.sign(a.length - b.length);
+    if (aParts.length === bParts.length) {
+        return 0;
+    }
+
+    let longestArray = aParts;
+    if (bParts.length > longestArray.length) {
+        longestArray = bParts;
+    }
+
+    const continueIndex = Math.min(aParts.length, bParts.length);
+
+    for (let i = continueIndex; i < longestArray.length; i += 1) {
+        if (parseInt(longestArray[i], 10) > 0) {
+            return longestArray === bParts ? -1 : +1;
+        }
+    }
+
+    return 0;
 }
 
 versions = versions.sort(compareVersions);


### PR DESCRIPTION
This fix makes sure `15` is equal to `15.0` and not considered smaller.
In term of versions sorting, it's not a big deal and the old code does not break ordering, but it's better to be accurate.

Sorry for introducing this issue in my previous PR.