### PR TITLE
Populator templates hotfixes

### DIFF
--- a/plugins/populator/frontend/public/javascripts/countly.models.js
+++ b/plugins/populator/frontend/public/javascripts/countly.models.js
@@ -535,9 +535,6 @@
             else if (id === "[CLY]_view") {
                 event.dur = getRandomInt(0, 100);
             }
-            else {
-                event.dur = getRandomInt(0, 10);
-            }
 
             if (eventTemplate && eventTemplate.sum) {
                 event.sum = getRandomInt(eventTemplate.sum[0], eventTemplate.sum[1] || 10);

--- a/plugins/populator/frontend/public/javascripts/countly.models.js
+++ b/plugins/populator/frontend/public/javascripts/countly.models.js
@@ -1191,6 +1191,7 @@
             delete template.events[""]; // delete events without keys
             Object.keys(template.events).forEach(function(key) {
                 var event = template.events[key];
+
                 if (event.segments) {
                     delete event.segments[""];
                 }
@@ -1199,12 +1200,7 @@
                     delete event.segments;
                 }
 
-                if (Object.keys(event).length === 0) {
-                    delete template.events[key];
-                }
-                else {
-                    template.events[key] = event;
-                }
+                template.events[key] = event;
             });
 
             if (template.events.length === 0) {


### PR DESCRIPTION
- fixed events with just names (nothing else) being culled when being sent to the API
- removed adding duration to events without duration in their templates (except internal view events)