### PR TITLE
gracefully skip puppeteer if not installed

### DIFF
--- a/api/utils/render.js
+++ b/api/utils/render.js
@@ -5,7 +5,17 @@
 * @module api/utils/render
 */
 
-var puppeteer = require('puppeteer');
+var puppeteer;
+try {
+    puppeteer = require('puppeteer');
+}
+catch (err) {
+    console.warn(
+        `Puppeteer not installed. Please install puppeteer (1.19.0) if
+        you would like to use api/utils/render.js. \nGracefully skipping
+        any functionality associated with Puppeteer...`, err.stack
+    );
+}
 var Promise = require('bluebird');
 var pathModule = require('path');
 var exec = require('child_process').exec;
@@ -34,6 +44,12 @@ var countlyConfig = require('./../config', 'dont-enclose');
  * @param  {function} cb - callback function called with the error value or the image data
  */
 exports.renderView = function(options, cb) {
+    if (puppeteer === undefined) {
+        cb = typeof cb === 'function' ? cb : () => undefined;
+        return cb(new Error(
+            'Puppeteer not installed. Please install Puppeteer (1.19.0) to use this plugin.'
+        ));
+    }
     Promise.coroutine(function * () {
         /**
          * Function to set a timeout


### PR DESCRIPTION
I installed Countly on my own Archlinux server, and didn't want to go through the hassle of dealing with compiling/installing Puppeteer. Since I noticed that it wasn't that essential to use Puppeteer, I removed it from my own package.json. I figured this would be a nice RT check: if the user (server admin / developer) has opted out of installing Puppeteer, then simply ignore the functionality which depends on Puppeteer.