### PR TITLE
NGINX SSL update

### DIFF
--- a/bin/config/nginx.server.ssl.conf
+++ b/bin/config/nginx.server.ssl.conf
@@ -38,7 +38,7 @@ server {
     # 3.) fixed ECDH cipher (does not allow for PFS)
     # 4.) known vulnerable cypers (MD5, RC4, etc)
     # 5.) little-used ciphers (Camellia, Seed)
-    ssl_ciphers 'kEECDH+ECDSA+AES128 kEECDH+ECDSA+AES256 kEECDH+AES128 kEECDH+AES256 kEDH+AES128 kEDH+AES256 DES-CBC3-SHA +SHA !aNULL !eNULL !LOW !kECDH !DSS !MD5 !EXP !PSK !SRP !CAMELLIA !SEED';
+    ssl_ciphers 'kEECDH+ECDSA+AES128 kEECDH+ECDSA+AES256 kEECDH+AES128 kEECDH+AES256 kEDH+AES128 kEDH+AES256 +SHA !DES-CBC3-SHA !aNULL !eNULL !LOW !kECDH !DSS !3DES !MD5 !EXP !PSK !SRP !CAMELLIA !SEED';
 
     # Cache SSL Sessions for up to 10 minutes
     # This improves performance by avoiding the costly session negotiation process where possible


### PR DESCRIPTION
Updated `ssl_ciphers` due to latest security tests.