### PR TITLE
[crashes] fixed crash menu arrow

### DIFF
--- a/plugins/crashes/frontend/public/javascripts/countly.views.js
+++ b/plugins/crashes/frontend/public/javascripts/countly.views.js
@@ -1567,6 +1567,13 @@ window.CrashgroupView = countlyView.extend({
                     $("#crashgroup-manipulation-menu").css("opacity", 0);
                     $("#crashgroup-manipulation-menu").hide();
                 }
+
+                if ($("#crashgroup-manipulation-menu").is(":hidden")) {
+                    $("#crashgroup-manipulation-trigger i").removeClass("ion-chevron-up").addClass("ion-chevron-down");
+                }
+                else {
+                    $("#crashgroup-manipulation-trigger i").removeClass("ion-chevron-down").addClass("ion-chevron-up");
+                }
             });
 
             $("#crashgroup-manipulation-menu .item.crash-manipulation-button").off("click").on("click", function(event) {


### PR DESCRIPTION
Fixed a bug where the crash manipulation menu chevron wasn't updated if you clicked somewhere else on the screen to close it.