### PR TITLE
[SERVER-1845] Bugfix. Deleting multiple events Confirmation button is of screen.

### DIFF
--- a/frontend/express/public/javascripts/countly/countly.views.js
+++ b/frontend/express/public/javascripts/countly/countly.views.js
@@ -4211,6 +4211,7 @@ window.EventsBlueprintView = countlyView.extend({
             countlyEvent.setActiveEvent(previousEvent);
         }
         this.template = Handlebars.compile($("#template-events-blueprint").html());
+        this.textLimit = 100;
     },
     pageScript: function() {
         var self = this;
@@ -4399,6 +4400,10 @@ window.EventsBlueprintView = countlyView.extend({
                     var eventName = el.data('name');
                     if (eventName === "") {
                         eventName = event;
+                    }
+
+                    if (eventName.length > self.textLimit) {
+                        eventName = eventName.substr(0, self.textLimit) + "...";
                     }
                     CountlyHelpers.confirm(jQuery.i18n.prop("events.general.want-delete-this", "<b>" + eventName + "</b>"), "popStyleGreen", function(result) {
                         if (!result) {
@@ -4623,8 +4628,15 @@ window.EventsBlueprintView = countlyView.extend({
                         else if (selected === "delete") {
                             var title = jQuery.i18n.map["events.general.want-delete-title"];
                             var msg = jQuery.i18n.prop("events.general.want-delete", "<b>" + nameList.join(", ") + "</b>");
+                            if (nameList.join(", ").length > self.textLimit) {
+                                var mz = jQuery.i18n.prop("events.delete.multiple-events", nameList.length);
+                                msg = jQuery.i18n.prop("events.general.want-delete", "<b>" + mz + "</b>");
+                            }
                             var yes_but = jQuery.i18n.map["events.general.yes-delete-events"];
                             if (changeList.length === 1) {
+                                if (nameList[0].length > self.textLimit) {
+                                    nameList[0] = nameList[0].substr(0, self.textLimit) + "...";
+                                }
                                 msg = jQuery.i18n.prop("events.general.want-delete-this", "<b>" + nameList.join(", ") + "</b>");
                                 title = jQuery.i18n.map["events.general.want-delete-this-title"];
                                 yes_but = jQuery.i18n.map["events.general.yes-delete-event"];

--- a/frontend/express/public/localization/dashboard/dashboard.properties
+++ b/frontend/express/public/localization/dashboard/dashboard.properties
@@ -442,6 +442,7 @@ events.edit.display-duration-description = A display name for the optional durat
 events.no-event = There are no events tracked for this application\!
 events.delete-confirm = You are about to delete all data associated with event "{0}". Do you want to continue?
 events.delete-confirm-many = You are about to delete all data associated with these events. Do you want to continue?
+events.delete.multiple-events = {0} events
 events.edit.omit-event-segments = Omit event segments
 events.edit.omit-event-segments-description = Choose which segments of this custom event to omit. Omitted segments will not be saved in the future and past data for these segments will be purged immediately after you save these settings.
 events.edit.omit-event-segments-description-drill = Data for these segments will still be stored in Drill.


### PR DESCRIPTION
Fixed by changing all named events to N events in case there is text length limit reached (Currently length is 100). In case single event name is to long it is cropped and added ... at the end of it.