### PR TITLE
Update .shellcheckrc

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -4,3 +4,5 @@ disable=SC2164
 disable=SC2237
 disable=SC2002
 disable=SC2012
+disable=SC2001
+disable=SC2116


### PR DESCRIPTION
Ignore 2 rules:
- SC2116: Useless echo? Instead of 'cmd $(echo foo)', just use 'cmd foo'.
- SC2001: See if you can use ${variable//search/replace} instead.