### PR TITLE
[frontend] derived saner version of cly-fields-select called cly-multi-select

### DIFF
--- a/frontend/express/public/javascripts/countly/vue/components/dropdown.js
+++ b/frontend/express/public/javascripts/countly/vue/components/dropdown.js
@@ -335,10 +335,14 @@
                                     </div>\
                                     <table v-for="field in fields" :key="field.key">\
                                         <tr class="cly-multi-select__field">{{field.label}}</tr>\
-                                        <tr>\
+                                        <tr v-if="\'items\' in field">\
                                             <el-select class="cly-multi-select__field-dropdown" :placeholder="optionLabel(field, unsavedValue[field.key])" v-model="unsavedValue[field.key]">\
                                                 <el-option v-for="item in field.items" :key="item.key" :value="item.key" :label="item.label"></el-option>\
                                             </el-select>\
+                                        </tr>\
+                                        <tr v-else-if="\'options\' in field">\
+                                            <cly-select-x v-bind="field" class="cly-multi-select__field-dropdown" :width="320" :placeholder="optionLabel(field, unsavedValue[field.key])" v-model="unsavedValue[field.key]">\
+                                            </cly-select-x>\
                                         </tr>\
                                     </table>\
                                 </div>\
@@ -370,9 +374,16 @@
         computed: {
             optionLabel: function() {
                 return function(field, option) {
-                    return field.items.find(function(item) {
-                        return item.key === option;
-                    }).label;
+                    if ("items" in field) {
+                        return field.items.find(function(item) {
+                            return item.key === option;
+                        }).label;
+                    }
+                    else if ("options" in field) {
+                        return field.options.find(function(item) {
+                            return item.value === option;
+                        }).label;
+                    }
                 };
             },
             dropdownLabel: function() {

--- a/frontend/express/public/javascripts/countly/vue/components/dropdown.js
+++ b/frontend/express/public/javascripts/countly/vue/components/dropdown.js
@@ -337,7 +337,7 @@
                                         <tr class="cly-multi-select__field">{{field.label}}</tr>\
                                         <tr v-if="\'items\' in field">\
                                             <el-select class="cly-multi-select__field-dropdown" :placeholder="optionLabel(field, unsavedValue[field.key])" v-model="unsavedValue[field.key]">\
-                                                <el-option v-for="item in field.items" :key="item.key" :value="item.key" :label="item.label"></el-option>\
+                                                <el-option v-for="item in field.items" :key="item.value" :value="item.value" :label="item.label"></el-option>\
                                             </el-select>\
                                         </tr>\
                                         <tr v-else-if="\'options\' in field">\
@@ -374,16 +374,9 @@
         computed: {
             optionLabel: function() {
                 return function(field, option) {
-                    if ("items" in field) {
-                        return field.items.find(function(item) {
-                            return item.key === option;
-                        }).label;
-                    }
-                    else if ("options" in field) {
-                        return field.options.find(function(item) {
-                            return item.value === option;
-                        }).label;
-                    }
+                    return (field.items || field.options || []).find(function(item) {
+                        return item.value === option;
+                    }).label;
                 };
             },
             dropdownLabel: function() {

--- a/frontend/express/public/javascripts/countly/vue/components/dropdown.js
+++ b/frontend/express/public/javascripts/countly/vue/components/dropdown.js
@@ -310,6 +310,115 @@
             }
         }
     }));
+
+    Vue.component("cly-multi-select", countlyBaseComponent.extend({
+        mixins: [_mixins.i18n],
+        template: '<cly-dropdown ref="dropdown" v-on="$listeners" class="cly-multi-select__dropdown">\
+                        <template v-slot:trigger="dropdown">\
+                            <slot name="trigger">\
+                                <cly-input-dropdown-trigger\
+                                ref="trigger"\
+                                :disabled="false"\
+                                :adaptive-length="false"\
+                                :focused="dropdown.focused"\
+                                :opened="dropdown.visible"\
+                                :placeholder="dropdownLabel"\>\
+                                </cly-input-dropdown-trigger>\
+                            </slot>\
+                        </template>\
+                        <div class="cly-multi-select default-skin">\
+                            <div class="cly-multi-select__body">\
+                                <div>\
+                                    <div>\
+                                        <span class="cly-multi-select__title">{{title}}</span>\
+                                        <el-button class="cly-multi-select__reset" @click="reset" type="text">{{resetLabel}}</el-button>\
+                                    </div>\
+                                    <table v-for="field in fields" :key="field.key">\
+                                        <tr class="cly-multi-select__field">{{field.label}}</tr>\
+                                        <tr>\
+                                            <el-select class="cly-multi-select__field-dropdown" :placeholder="optionLabel(field, unsavedValue[field.key])" v-model="unsavedValue[field.key]">\
+                                                <el-option v-for="item in field.items" :key="item.key" :value="item.key" :label="item.label"></el-option>\
+                                            </el-select>\
+                                        </tr>\
+                                    </table>\
+                                </div>\
+                                <div class="cly-multi-select__controls">\
+                                    <el-button v-bind="$attrs" class="cly-multi-select__cancel" @click="close">{{cancelLabel}}</el-button>\
+                                    <el-button v-bind="$attrs" class="cly-multi-select__confirm" @click="save">{{confirmLabel}}</el-button>\
+                                </div>\
+                            </div>\
+                        </div>\
+                    </cly-dropdown>',
+        props: {
+            cancelLabel: {type: String, default: CV.i18n("events.general.cancel")},
+            confirmLabel: {type: String, default: CV.i18n("events.general.confirm")},
+            resetLabel: {type: String, default: "Reset Filters"},
+            value: {
+                type: Object,
+                default: function() {
+                    return {};
+                }
+            },
+            fields: {
+                type: Array,
+                default: function() {
+                    return [];
+                }
+            },
+            title: {type: String, default: "Filter Parameters"}
+        },
+        computed: {
+            optionLabel: function() {
+                return function(field, option) {
+                    return field.items.find(function(item) {
+                        return item.key === option;
+                    }).label;
+                };
+            },
+            dropdownLabel: function() {
+                var self = this;
+                return this.fields.map(function(field) {
+                    return self.optionLabel(field, self.value[field.key]);
+                }).join(", ");
+            }
+        },
+        data: function() {
+            return {
+                unsavedValue: Object.assign({}, this.value)
+            };
+        },
+        watch: {
+            value: {
+                immediate: true,
+                handler: function(newValue) {
+                    this.unsavedValue = Object.assign({}, newValue);
+                }
+            },
+        },
+        methods: {
+            close: function(dontSync) {
+                if (!dontSync) {
+                    this.unsavedValue = Object.assign({}, this.value);
+                }
+                this.$refs.dropdown.handleClose();
+            },
+            save: function() {
+                this.$emit("input", this.unsavedValue);
+                this.close();
+            },
+            reset: function() {
+                var self = this;
+                this.fields.forEach(function(field) {
+                    if ("default" in field) {
+                        self.$set(self.unsavedValue, field.key, field.default);
+                    }
+                });
+                this.save();
+            }
+        }
+    }));
+
+
     Vue.component("cly-more-options", countlyBaseComponent.extend({
         componentName: 'ElDropdown',
         mixins: [ELEMENT.utils.Emitter],

--- a/frontend/express/public/stylesheets/styles/blocks/_dropdown.scss
+++ b/frontend/express/public/stylesheets/styles/blocks/_dropdown.scss
@@ -67,6 +67,81 @@
       }
 }
 
+.cly-multi-select {
+    &.default-skin {
+        display: inline-block;
+
+        .el-input__inner::placeholder{
+            color: black;
+        }
+
+        .cly-multi-select__body {
+            box-shadow: 0 3px 7px rgba(0, 0, 0, 0.08);
+            background-color: #fff;
+            position: absolute;
+            top: 0px;
+            z-index: 100;
+            border: 1px solid #d0d0d0;
+            border-radius: 2px;
+            padding: 16px;
+            width: max-content;
+        }
+
+        .cly-multi-select__controls {
+            float: right;
+            margin-top: 10px;
+        }
+    }
+
+    &__title {
+        color: #333C48;
+        font-family: t.$font-family;
+        line-height: 24px;
+        font-weight: 500;
+        font-size: 16px;
+    }
+
+    &__reset {
+        float: right;
+        font-size: 12px;
+        padding-bottom: 26px;
+        padding-top: 0px;
+        color: #D23F00;
+        cursor: pointer;
+        line-height: 20px;
+    }
+
+    &__field {
+        color: #333C48;
+        font-family: t.$font-family;
+        line-height: 20px;
+        font-weight: 500;
+        font-size: 12px;
+        padding-bottom: 3px;
+    }
+
+    &__field-dropdown{
+        width: 320px;
+        height: 32px;
+        margin-bottom: 16px;
+    }
+
+    &__confirm{
+        background-color: #12AF51;
+        color: white;
+    }
+
+    &__cancel {
+        background: #F6F6F6;
+    }
+
+    &__dropdown {
+        .el-input__inner::placeholder{
+            color: black;
+        }
+    }
+}
+
 .cly-vue-dropdown {
     &__pop {
         padding: 0px;


### PR DESCRIPTION
What's different?

- `fields[].items[]` property names follow `el-option` prop names so `label` actually maps to `label` and `key` maps to rest of the option props used internally (`key` and `value`).
- Using `fields[].options` instead of `fields[].items` allows you to use `cly-select-x` instead of `el-select`.
- `resetLabel` is now a prop in case someone needs to change it for their use.
- You can now just use `v-model` with the component and have it actually work correctly right away instead of having to mess with setters in the parent component.
- Its SCSS is no longer all wack with mixed/incorrect indentation.
- Worryingly vague `controls` class renamed to more BEM-y `cly-multi-select__controls`.

What can be improved?

- `resetLabel` and `title` props' default values should be replaced by i18n equivalents.
- A validator should be defined for the `fields` prop.
- The CSS can probably be slimmed down as well, like with bulma classes.