### PR TITLE
SERVER-2285: Audit Logs add option not to record and show IP address

### DIFF
--- a/plugins/systemlogs/api/api.js
+++ b/plugins/systemlogs/api/api.js
@@ -4,6 +4,9 @@ var pluginOb = {},
     plugins = require('../../pluginManager.js');
 
 (function() {
+    plugins.setConfigs("systemlogs", {
+        preventIPTracking: false
+    });
 
     //read api call
     plugins.register("/o", function(ob) {
@@ -334,7 +337,16 @@ var pluginOb = {},
         log.ts = Math.round(new Date().getTime() / 1000);
         log.cd = new Date();
         log.u = user.email || user.username || "";
-        log.ip = common.getIpAddress(params.req);
+
+        var PreventIPTracking = plugins.getConfig("systemlogs").preventIPTracking;
+
+        if (PreventIPTracking) {
+            log.ip = null;
+        }
+        else {
+            log.ip = common.getIpAddress(params.req);
+        }
+
         if (typeof data.app_id !== "undefined") {
             log.app_id = data.app_id;
         }

--- a/plugins/systemlogs/frontend/app.js
+++ b/plugins/systemlogs/frontend/app.js
@@ -1,5 +1,6 @@
 var exported = {},
-    countlyConfig = require('../../../api/config', 'dont-enclose');
+    countlyConfig = require('../../../api/config', 'dont-enclose'),
+    plugins = require('../../../plugins/pluginManager');
 
 (function(plugin) {
     var countlyDb;
@@ -223,7 +224,13 @@ var exported = {},
         log.ts = getTimestamp();
         log.cd = new Date();
         log.u = user.email || user.username || "";
-        log.ip = getIpAddress(req);
+        var PreventIPTracking = plugins.getConfig("systemlogs").preventIPTracking;
+        if (PreventIPTracking) {
+            log.ip = null;
+        }
+        else {
+            log.ip = getIpAddress(req);
+        }
         if (typeof data.app_id !== "undefined") {
             log.app_id = data.app_id;
         }

--- a/plugins/systemlogs/frontend/public/javascripts/countly.views.js
+++ b/plugins/systemlogs/frontend/public/javascripts/countly.views.js
@@ -515,4 +515,24 @@ $(document).ready(function() {
             });
         }, 1000);
     });
+
+    if (app.configurationsView) {
+        app.configurationsView.registerLabel('systemlogs', 'systemlogs.title');
+        app.configurationsView.registerLabel('systemlogs.preventIPTracking', 'systemlogs.prevent-ip-tracking');
+        app.configurationsView.registerInput("systemlogs.preventIPTracking", function(value) {
+            var input = '<div class="on-off-switch">';
+
+            if (value) {
+                input += '<input type="checkbox" name="on-off-switch" class="on-off-switch-checkbox" id="systemlogs.preventIPTracking" checked>';
+            }
+            else {
+                input += '<input type="checkbox" name="on-off-switch" class="on-off-switch-checkbox" id="systemlogs.preventIPTracking">';
+            }
+
+            input += '<label class="on-off-switch-label" for="systemlogs.preventIPTracking"></label>';
+            input += '<span class="text">' + jQuery.i18n.map["plugins.enable"] + '</span>';
+            input += "</div>";
+            return input;
+        });
+    }
 });

--- a/plugins/systemlogs/frontend/public/localization/systemlogs.properties
+++ b/plugins/systemlogs/frontend/public/localization/systemlogs.properties
@@ -24,6 +24,7 @@ systemlogs.for-campaign = For Campaign
 systemlogs.for-crash = For Crash
 systemlogs.for-id = For ID
 systemlogs.data = Data
+systemlogs.prevent-ip-tracking = Disable IP Tracking
 
 systemlogs.action.logout = Logout
 systemlogs.action.password_reset = Password Reset


### PR DESCRIPTION
By adding "Disable IP Tracking" option, ip tracking is prevented when settings are changed and login/logout operations.