### PR TITLE
Fix Link to Docker Hub Image

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ There are several ways to install Countly:
 
 3. For bash lovers, we provide a beautiful installation script (`bin/countly.install.sh`) in countly-server package which installs everything required to run Countly Server. For this, you need a stable release of this repository [available here](https://github.com/Countly/countly-server/releases). 
 
-4. Countly Community Edition also has Docker support - [see our official Docker repository](https://registry.hub.docker.com/u/countly/countly-server/) and [installation instructions for Docker](http://resources.count.ly/docs/installing-countly-server)
+4. Countly Community Edition also has Docker support - [see our official Docker repository](https://registry.hub.docker.com/r/countly/countly-server/) and [installation instructions for Docker](http://resources.count.ly/docs/installing-countly-server)
 
 If you want to upgrade Countly from a previous version, please take a look at [upgrading documentation](http://resources.count.ly/v1.0/docs/upgrading-countly-server).
 


### PR DESCRIPTION
Hey! I was just trying to get the project running and reading some docs, so I could tackle the initial exercise later.
It seems the link to the Docker image is incorrect though, it should be `/r/`, not `/u/`. :thinking: 

This PR just corrects that so users get taken to the page they expect.