### PR TITLE
[api] use week years for week-long ticks

### DIFF
--- a/api/lib/countly.common.js
+++ b/api/lib/countly.common.js
@@ -32,7 +32,7 @@ function getTicksBetween(startTimestamp, endTimestamp) {
             dayIt.add(1 + dayIt.daysInMonth() - dayIt.date(), "days");
         }
         else if (daysLeft >= (7 - dayIt.day()) && dayIt.day() === 1) {
-            ticks.push(dayIt.format("YYYY.[w]w"));
+            ticks.push(dayIt.format("gggg.[w]w"));
             dayIt.add(8 - dayIt.day(), "days");
         }
         else {
@@ -61,7 +61,7 @@ function getTicksCheckBetween(startTimestamp, endTimestamp) {
             dayIt.add(1 + dayIt.daysInMonth() - dayIt.date(), "days");
         }
         else {
-            ticks.push(dayIt.format("YYYY.[w]w"));
+            ticks.push(dayIt.format("gggg.[w]w"));
             dayIt.add(8 - dayIt.day(), "days");
         }
     }


### PR DESCRIPTION
quick fix to helper functions that make period objects to make moment stop formatting 2020 w53 as 2020 w1 and format it to 2021 w1 instead