### PR TITLE
[platform-percentage-missmatch] missmatch fixed. but not sure it was …

### DIFF
--- a/frontend/express/public/javascripts/countly/countly.device.detail.js
+++ b/frontend/express/public/javascripts/countly/countly.device.detail.js
@@ -92,7 +92,7 @@
         ], "platforms");
         chartData.chartData = countlyCommon.mergeMetricsByName(chartData.chartData, "os_");
         var platformNames = _.pluck(chartData.chartData, 'os_'),
-            platformTotal = _.pluck(chartData.chartData, 'u'),
+            platformTotal = _.pluck(chartData.chartData, 't'),
             chartData2 = [];
 
         /*var sum = _.reduce(platformTotal, function(memo, num) {


### PR DESCRIPTION
…a problem.

- top bars at main screen is shows sessions counts.
- and the platforms chart that inside of platform view is shows users count.
- this difference is creating a missmatch between platforms view and platforms top bar.
- for solve this missmatch I changed "u" property as "t" that represent to sessions instead of users and this make both values are equal.