### PR TITLE
Made pluginsManager's dispatch function more error resilient

### DIFF
--- a/plugins/pluginManager.js
+++ b/plugins/pluginManager.js
@@ -435,7 +435,12 @@ var pluginManager = function pluginManager() {
         if (events[event]) {
             try {
                 for (let i = 0, l = events[event].length; i < l; i++) {
-                    promise = events[event][i].call(null, params);
+                    try {
+                        promise = events[event][i].call(null, params);
+                    }
+                    catch (error) {
+                        promise = Promise.reject(error);
+                    }
                     if (promise) {
                         used = true;
                     }
@@ -449,14 +454,6 @@ var pluginManager = function pluginManager() {
             if (params && params.params && params.params.promises) {
                 params.params.promises.push(new Promise(function(resolve) {
                     Promise.allSettled(promises).then(function(results) {
-                        results = results.map(function(result) {
-                            if (result.isRejected()) {
-                                console.log(result.reason());
-                            }
-                            else {
-                                return result.value();
-                            }
-                        });
                         resolve();
                         if (callback) {
                             callback(null, results);
@@ -466,14 +463,6 @@ var pluginManager = function pluginManager() {
             }
             else if (callback) {
                 Promise.allSettled(promises).then(function(results) {
-                    results = results.map(function(result) {
-                        if (result.isRejected()) {
-                            console.log(result.reason());
-                        }
-                        else {
-                            return result.value();
-                        }
-                    });
                     callback(null, results);
                 });
             }


### PR DESCRIPTION
As we discussed, here are the changes:

1. The call to `register`ed function now supports the cases where it throws synchronously.
I'm not sure if the `if (promise) { used = true; }` should go in the `try` block to not set to true in case of error. Let me know.

2. Result of settled promises is not reduced to their value anymore, giving more control to the caller of `dispatch` for error handling.