### PR TITLE
New UI home [SERVER-2070]

### DIFF
--- a/api/parts/mgmt/users.js
+++ b/api/parts/mgmt/users.js
@@ -318,6 +318,38 @@ function killAllSessionForUser(userId) {
 
 }
 
+usersApi.updateHomeSettings = function(params) {
+    params = params || {};
+    params.qstring = params.qstring || {};
+    if (!params.member) {
+        common.returnMessage(params, 400, 'Could not get member');
+    }
+    else if (!params.qstring.homeSettings) {
+        common.returnMessage(params, 400, '`homeSettings` should contain stringified object with home settings');
+    }
+    else if (!params.qstring.app_id) {
+        common.returnMessage(params, 400, '`app_id` must be passed');
+    }
+    else {
+        try {
+            params.qstring.homeSettings = JSON.parse(params.qstring.homeSettings);
+        }
+        catch (SyntaxError) {
+            params.qstring.homeSettings = {};
+        }
+        var updateObj = {};
+        updateObj["homeSettings." + params.qstring.app_id] = params.qstring.homeSettings;
+        common.db.collection('members').update({_id: common.db.ObjectID(params.member._id + "")}, {"$set": updateObj}, function(err3 /* , res1*/) {
+            if (err3) {
+                console.log(err3);
+                common.returnMessage(params, 400, 'Mongo error');
+            }
+            else {
+                common.returnMessage(params, 200, 'Success');
+            }
+        });
+    }
+};
 /**
 * Updates dashboard user's data and output result to browser
 * @param {params} params - params object

--- a/api/utils/requestProcessor.js
+++ b/api/utils/requestProcessor.js
@@ -244,6 +244,9 @@ const processRequest = (params) => {
                 case 'deleteOwnAccount':
                     validateDelete(params, 'global_users', countlyApi.mgmt.users.deleteOwnAccount);
                     break;
+                case 'updateHomeSettings':
+                    validateUpdate(params, 'global_users', countlyApi.mgmt.users.updateHomeSettings);
+                    break;
                 case 'ack':
                     validateUserForWriteAPI(countlyApi.mgmt.users.ackNotification, params);
                     break;

--- a/frontend/express/public/core/carrier/javascripts/countly.views.js
+++ b/frontend/express/public/core/carrier/javascripts/countly.views.js
@@ -1,4 +1,4 @@
-/* global countlyVue,CV,countlyCommon,countlyAppCarrier,*/
+/* global countlyVue,CV,countlyCommon,countlyAppCarrier,countlyGlobal*/
 var AppCarrierView = countlyVue.views.create({
     template: CV.T("/core/carrier/templates/carrier.html"),
     data: function() {

--- a/frontend/express/public/core/carrier/javascripts/countly.views.js
+++ b/frontend/express/public/core/carrier/javascripts/countly.views.js
@@ -73,16 +73,16 @@ var AppCarrierView = countlyVue.views.create({
     ]
 });
 
-
-
-countlyVue.container.registerTab("/analytics/technology", {
-    priority: 5,
-    name: "carriers",
-    title: CV.i18n('carriers.title'),
-    route: "#/" + countlyCommon.ACTIVE_APP_ID + "/analytics/technology/carriers",
-    component: AppCarrierView,
-    vuex: [{
-        clyModel: countlyAppCarrier
-    }]
-});
+if (countlyGlobal.apps[countlyCommon.ACTIVE_APP_ID].type === "mobile") {
+    countlyVue.container.registerTab("/analytics/technology", {
+        priority: 5,
+        name: "carriers",
+        title: CV.i18n('carriers.title'),
+        route: "#/" + countlyCommon.ACTIVE_APP_ID + "/analytics/technology/carriers",
+        component: AppCarrierView,
+        vuex: [{
+            clyModel: countlyAppCarrier
+        }]
+    });
+}
 

--- a/frontend/express/public/core/device-and-type/javascripts/countly.models.js
+++ b/frontend/express/public/core/device-and-type/javascripts/countly.models.js
@@ -476,7 +476,7 @@
             fetchHomeDashboard: function(context) {
                 return countlyDevicesAndTypes.service.fetchHomeDashboardData().then(function() {
                     var totals = countlyDevicesAndTypes.service.calculateHomeTotals();
-                    context.commit('setDashboardTotals', totals);
+                    return context.commit('setDashboardTotals', totals);
 
                 });
             },

--- a/frontend/express/public/core/device-and-type/javascripts/countly.models.js
+++ b/frontend/express/public/core/device-and-type/javascripts/countly.models.js
@@ -1,12 +1,10 @@
-/* global CountlyHelpers, jQuery, $,countlyTotalUsers,countlyCommon,countlyVue,countlyDeviceList,countlyOsMapping,countlyDeviceDetails,countlyBrowser*/
+/* global CountlyHelpers, jQuery, $,countlyTotalUsers,countlyCommon,countlyVue,countlyDeviceList,countlyOsMapping,countlyDeviceDetails,countlyBrowser, countlyGlobal*/
 (function(countlyDevicesAndTypes) {
 
     CountlyHelpers.createMetricModel(window.countlyDevicesAndTypes, {name: "device_details", estOverrideMetric: "platforms"}, jQuery);
     countlyDevicesAndTypes.os_mapping = countlyOsMapping; //./frontend/express/public/javascripts/countly/countly.device.osmapping.js
 
     //CountlyDeviceList - ./frontend/express/public/javascripts/countly/countly.device.list.js
-
-
     countlyDevicesAndTypes.getCleanVersion = function(version) {
         for (var i in countlyDevicesAndTypes.os_mapping) {
             version = version.replace(new RegExp("^" + countlyDevicesAndTypes.os_mapping[i].short, "g"), "");
@@ -128,6 +126,21 @@
                 countlyTotalUsers.initialize("platform_versions"),
                 countlyTotalUsers.initialize("resolutions"));
         },
+        fetchHomeDashboardData: function() {
+            //app type is mobile
+
+            var appType = "";
+            if (countlyGlobal && countlyGlobal.apps && countlyCommon.ACTIVE_APP_ID && countlyGlobal.apps[countlyCommon.ACTIVE_APP_ID]) {
+                appType = countlyGlobal.apps[countlyCommon.ACTIVE_APP_ID].type;
+            }
+
+            if (appType === "web") {
+                return $.when(countlyDevice.initialize(), countlyDevicesAndTypes.initialize(), countlyTotalUsers.initialize("platforms"), countlyTotalUsers.initialize("devices")), countlyBrowser.initialize(), countlyTotalUsers.initialize("browser");
+            }
+            else {
+                return $.when(countlyDevice.initialize(), countlyDevicesAndTypes.initialize(), countlyTotalUsers.initialize("platforms"), countlyTotalUsers.initialize("devices"), countlyTotalUsers.initialize("app_versions"), countlyTotalUsers.initialize("device_type"));
+            }
+        },
         fetchDeviceTypes: function() {
             return $.when(countlyDevicesAndTypes.initialize(), countlyTotalUsers.initialize("device_type"));
         },
@@ -211,6 +224,91 @@
             chartData.versions = stacked_version;
 
             return chartData;
+        },
+        calculateHomeTotals: function() {
+
+            var tops = {};
+            var loadTotalsFor = [
+                {"model": countlyDevice, "label": "devices", "func": countlyDevicesAndTypes.helpers.getDeviceFullName},
+                {
+                    "model": countlyBrowser,
+                    "label": "browser",
+                    "func": function(rangeArr) {
+                        return rangeArr;
+                    }
+                },
+                {
+                    "model": countlyDevicesAndTypes,
+                    "label": "os",
+                    "func": function(rangeArr) {
+                        if (countlyDevicesAndTypes.os_mapping[rangeArr.toLowerCase()]) {
+                            return countlyDevicesAndTypes.os_mapping[rangeArr.toLowerCase()].name;
+                        }
+                        return rangeArr;
+                    }
+                },
+                {
+                    "model": countlyDevicesAndTypes,
+                    "label": "app_versions",
+                    "func": function(rangeArr) {
+                        return rangeArr.replace(/:/g, ".");
+                    }
+                },
+                {
+                    "model": countlyDevicesAndTypes,
+                    "label": "device_type",
+                    "func": function(rangeArr) {
+                        return rangeArr;
+                    }
+                }
+            ];
+            //countlyDevicesAndTypes.helpers.loadTableFromModel(countlyDevicesAndTypes, metric, options.func)
+
+
+            var property = "t";
+            for (var pp = 0; pp < loadTotalsFor.length; pp++) {
+
+                var tableData = countlyDevicesAndTypes.helpers.loadTableFromModel(loadTotalsFor[pp].model, loadTotalsFor[pp].label, loadTotalsFor[pp].func);
+                tableData = tableData || {};
+                tableData = tableData.chartData || [];
+
+                var totals = 0;
+                var topN = [];
+
+
+                for (var k = 0; k < tableData.length; k++) {
+                    totals += tableData[k][property];
+                    if (topN.length < 5) {
+                        topN.push(tableData[k]);
+                        topN = topN.sort(function(a, b) {
+                            return a[property] - b[property];
+                        });
+                    }
+                    else {
+                        if (topN[2][property] < tableData[k][property]) {
+                            topN[2] = tableData[k];
+                            topN = topN.sort(function(a, b) {
+                                return a[property] - b[property];
+                            });
+                        }
+                    }
+                }
+                for (var z = 0; z < topN.length; z++) {
+                    topN[z] = {"name": topN[z][loadTotalsFor[pp].label], "percent": Math.round((topN[z][property] || 0) * 1000 / (totals || 1)) / 10, "value": topN[z][property]};
+                }
+                tops[loadTotalsFor[pp].label] = topN;
+            }
+
+            for (var key in tops) {
+                for (var z1 = 0; z1 < tops[key].length; z1++) {
+                    tops[key][z1].bar = [{
+                        percentage: tops[key][z1].percent,
+                        color: "#017AFF"
+                    }
+                    ];
+                }
+            }
+            return tops;
         },
         calculateDevices: function() {
             var metric = "devices";
@@ -296,6 +394,7 @@
                 appBrowser: {"chart": {}, "table": []},
                 deviceTypes: {"pie": {"newUsers": [], "totalSessions": []}, "chart": {}, "totals": {}, "table": []},
                 appDevices: {"pie": {"newUsers": [], "totalSessions": []}, "totals": {}, "table": []},
+                dashboardTotals: [],
                 minNonEmptyBucketsLength: 0,
                 nonEmptyBuckets: [],
                 isLoading: false,
@@ -374,6 +473,13 @@
                     context.dispatch('onFetchError', error);
                 });
             },
+            fetchHomeDashboard: function(context) {
+                return countlyDevicesAndTypes.service.fetchHomeDashboardData().then(function() {
+                    var totals = countlyDevicesAndTypes.service.calculateHomeTotals();
+                    context.commit('setDashboardTotals', totals);
+
+                });
+            },
             onFetchInit: function(context) {
                 context.commit('setFetchInit');
             },
@@ -401,6 +507,9 @@
             setResolution: function(state, value) {
                 state.appResolution = value;
                 countlyDevicesAndTypes.helpers.setEmptyDefault(state.appResolution);
+            },
+            setDashboardTotals: function(state, value) {
+                state.dashboardTotals = value;
             },
             setDeviceTypes: function(state, value) {
                 state.deviceTypes = value;

--- a/frontend/express/public/core/device-and-type/javascripts/countly.views.js
+++ b/frontend/express/public/core/device-and-type/javascripts/countly.views.js
@@ -1,4 +1,4 @@
-/* global countlyVue,CV,countlyCommon,countlyDevicesAndTypes,app*/
+/* global countlyVue,CV,countlyCommon,countlyDevicesAndTypes,app, countlyGlobal*/
 var DevicesTabView = countlyVue.views.create({
     template: CV.T("/core/device-and-type/templates/devices-tab.html"),
     mounted: function() {
@@ -227,4 +227,96 @@ countlyVue.container.registerTab("/analytics/technology", {
     vuex: [{
         clyModel: countlyDevicesAndTypes
     }]
+});
+
+
+//Tehnology Dashboard widget
+var TechnologyHomeWidget = countlyVue.views.create({
+    template: CV.T("/core/device-and-type/templates/technologyHomeWidget.html"),
+    data: function() {
+        return {
+            dataBlocks: [],
+        };
+    },
+    beforeCreate: function() {
+        this.module = countlyDevicesAndTypes.getVuexModule();
+        CV.vuex.registerGlobally(this.module);
+    },
+    beforeDestroy: function() {
+        CV.vuex.unregister(this.module.name);
+    },
+    mounted: function() {
+        var self = this;
+        this.$store.dispatch('countlyDevicesAndTypes/fetchHomeDashboard').then(function() {
+            self.dataBlocks = self.calculateAllData();
+        });
+    },
+    methods: {
+        refresh: function() {
+            var self = this;
+            this.$store.dispatch('countlyDevicesAndTypes/fetchHomeDashboard').then(function() {
+                self.dataBlocks = self.calculateAllData();
+            });
+        },
+        calculateAllData: function() {
+            var tops = {};
+            if (this.$store.state && this.$store.state.countlyDevicesAndTypes && this.$store.state.countlyDevicesAndTypes.dashboardTotals) {
+                tops = this.$store.state.countlyDevicesAndTypes.dashboardTotals || {};
+            }
+
+            var appType = "";
+            if (countlyGlobal && countlyGlobal.apps && countlyCommon.ACTIVE_APP_ID && countlyGlobal.apps[countlyCommon.ACTIVE_APP_ID]) {
+                appType = countlyGlobal.apps[countlyCommon.ACTIVE_APP_ID].type;
+            }
+
+
+            var dd = [
+                {
+                    "title": CV.i18n('common.bar.top-platform'),
+                    "description": CV.i18n('common.bar.top-platform.description'),
+                    "data": tops.os || []
+                },
+                {
+                    "title": CV.i18n('common.bar.top-devices'),
+                    "description": CV.i18n('common.bar.top-devices.description'),
+                    "data": tops.devices || []
+                }];
+
+            if (appType === "web") {
+                dd.push({
+                    "title": CV.i18n('common.bar.top-browsers'),
+                    "description": CV.i18n('common.bar.top-browsers.description'),
+                    "data": tops.browser || []
+                });
+            }
+            else {
+                dd.push({
+                    "title": CV.i18n('common.bar.top-app-versions'),
+                    "description": CV.i18n('common.bar.top-app-versions.description'),
+                    "data": tops.app_versions || []
+                });
+            }
+
+            dd.push(
+                {
+                    "title": CV.i18n('common.bar.top-device-types'),
+                    "description": CV.i18n('common.bar.top-device-types.description'),
+                    "data": tops.device_type || []
+                }
+            );
+            return dd;
+        }
+    }
+});
+
+countlyVue.container.registerData("/home/widgets", {
+    _id: "technology-dashboard-widget",
+    label: CV.i18n('sidebar.analytics.technology'),
+    description: CV.i18n('sidebar.analytics.technology-description'),
+    enabled: {"default": true}, //object. For each type set if by default enabled
+    available: {"default": true}, //object. default - for all app types. For other as specified.
+    order: 6, //sorted by ascending
+    placeBeforeDatePicker: false,
+    component: TechnologyHomeWidget,
+    linkTo: {"label": CV.i18n('devices.go-to-technology'), "href": "#/analytics/technology/devices-and-types"}
 });

--- a/frontend/express/public/core/device-and-type/javascripts/countly.views.js
+++ b/frontend/express/public/core/device-and-type/javascripts/countly.views.js
@@ -244,6 +244,7 @@ var TechnologyHomeWidget = countlyVue.views.create({
     },
     beforeDestroy: function() {
         CV.vuex.unregister(this.module.name);
+        this.module = null;
     },
     mounted: function() {
         var self = this;

--- a/frontend/express/public/core/device-and-type/stylesheets/_main.scss
+++ b/frontend/express/public/core/device-and-type/stylesheets/_main.scss
@@ -9,3 +9,11 @@
 .version-graph-block:last-child {
 margin-bottom: 12px;
 }
+
+.technologyDashboardWidget>.bu-column:nth-child(odd)>.cly-vue-section{
+	padding-right:8px;
+}
+
+.technologyDashboardWidget>.bu-column:nth-child(even)>.cly-vue-section{
+	padding-left:8px;
+}

--- a/frontend/express/public/core/device-and-type/stylesheets/_main.scss
+++ b/frontend/express/public/core/device-and-type/stylesheets/_main.scss
@@ -1,19 +1,19 @@
 .technology-analytics-wrapper .devices-date-picker-container {
-	margin-bottom:32px;
+    margin-bottom:32px;
 }
-.technology-analytics-wrapper .version-graph-block .version-graph-title{
-	margin:0px;
-	padding-bottom:4px;
+.technology-analytics-wrapper .version-graph-block .version-graph-title {
+    margin:0px;
+    padding-bottom:4px;
 }
 
 .version-graph-block:last-child {
-margin-bottom: 12px;
+    margin-bottom: 12px;
 }
 
-.technologyDashboardWidget>.bu-column:nth-child(odd)>.cly-vue-section{
-	padding-right:8px;
+.technology-dashboard-widget> .bu-column:nth-child(odd)>.cly-vue-section {
+    padding-right:8px;
 }
 
-.technologyDashboardWidget>.bu-column:nth-child(even)>.cly-vue-section{
-	padding-left:8px;
+.technology-dashboard-widget>.bu-column:nth-child(even)>.cly-vue-section {
+    padding-left:8px;
 }

--- a/frontend/express/public/core/device-and-type/templates/technologyHomeWidget.html
+++ b/frontend/express/public/core/device-and-type/templates/technologyHomeWidget.html
@@ -1,0 +1,23 @@
+<div v-bind:class="[componentId]">
+	<div class="bu-columns bu-is-multiline bu-is-gapless technologyDashboardWidget technology-analytics-wrapper">
+		<div class="bu-column bu-is-6 " :key="idx" v-for="(item, idx) in dataBlocks" >
+			<cly-section class="bu-pt-2 bu-pb-2">
+					<div class="bu-level-left bu-p-5">
+						<span class="text-medium">{{item.title}}</span>
+						<span class="cly-vue-tooltip-icon ion ion-help-circled has-tooltip" style="margin-left:10px" v-tooltip.top-center="item.description"></span>
+					</div>
+					<div class="topData bu-pl-3 bu-pr-3 bu-pb-5">
+						<div :key="idx2" v-for="(item2, idx2) in item.data" >
+							<div class="version-graph-block bu-p-3">
+								<div class="bu-columns version-graph-title">
+									<div class="bu-column">{{item2.name}}</div>
+									<div class="bu-column">{{item2.value}} | {{item2.percent}} % </div>
+								</div>
+								<cly-progress-bar :entities="item2.bar" :height=8></cly-progress-bar>
+							</div>
+						</div>
+					</div>
+			</cly-section>
+		</div>
+	</div>
+</div>

--- a/frontend/express/public/core/device-and-type/templates/technologyHomeWidget.html
+++ b/frontend/express/public/core/device-and-type/templates/technologyHomeWidget.html
@@ -1,5 +1,5 @@
 <div v-bind:class="[componentId]">
-	<div class="bu-columns bu-is-multiline bu-is-gapless technologyDashboardWidget technology-analytics-wrapper">
+	<div class="bu-columns bu-is-multiline bu-is-gapless technology-dashboard-widget technology-analytics-wrapper">
 		<div class="bu-column bu-is-6 " :key="idx" v-for="(item, idx) in dataBlocks" >
 			<cly-section class="bu-pt-2 bu-pb-2">
 					<div class="bu-level-left bu-p-5">

--- a/frontend/express/public/core/events/javascripts/countly.overview.models.js
+++ b/frontend/express/public/core/events/javascripts/countly.overview.models.js
@@ -396,6 +396,17 @@
                         }
                     });
             },
+            fetchTopEvents: function(context, count) {
+                return countlyEventsOverview.service.fetchMonitorEvents(context).then(function(res) {
+                    if (res) {
+                        return countlyEventsOverview.service.fetchTopEvents("count", count).then(function(resp) {
+                            if (resp) {
+                                return context.commit("setTopEvents", countlyEventsOverview.helpers.getTopEvents(resp, res.map) || []);
+                            }
+                        });
+                    }
+                });
+            },
             fetchMonitorEvents: function(context) {
                 return countlyEventsOverview.service.fetchMonitorEvents(context)
                     .then(function(res) {

--- a/frontend/express/public/core/events/javascripts/countly.overview.views.js
+++ b/frontend/express/public/core/events/javascripts/countly.overview.views.js
@@ -256,4 +256,50 @@
     app.route("/analytics/events/overview", "overview", function() {
         this.renderWhenReady(EventsOverviewViewWrapper);
     });
+
+
+    var EventsHomeWidget = countlyVue.views.create({
+        template: CV.T("/core/events/templates/eventsHomeWidget.html"),
+        data: function() {
+            return {
+                items: [],
+                linkTo: {"label": CV.i18n('events.go-to-events'), "href": "#/analytics/events/overview"}
+            };
+        },
+        mounted: function() {
+            var self = this;
+            this.$store.dispatch('countlyEventsOverview/fetchTopEvents',5).then(function() {
+                self.calculateAllData();
+            });
+        },
+        beforeCreate: function() {
+            this.module = countlyEventsOverview.getVuexModule();
+            CV.vuex.registerGlobally(this.module);
+        },
+        beforeDestroy: function() {
+            CV.vuex.unregister(this.module.name);
+        },
+        methods: {
+            refresh: function() {
+                var self = this;
+                this.$store.dispatch('countlyEventsOverview/fetchTopEvents', 5).then(function() {
+                    self.calculateAllData();
+                });
+            },
+            calculateAllData: function() {
+                var data = this.$store.getters["countlyEventsOverview/topEvents"];
+                data = data.splice(0, 5);
+                this.items = data;
+            }
+        }
+    });
+    countlyVue.container.registerData("/home/widgets", {
+        _id: "events-dashboard-widget",
+        enabled: {"default": true}, //object. For each type set if by default enabled
+        available: {"default": true}, //object. default - for all app types. For other as specified.
+        placeBeforeDatePicker: true,
+        order: 2,
+        component: EventsHomeWidget
+    });
+
 })();

--- a/frontend/express/public/core/events/javascripts/countly.overview.views.js
+++ b/frontend/express/public/core/events/javascripts/countly.overview.views.js
@@ -268,7 +268,7 @@
         },
         mounted: function() {
             var self = this;
-            this.$store.dispatch('countlyEventsOverview/fetchTopEvents',5).then(function() {
+            this.$store.dispatch('countlyEventsOverview/fetchTopEvents', 5).then(function() {
                 self.calculateAllData();
             });
         },

--- a/frontend/express/public/core/events/templates/eventsHomeWidget.html
+++ b/frontend/express/public/core/events/templates/eventsHomeWidget.html
@@ -1,0 +1,23 @@
+<div v-bind:class="[componentId]">
+	
+	
+	<div class="bu-level bu-pb-3">
+		<div class="bu-level-left">
+			<h4 class="bu-pt-2 bu-mb-4 cly-vue-events-overview-subheadings--font">{{i18n('events.overview.top.events.by.count')}} </h4>
+		</div>
+		<div class="bu-level-right">
+			<a v-if="linkTo" class="cly-back-link text-medium" :href="linkTo.href"><span>{{linkTo.label}}<i class="fas fa-arrow-right bu-pl-3"></i></span></a>
+		</div>
+	</div>		
+	<cly-section>
+		<cly-metric-cards>
+			<cly-metric-card formatting="long" color="#097EFF" numberClasses="bu-is-flex bu-is-align-items-center" :key="idx" v-for="(item, idx) in items">
+				{{item.name}}
+				<cly-tooltip-icon v-if="item.info" icon="ion-help-circled" :tooltip="item.info"></cly-tooltip-icon>
+				<template v-slot:number>{{item.value}}</template>
+				<span v-if="item.trend=='d'" slot="description" class="cly-trend-down"><i class="bu-pr-1 fas fa-arrow-circle-down"></i>{{item.change}}</span>
+				<span v-else slot="description" class="cly-trend-up"><i class="bu-pr-1 fas fa-arrow-circle-up"></i>{{item.change}}</span>
+			</cly-metric-card>
+		</cly-metric-cards>
+	</cly-section>
+</div>

--- a/frontend/express/public/core/geo-countries/javascripts/countly.models.js
+++ b/frontend/express/public/core/geo-countries/javascripts/countly.models.js
@@ -60,13 +60,13 @@
         var countlyCountryActions = {
             fetchData: function(context) {
                 context.dispatch('onFetchInit');
-                countlyCountry.service.fetchData().then(function() {
+                return countlyCountry.service.fetchData().then(function() {
                     countlyCountry.setDb(countlySession.getDb());
                     var countries = countlyCountry.service.calculateData();
                     context.commit('setData', countries);
-                    context.dispatch('onFetchSuccess');
+                    return context.dispatch('onFetchSuccess');
                 }).catch(function(error) {
-                    context.dispatch('onFetchError', error);
+                    return context.dispatch('onFetchError', error);
                 });
             },
             onFetchInit: function(context) {

--- a/frontend/express/public/core/geo-countries/javascripts/countly.views.js
+++ b/frontend/express/public/core/geo-countries/javascripts/countly.views.js
@@ -234,6 +234,101 @@ var GeoAnalyticsView = countlyVue.views.create({
     }
 });
 
+
+var CountriesHomeWidget = countlyVue.views.create({
+    template: CV.T("/core/geo-countries/templates/countriesHomeWidget.html"),
+    data: function() {
+        var buttonText = "";
+        var buttonLink = "#/analytics/geo/countries/All";
+        if (countlyGlobal.apps[countlyCommon.ACTIVE_APP_ID] && countlyGlobal.apps[countlyCommon.ACTIVE_APP_ID].country) {
+            buttonText = CV.i18n('common.show') + " " + countlyLocation.getCountryName(countlyGlobal.apps[countlyCommon.ACTIVE_APP_ID].country);
+            buttonLink = "#/analytics/geo/countries/" + countlyGlobal.apps[countlyCommon.ACTIVE_APP_ID].country;
+        }
+        else {
+            buttonText = CV.i18n('common.show') + " " + CV.i18n("countries.table.country");
+        }
+
+        return {
+            path: "",
+            buttonText: buttonText,
+            buttonLink: buttonLink
+
+        };
+    },
+    beforeCreate: function() {
+        this.module = countlyCountry.getVuexModule();
+        CV.vuex.registerGlobally(this.module);
+    },
+    beforeDestroy: function() {
+        CV.vuex.unregister(this.module.name);
+    },
+    mounted: function() {
+        this.$store.dispatch('countlyCountry/fetchData');
+    },
+    methods: {
+        refresh: function() {
+            this.$store.dispatch('countlyCountry/fetchData');
+        },
+        swithToCityView: function() {
+            windows.location.href = this.path;
+        },
+        regionClick: function(region) {
+            this.path = "#/analytics/geo/countries/" + region;
+            this.$refs.toCityViewLink.href = this.path;
+            this.$refs.toCityViewLink.click();
+        },
+    },
+    computed: {
+        data: function() {
+            return this.$store.state.countlyCountry.data || {};
+        },
+        chooseProperties: function() {
+            var totals = this.data.totals || {};
+            totals.t = totals.t || {};
+            totals.u = totals.u || {};
+            totals.n = totals.n || {};
+            return [
+                {"value": "t", "label": CV.i18n('common.table.total-sessions'), "trend": totals.t.trend, "number": countlyCommon.getShortNumber(totals.t.total || 0), "trendValue": totals.t.change},
+                {"value": "u", "label": CV.i18n('common.table.total-users'), "trend": totals.u.trend, "number": countlyCommon.getShortNumber(totals.u.total || 0), "trendValue": totals.u.change},
+                {"value": "n", "label": CV.i18n('common.table.new-users'), "trend": totals.n.trend, "number": countlyCommon.getShortNumber(totals.n.total || 0), "trendValue": totals.n.change}
+            ];
+        },
+        countriesData: function() {
+            var geoChart = {};
+            var table = this.data.table || [];
+            var selectedProperty = this.$store.state.countlyCountry.selectedProperty || "t";
+            for (var k = 0; k < table.length; k++) {
+                geoChart[table[k].country] = {"value": table[k][selectedProperty]};
+            }
+            return geoChart;
+        },
+        selectedProperty: {
+            set: function(value) {
+                this.$store.dispatch('countlyCountry/onSetSelectedProperty', value);
+            },
+            get: function() {
+                return this.$store.state.countlyCountry.selectedProperty;
+            }
+        }
+    }
+
+
+});
+
+
+countlyVue.container.registerData("/home/widgets", {
+    _id: "countries-dashboard-widget",
+    label: CV.i18n('countries.title'),
+    description: CV.i18n('countries.description'),
+    enabled: {"default": true}, //object. For each type set if by default enabled
+    available: {"default": true}, //object. default - for all app types. For other as specified.
+    order: 8, //sorted by ascending
+    placeBeforeDatePicker: false,
+    component: CountriesHomeWidget,
+    linkTo: {"label": CV.i18n('countries.go-to-countries'), "href": "#/analytics/geo/countries"}
+});
+
+
 var getGeoAnalyticsView = function() {
     var tabsVuex = countlyVue.container.tabsVuex(["/analytics/geo"]);
     return new countlyVue.views.BackboneWrapper({

--- a/frontend/express/public/core/geo-countries/stylesheets/_main.scss
+++ b/frontend/express/public/core/geo-countries/stylesheets/_main.scss
@@ -2,8 +2,8 @@
 	margin-bottom:32px;
 }
 
-.routename-analytics-geo .cly-vue-radio-block .radio-wrapper .radio-button {
-	padding: 66px 33px;
+.geo-countries-section .cly-vue-radio-block .radio-wrapper .radio-button {
+	padding: 95px 33px;
 }
 
 .routename-analytics-geo .radio-column{

--- a/frontend/express/public/core/geo-countries/templates/cities.html
+++ b/frontend/express/public/core/geo-countries/templates/cities.html
@@ -12,7 +12,7 @@
     </cly-header>
     <cly-main >
 		<cly-date-picker-g class="geo-date-picker-container"></cly-date-picker-g>
-		<cly-section class="geo-analytics-data">
+		<cly-section class="geo-analytics-data geo-countries-section">
 			<div class="bu-columns bu-is-gapless">
 				<div class="radio-column">
 					<cly-radio-block v-bind:items="chooseProperties" v-model="selectedProperty"></cly-radio-block>

--- a/frontend/express/public/core/geo-countries/templates/countries.html
+++ b/frontend/express/public/core/geo-countries/templates/countries.html
@@ -17,7 +17,7 @@
     </cly-header>
     <cly-main >
 		<cly-date-picker-g class="geo-date-picker-container" ref="datePicker"></cly-date-picker-g>
-		<cly-section class="geo-analytics-data">
+		<cly-section class="geo-analytics-data geo-countries-section">
 			<div class="bu-columns bu-is-gapless">
 				<div style="width:256px;">
 					<cly-radio-block v-bind:items="chooseProperties" v-model="selectedProperty"></cly-radio-block>

--- a/frontend/express/public/core/geo-countries/templates/countriesHomeWidget.html
+++ b/frontend/express/public/core/geo-countries/templates/countriesHomeWidget.html
@@ -1,0 +1,27 @@
+<div v-bind:class="[componentId]">
+	<cly-section class="geo-countries-section" >
+		<cly-section class="geo-analytics-data">
+			<div class="bu-columns bu-is-gapless">
+				<div style="width:256px;">
+					<cly-radio-block v-bind:items="chooseProperties" type="vertical" v-model="selectedProperty"></cly-radio-block>
+				</div>
+				<div class="bu-column" style="position:relative">
+					<cly-worldmap
+						external-country=""
+						external-detail-mode="world"
+						value-type="Sessions"
+						:show-detail-mode-select="false"
+						:show-navigation="false"
+						:prevent-going-to-country="true"
+						:countries-data="countriesData"
+						@country-click="regionClick"
+						>
+					</cly-worldmap>
+					<div style="position: absolute; top: 20px; left:20px;">
+						<a  ref="toCityViewLink" class="cly-vue-button button-light-skin ToLink" :href="buttonLink">{{buttonText}}</a>
+					</div>
+				</div>
+			</div>
+		</cly-section>
+	</cly-section>
+</div>

--- a/frontend/express/public/core/home/javascripts/countly.models.js
+++ b/frontend/express/public/core/home/javascripts/countly.models.js
@@ -37,10 +37,11 @@
                         homeSettings: JSON.stringify(data)
                     },
                     dataType: "json"
-                }, {disableAutoCatch: true}).then(function(/*json*/) {
-
+                }, {disableAutoCatch: true}).then(function() {
+                    //if we are here  - update is fine
+                    return context.commit('setUpdateError', null);
                 }).catch(function(error) {
-                    context.dispatch('onFetchError', error);
+                    return context.commit('setUpdateError', error);
                 });
             },
             onFetchInit: function(context) {
@@ -70,6 +71,9 @@
                 else {
                     state.image = data.path;
                 }
+            },
+            setUpdateError: function(state, error) {
+                state.updateError = error;
             },
             setFetchError: function(state, error) {
                 state.isLoading = false;

--- a/frontend/express/public/core/home/javascripts/countly.models.js
+++ b/frontend/express/public/core/home/javascripts/countly.models.js
@@ -1,0 +1,91 @@
+/* global countlyVue,CV,countlyCommon*/
+
+(function(countlyHomeView) {
+    countlyHomeView.getVuexModule = function() {
+        var getInitialState = function() {
+            return {
+                data: {},
+                image: ""
+            };
+        };
+
+        var HomeViewActions = {
+            downloadScreen: function(context) {
+                return CV.$.ajax({
+                    type: "GET",
+                    url: "/render?view=/dashboard&route=/" + countlyCommon.ACTIVE_APP_ID + "/",
+                    data: {
+                        app_id: countlyCommon.ACTIVE_APP_ID,
+                        "id": "main_home_view",
+                        options: JSON.stringify({"dimensions": {"width": 2000, "padding": 25}})
+                    },
+                    dataType: "json"
+                }, {disableAutoCatch: true}).then(function(json) {
+                    context.dispatch('onSetDownloadImage', {error: null, path: json.path});
+
+                }).catch(function(error) {
+                    context.imageToDownload = false;
+                    context.dispatch('onSetDownloadImage', {error: error, path: null});
+                });
+            },
+            updateHomeView: function(context, data) {
+                return CV.$.ajax({
+                    type: "POST",
+                    url: countlyCommon.API_PARTS.users.w + "/updateHomeSettings",
+                    data: {
+                        app_id: countlyCommon.ACTIVE_APP_ID,
+                        homeSettings: JSON.stringify(data)
+                    },
+                    dataType: "json"
+                }, {disableAutoCatch: true}).then(function(/*json*/) {
+
+                }).catch(function(error) {
+                    context.dispatch('onFetchError', error);
+                });
+            },
+            onFetchInit: function(context) {
+                context.commit('setFetchInit');
+            },
+            onFetchError: function(context, error) {
+                context.commit('setFetchError', error);
+            },
+            onFetchSuccess: function(context) {
+                context.commit('setFetchSuccess');
+            },
+            onSetDownloadImage: function(context, data) {
+                context.commit('setDownloadImage', data);
+            }
+        };
+
+        var HomeViewMutations = {
+            setData: function(state, value) {
+                state.data = value;
+            },
+            setDownloadImage: function(state, data) {
+                data = data || {};
+                var error = data.error;
+                if (error) {
+                    state.image = null;
+                }
+                else {
+                    state.image = data.path;
+                }
+            },
+            setFetchError: function(state, error) {
+                state.isLoading = false;
+                state.hasError = true;
+                state.error = error;
+            },
+            setFetchSuccess: function(state) {
+                state.isLoading = false;
+                state.hasError = false;
+                state.error = null;
+            }
+        };
+        return countlyVue.vuex.Module("countlyHomeView", {
+            state: getInitialState,
+            actions: HomeViewActions,
+            mutations: HomeViewMutations
+        });
+    };
+}(window.countlyHomeView = window.countlyHomeView || {}));

--- a/frontend/express/public/core/home/javascripts/countly.views.js
+++ b/frontend/express/public/core/home/javascripts/countly.views.js
@@ -67,7 +67,9 @@ var HomeViewView = countlyVue.views.create({
 
                     if (typeof userSettings[allComponents[k]._id] !== "undefined") {
                         enabled = userSettings[allComponents[k]._id].enabled || false;
-                        order = userSettings[allComponents[k]._id].order || 0;
+                        if (typeof userSettings[allComponents[k]._id].order !== "undefined") {
+                            order = userSettings[allComponents[k]._id].order;
+                        }
                     }
 
                     if (!this.registredComponents[allComponents[k]._id]) {
@@ -146,13 +148,9 @@ var HomeViewView = countlyVue.views.create({
                         not_changed = false;
                     }
                 }
-                if (!not_changed) {
-                    this.ordered = forOrdering;
-                }
             }
             else {
                 not_changed = false;
-                this.ordered = forOrdering;
             }
 
             if (!not_changed) {
@@ -175,7 +173,10 @@ var HomeViewView = countlyVue.views.create({
             //save for users
             var userSettings = {};
             for (var k in this.registredComponents) {
-                if (values.indexOf(k) === -1) {
+                if (this.registredComponents[k].placeBeforeDatePicker === true) {
+                    userSettings[k] = {"enabled": true};
+                }
+                else if (values.indexOf(k) === -1) {
                     userSettings[k] = {"enabled": false};
                     this.registredComponents[k].enabled = false;
                 }

--- a/frontend/express/public/core/home/javascripts/countly.views.js
+++ b/frontend/express/public/core/home/javascripts/countly.views.js
@@ -163,6 +163,7 @@ var HomeViewView = countlyVue.views.create({
         setSelectedComponents: function(values) {
             //save for users
             var userSettings = {};
+            var self = this;
             for (var k in this.registredComponents) {
                 if (this.registredComponents[k].placeBeforeDatePicker === true) {
                     userSettings[k] = {"enabled": true};
@@ -181,12 +182,17 @@ var HomeViewView = countlyVue.views.create({
             countlyGlobal.member.homeSettings[countlyCommon.ACTIVE_APP_ID] = userSettings;
 
             this.$store.dispatch('countlyHomeView/updateHomeView', userSettings).then(function() {
-                CountlyHelpers.notify({type: "ok", title: jQuery.i18n.map["common.success"], message: jQuery.i18n.map["events.general.changes-saved"], sticky: false, clearAll: true});
+                if (self.$store.state.countlyHomeView.updateError) {
+                    CountlyHelpers.notify({type: "error", title: jQuery.i18n.map["common.error"], message: jQuery.i18n.map["common.error"], sticky: false, clearAll: true});
+                }
+                else {
+                    CountlyHelpers.notify({type: "ok", title: jQuery.i18n.map["common.success"], message: jQuery.i18n.map["events.general.changes-saved"], sticky: false, clearAll: true});
+                }
             });
 
             this.calculatePlacedComponents();
         },
-        Selected: function(command) {
+        selected: function(command) {
             if (command === "download") {
                 var self = this;
                 CountlyHelpers.notify({type: "ok", title: jQuery.i18n.map["common.success"], message: "Starting image generation.you will be notified when it is ready. Please do not leave site.", sticky: true, clearAll: true});

--- a/frontend/express/public/core/home/javascripts/countly.views.js
+++ b/frontend/express/public/core/home/javascripts/countly.views.js
@@ -1,0 +1,226 @@
+/* global jQuery,CountlyHelpers,countlyVue, CV, countlyCommon,countlyGlobal, app,countlyHomeView*/
+
+var HomeViewView = countlyVue.views.create({
+    template: CV.T("/core/home/templates/home.html"),
+    data: function() {
+        return {
+            description: CV.i18n('dashboard.home-desc'),
+            allComponents: [],
+            topComponents: [],
+            componentSelector: [],
+            showComponentSelector: true,
+            selectedDynamicComponents: [],
+            selectedText: "",
+            registredComponents: {},
+            ordered: []
+        };
+    },
+    mounted: function() {
+        this.loadAllWidgets();
+    },
+    beforeDestroy: function() {
+        //call killing vuex modules there.
+        for (var k in this.registredComponents) {
+            var cc = this.registredComponents[k].component();
+            if (this.registredComponents[k] && this.registredComponents[k].component && this.registredComponents[k].component.module) {
+                CV.vuex.unregister(this.registredComponents[k].component.module.name);
+            }
+        }
+    },
+    methods: {
+        refresh: function() {
+            this.loadAllWidgets();
+        },
+        loadAllWidgets: function() {
+            var userSettings = {};
+            if (countlyGlobal && countlyGlobal.member && countlyGlobal.member.homeSettings && countlyCommon.ACTIVE_APP_ID) {
+                userSettings = countlyGlobal.member.homeSettings[countlyCommon.ACTIVE_APP_ID] || {};
+            }
+            var cc = countlyVue.container.dataMixin({
+                'homeComponents': '/home/widgets'
+            });
+            cc = cc.data();
+            var allComponents = cc.homeComponents; //all components
+
+            var appType = "";
+            if (countlyGlobal && countlyGlobal.apps && countlyCommon.ACTIVE_APP_ID && countlyGlobal.apps[countlyCommon.ACTIVE_APP_ID]) {
+                appType = countlyGlobal.apps[countlyCommon.ACTIVE_APP_ID].type;
+            }
+
+            for (var k = 0; k < allComponents.length; k++) {
+                var available = false;
+                if (allComponents[k].available) {
+                    available = allComponents[k].available.default || false;
+                    if (typeof allComponents[k].available[appType] !== 'undefined') {
+                        available = allComponents[k].available[appType];
+                    }
+                }
+                if (available) {
+                    var enabled = false;
+                    var order = allComponents[k].order || 0;
+                    if (allComponents[k].enabled) {
+                        enabled = allComponents[k].enabled.default || false;
+                        if (typeof allComponents[k].enabled[appType] !== 'undefined') {
+                            enabled = allComponents[k].enabled[appType];
+                        }
+                    }
+
+                    if (typeof userSettings[allComponents[k]._id] !== "undefined") {
+                        enabled = userSettings[allComponents[k]._id].enabled || false;
+                        order = userSettings[allComponents[k]._id].order || 0;
+                    }
+
+                    if (!this.registredComponents[allComponents[k]._id]) {
+
+                        if (enabled && !allComponents[k].placeBeforeDatePicker && this.selectedDynamicComponents.indexOf(allComponents[k]._id) === -1) {
+                            this.selectedDynamicComponents.push(allComponents[k]._id);//add as selected
+                        }
+                        this.registredComponents[allComponents[k]._id] = {"width": allComponents[k].width, "enabled": enabled, _id: allComponents[k]._id, "label": allComponents[k].label, "description": allComponents[k].description, "order": allComponents[k].order, "placeBeforeDatePicker": allComponents[k].placeBeforeDatePicker, "component": allComponents[k].component, "linkTo": allComponents[k].linkTo};
+                        if (this.registredComponents[allComponents[k]._id].placeBeforeDatePicker) {
+                            if (this.topComponents.length === 0) {
+                                this.topComponents.push(this.registredComponents[allComponents[k]._id]);
+                            }
+                            else {
+                                var placeAt = 0;
+                                for (var zz = this.topComponents.length; zz > 0; zz--) {
+                                    if (this.topComponents[zz - 1].order < allComponents[k].order) {
+                                        placeAt = zz;
+                                        break;
+                                    }
+
+                                }
+                                this.topComponents.splice(placeAt, 0, this.registredComponents[allComponents[k]._id]);
+                            }
+                        }
+                    }
+                    this.registredComponents[allComponents[k]._id].enabled = enabled;
+                    this.registredComponents[allComponents[k]._id].order = order;
+                }
+
+            }
+
+            this.calculatePlacedComponents();
+
+        },
+        calculatePlacedComponents: function() {
+            this.componentSelector = [];
+            this.allComponents = [];
+            var forOrdering = [];
+
+            for (var k in this.registredComponents) {
+                if (!this.registredComponents[k].placeBeforeDatePicker) {
+                    this.componentSelector.push({"value": this.registredComponents[k]._id, label: this.registredComponents[k].label, "order": this.registredComponents[k].order});
+                }
+                if (this.registredComponents[k].enabled) {
+                    if (!this.registredComponents[k].placeBeforeDatePicker) {
+                        forOrdering.push({"_id": k, "size": this.registredComponents[k].width || 12, "order": this.registredComponents[k].order});
+                    }
+                }
+            }
+            this.componentSelector = this.componentSelector.sort(function(a, b) {
+                return a.order - b.order;
+            });
+            forOrdering = forOrdering.sort(function(a, b) {
+                return a.order - b.order;
+            });
+
+            for (var z = 0; z < forOrdering.length; z++) {
+                if (forOrdering[z].size && forOrdering[z].size === 6) {
+                    if (z + 1 < forOrdering.length && forOrdering[z + 1].size === 6) {
+                        forOrdering[z].classes = "bu-pr-3";
+                        forOrdering[z + 1].classes = "bu-pl-3";
+                        forOrdering[z] = {"itemgroup": true, data: [forOrdering[z], forOrdering[z + 1]] };
+                        forOrdering.splice(z + 1, 1);
+                    }
+                }
+                else {
+                    forOrdering[z].classes = "";
+                }
+            }
+
+
+            var not_changed = true;
+            if (this.ordered.length === forOrdering.length) {
+                for (var z1 = 0; z1 < forOrdering.length; z1++) {
+                    if (forOrdering[z1]._id !== this.ordered[z1]._id) {
+                        not_changed = false;
+                    }
+                }
+                if (!not_changed) {
+                    this.ordered = forOrdering;
+                }
+            }
+            else {
+                this.ordered = forOrdering;
+            }
+
+            if (this.componentSelector.length > 0) {
+                this.showComponentSelector = true;
+            }
+            else {
+                this.showComponentSelector = false;
+            }
+        },
+        setSelectedComponents: function(values) {
+            //save for users
+            var userSettings = {};
+            for (var k in this.registredComponents) {
+                if (values.indexOf(k) === -1) {
+                    userSettings[k] = {"enabled": false};
+                    this.registredComponents[k].enabled = false;
+                }
+                else {
+                    userSettings[k] = {"enabled": true, "order": values.indexOf(k)};
+                    this.registredComponents[k].enabled = true;
+                    this.registredComponents[k].order = values.indexOf(k);
+                }
+            }
+            countlyGlobal.member.homeSettings = countlyGlobal.member.homeSettings || {};
+            countlyGlobal.member.homeSettings[countlyCommon.ACTIVE_APP_ID] = userSettings;
+
+            this.$store.dispatch('countlyHomeView/updateHomeView', userSettings).then(function() {
+                CountlyHelpers.notify({type: "ok", title: jQuery.i18n.map["common.success"], message: jQuery.i18n.map["events.general.changes-saved"], sticky: false, clearAll: true});
+            });
+
+            this.calculatePlacedComponents();
+        },
+        Selected: function(command) {
+            if (command === "download") {
+                var self = this;
+                CountlyHelpers.notify({type: "ok", title: jQuery.i18n.map["common.success"], message: "Starting image generation.you will be notified when it is ready. Please do not leave site.", sticky: true, clearAll: true});
+                this.$store.dispatch("countlyHomeView/downloadScreen").then(function() {
+                    if (self.$store.state.countlyHomeView.image) {
+                        CountlyHelpers.notify({type: "ok", title: jQuery.i18n.map["common.success"], message: "<a href='" + self.$store.state.countlyHomeView.image + "'>Download</a>", sticky: true, clearAll: true});
+                    }
+                    else {
+                        CountlyHelpers.notify({type: "error", title: jQuery.i18n.map["common.success"], message: "ERROR", sticky: false, clearAll: true});
+                    }
+                });
+            }
+        }
+    },
+    computed: {
+
+    },
+    mixins: [
+        countlyVue.container.dataMixin({
+            'homeComponents': '/home/widgets'
+        })
+    ]
+});
+
+
+var HomeView = new countlyVue.views.BackboneWrapper({
+    component: HomeViewView,
+    vuex: [{clyModel: countlyHomeView}]
+});
+
+
+app.HomeView = HomeView;
+
+
+app.route("/home", "home", function() {
+    var params = {};
+    this.HomeView.params = params;
+    this.renderWhenReady(this.HomeView);
+});

--- a/frontend/express/public/core/home/javascripts/countly.views.js
+++ b/frontend/express/public/core/home/javascripts/countly.views.js
@@ -151,7 +151,17 @@ var HomeViewView = countlyVue.views.create({
                 }
             }
             else {
+                not_changed = false;
                 this.ordered = forOrdering;
+            }
+
+            if (!not_changed) {
+
+                this.ordered = [];
+                var self = this;
+                setTimeout(function() {
+                    self.ordered = forOrdering;
+                }, 1000);
             }
 
             if (this.componentSelector.length > 0) {

--- a/frontend/express/public/core/home/javascripts/countly.views.js
+++ b/frontend/express/public/core/home/javascripts/countly.views.js
@@ -18,15 +18,6 @@ var HomeViewView = countlyVue.views.create({
     mounted: function() {
         this.loadAllWidgets();
     },
-    beforeDestroy: function() {
-        //call killing vuex modules there.
-        for (var k in this.registredComponents) {
-            var cc = this.registredComponents[k].component();
-            if (this.registredComponents[k] && this.registredComponents[k].component && this.registredComponents[k].component.module) {
-                CV.vuex.unregister(this.registredComponents[k].component.module.name);
-            }
-        }
-    },
     methods: {
         refresh: function() {
             this.loadAllWidgets();

--- a/frontend/express/public/core/home/templates/home.html
+++ b/frontend/express/public/core/home/templates/home.html
@@ -26,7 +26,7 @@
                     <el-button size="small" icon="ion-navicon-round"> {{i18n('common.customize')}} </el-button>
                 </template>
             </cly-select-x>
-			<cly-more-options size="small" class="bu-pl-2" @command="Selected">
+			<cly-more-options size="small" class="bu-pl-2" @command="selected">
 				<el-dropdown-item command="download"  >
 				  {{i18n('common.download')}} 
 				</el-dropdown-item>

--- a/frontend/express/public/core/home/templates/home.html
+++ b/frontend/express/public/core/home/templates/home.html
@@ -1,0 +1,87 @@
+<div v-bind:class="[componentId]">
+    <cly-header>
+        <template v-slot:header-left>
+            <h2> {{i18n('sidebar.home')}} 
+            </h2>
+            <span class="cly-vue-tooltip-icon ion ion-help-circled" style="margin-left:10px" v-tooltip.top-center="description"></span>
+        </template>
+		<template v-slot:header-right>
+			<cly-select-x
+                v-if="showComponentSelector"
+                search-placeholder=""
+                placeholder="i18n('dashboard.customize-home')"
+                :title="i18n('dashboard.customize-home')"
+                mode="multi-check-sortable"
+                placement="bottom-end"
+                :width="392"
+                :auto-commit="false"
+                :hide-default-tabs="true"
+                :hide-all-options-tab="true"
+				:searchable="false"
+                :options="componentSelector"
+				@input="setSelectedComponents"
+                v-model="selectedDynamicComponents"
+				showSelectedCount >
+                <template v-slot:trigger>
+                    <el-button size="small" icon="ion-navicon-round"> {{i18n('common.customize')}} </el-button>
+                </template>
+            </cly-select-x>
+			<cly-more-options size="small" class="bu-pl-2" @command="Selected">
+				<el-dropdown-item command="download"  >
+				  {{i18n('common.download')}} 
+				</el-dropdown-item>
+			</cly-more-options>
+			
+		</template>
+    </cly-header>
+	<cly-main>
+		<div id="main_home_view">
+			<div v-for="(item0, idx0) in topComponents" class="bu-pb-5">
+				<div class="bu-level bu-pb-3" v-if="item0.label">
+						<div class="bu-level-left">
+							<h2>{{item0.label}}</h2>
+							<span class="cly-vue-tooltip-icon ion ion-help-circled bu-pl-2" v-tooltip.top-center="item0.description"></span>
+						</div>
+						<div class="bu-level-right">
+							<a v-if="item0.linkTo" class="cly-back-link text-medium" :href="item0.linkTo.href"><span>{{item0.linkTo.label}}<i class="fas fa-arrow-right bu-pl-3"></i></span></a>
+						</div>
+				</div>
+				<component v-if="item0.component" v-bind:is="item0.component"></component>
+			</div>
+
+			<cly-date-picker-g></cly-date-picker-g>
+			<div  v-for="(item, idx) in ordered" class="bu-pt-5" >
+				<div v-if="item.itemgroup">
+					<div class="bu-columns bu-is-gapless">
+						<div  v-for="(item0, idx0) in item.data" v-if="registredComponents[item0._id]" class="bu-column bu-is-6">
+							<div :class="item0.classes">
+								<div class="bu-level bu-pb-3">
+									<div class="bu-level-left">
+										<h2>{{registredComponents[item0._id].label}}</h2>
+										<span class="cly-vue-tooltip-icon ion ion-help-circled bu-pl-2"  v-tooltip.top-center="registredComponents[item0._id].description"></span>
+									</div>
+									<div class="bu-level-right">
+										<a v-if="registredComponents[item0._id].linkTo" class="cly-back-link text-medium" :href="registredComponents[item0._id].linkTo.href"><span>{{registredComponents[item0._id].linkTo.label}}<i class="fas fa-arrow-right bu-pl-3"></i></span></a>
+									</div>
+								</div>
+								<component v-if="registredComponents[item0._id].component" v-bind:is="registredComponents[item0._id].component"></component>
+							</div>
+						</div>
+					</div>
+				</div>
+				<div v-if="registredComponents[item._id]">
+					<div class="bu-level bu-pb-3">
+						<div class="bu-level-left">
+							<h2>{{registredComponents[item._id].label}}</h2>
+							<span class="cly-vue-tooltip-icon ion ion-help-circled" style="margin-left:10px" v-tooltip.top-center="registredComponents[item._id].description"></span>
+						</div>
+						<div class="bu-level-right">
+							<a v-if="registredComponents[item._id].linkTo" class="cly-back-link text-medium" :href="registredComponents[item._id].linkTo.href"><span>{{registredComponents[item._id].linkTo.label}}<i class="fas fa-arrow-right bu-pl-3"></i></span></a>
+						</div>
+					</div>
+					<component v-if="registredComponents[item._id].component" v-bind:is="registredComponents[item._id].component"></component>
+				</div>
+			</div>
+		</div>
+	</cly-main>
+</div>

--- a/frontend/express/public/core/home/templates/sessionsWidget.html
+++ b/frontend/express/public/core/home/templates/sessionsWidget.html
@@ -1,0 +1,32 @@
+<div v-bind:class="[componentId]">
+	<div class="session-home-widget">	
+		<el-tabs v-model="sessionGraphTab" type="card" stretch>
+			<el-tab-pane :name="item.value" :key="idx" v-for="(item, idx) in chooseProperties" >
+				<div slot="label">
+					<div class="text-medium color-cool-gray-100 bu-mb-1 bu-p-5">
+						<div class="bu-is-flex bu-is-flex-direction-column bu-is-justify-content-space-between">
+							<div>
+								<span class="text-medium">{{item.label}}</span>
+								<span v-if="item.description" class="cly-vue-tooltip-icon ion ion-help-circled bu-pl-2"  v-tooltip.top-center="item.description"></span>
+							</div>
+						</div>
+						<div class="bu-is-flex bu-is-align-items-baseline number">
+							<h2>{{item.number}}</h2>
+							<div v-if="item.trend == 'u'" class="trend-up">
+								<i class="fas fa-arrow-up bu-pr-1"></i><span>{{item.trendValue}}</span>
+							</div>
+							<div v-if="item.trend == 'd'" class="trend-down"> 
+								<i class="fas fa-arrow-down bu-pr-1"></i><span>{{item.trendValue}}</span>
+							</div>
+						</div>
+					</div>
+				</div>
+				<div style="border-radius: 0 0px 4px 4px; background-color: #ffffff; border: 1px solid #ececec ">
+                <cly-chart-time :option="chartData(item.value)"></cly-chart-time>
+				</div>
+			</el-tab-pane>	              
+        </el-tabs>			
+	</div>
+</div>
+
+                   

--- a/frontend/express/public/core/session-overview/javascripts/countly.views.js
+++ b/frontend/express/public/core/session-overview/javascripts/countly.views.js
@@ -227,7 +227,7 @@ countlyVue.container.registerData("/home/widgets", {
     description: CV.i18n('session-overview.description'),
     enabled: {"default": true}, //object. For each type set if by default enabled
     available: {"default": true}, //object. default - for all app types. For other as specified.
-    order: 1, //sorted by ascending
+    order: 0, //sorted by ascending
     placeBeforeDatePicker: false,
     component: SessionHomeWidget,
     linkTo: {"label": CV.i18n('dashboard.go-to-sessions'), "href": "#/analytics/sessions"}

--- a/frontend/express/public/core/session-overview/javascripts/countly.views.js
+++ b/frontend/express/public/core/session-overview/javascripts/countly.views.js
@@ -1,4 +1,4 @@
-/* global countlyVue,CV,countlySessionOverview,app,countlyCommon*/
+/* global countlyVue,CV,countlySessionOverview,app,countlyCommon, $, countlyAnalyticsAPI, countlySession,countlyTotalUsers*/
 var SessionOverviewView = countlyVue.views.create({
     template: CV.T("/core/session-overview/templates/session-overview.html"),
     data: function() {
@@ -86,6 +86,153 @@ var getSessionAnalyticsView = function() {
         templates: []
     });
 };
+
+
+//Sessions data widget
+var SessionHomeWidget = countlyVue.views.create({
+    template: CV.T("/core/session-overview/templates/sessionsHomeWidget.html"),
+    data: function() {
+        return {
+            description: CV.i18n('session-overview.description'),
+            dataBlocks: [],
+            data: {},
+            lineOptions: {"series": []},
+            chooseProperties: this.calculateProperties(),
+            chosenProperty: "t",
+            sessionGraphTab: "t",
+        };
+    },
+    mounted: function() {
+        var self = this;
+        $.when(countlyAnalyticsAPI.initialize(["platforms", "devices", "carriers"]), countlySession.initialize(), countlyTotalUsers.initialize("users"), countlyCommon.getGraphNotes([countlyCommon.ACTIVE_APP_ID])).then(function() {
+            self.calculateAllData();
+        });
+    },
+    methods: {
+        refresh: function() {
+            var self = this;
+            $.when(countlyAnalyticsAPI.initialize(["platforms", "devices", "carriers"]), countlySession.initialize(), countlyTotalUsers.initialize("users"), countlyCommon.getGraphNotes([countlyCommon.ACTIVE_APP_ID])).then(function() {
+                self.calculateAllData();
+            });
+        },
+        chartData: function(value) {
+            return this.calculateSeries(value);
+        },
+        calculateAllData: function() {
+            this.chooseProperties = this.calculateProperties();
+            this.lineOptions = this.calculateSeries();
+        },
+        calculateProperties: function() {
+            var sessionData = countlySession.getSessionData();
+
+            var properties = [];
+            //keep this way to allow also switching to different columns for different types later.  Supports also more or less columns.
+            if (sessionData.usage['total-sessions']) {
+                properties.push({
+                    "value": "t",
+                    "label": CV.i18n('common.table.total-sessions'),
+                    "trend": sessionData.usage['total-sessions'].trend,
+                    "number": countlyCommon.getShortNumber(sessionData.usage['total-sessions'].total || 0),
+                    "trendValue": sessionData.usage['total-sessions'].change,
+                    "description": CV.i18n('dashboard.total-sessions-desc'),
+                });
+            }
+            if (sessionData.usage['new-users']) {
+                properties.push({
+                    "value": "n",
+                    "label": CV.i18n('common.table.new-sessions'),
+                    "trend": sessionData.usage['new-users'].trend,
+                    "number": countlyCommon.getShortNumber(sessionData.usage['new-users'].total || 0),
+                    "trendValue": sessionData.usage['new-users'].change,
+                    "description": CV.i18n('common.table.new-users-desc')
+                });
+            }
+
+            if (sessionData.usage['total-duration']) {
+                properties.push({
+                    "value": "d",
+                    "label": CV.i18n('dashboard.time-spent'),
+                    "trend": sessionData.usage['total-duration'].trend,
+                    "number": countlyCommon.getShortNumber(sessionData.usage['total-duration'].total || 0),
+                    "trendValue": sessionData.usage['total-duration'].change,
+                    "description": CV.i18n('dashboard.time-spent-desc')
+                });
+            }
+
+            if (sessionData.usage['avg-duration-per-session']) {
+                properties.push({
+                    "value": "d-avg",
+                    "label": CV.i18n('dashboard.avg-time-spent'),
+                    "trend": sessionData.usage['avg-duration-per-session'].trend,
+                    "number": countlyCommon.getShortNumber(sessionData.usage['avg-duration-per-session'].total || 0),
+                    "trendValue": sessionData.usage['avg-duration-per-session'].change,
+                    "description": CV.i18n('dashboard.avg-time-spent-desc'),
+                });
+            }
+
+            if (sessionData.usage['avg-duration-per-session']) {
+                properties.push({
+                    "value": "e-avg",
+                    "label": CV.i18n('dashboard.avg-reqs-received'),
+                    "trend": sessionData.usage['avg-events'].trend,
+                    "number": countlyCommon.getShortNumber(sessionData.usage['avg-events'].total || 0),
+                    "trendValue": sessionData.usage['avg-events'].change,
+                    "description": CV.i18n('dashboard.avg-reqs-received-desc')
+                });
+            }
+            return properties;
+        },
+        calculateSeries: function(value) {
+            var sessionDP = {};
+
+            switch (value || this.chosenProperty) {
+            case "t":
+                sessionDP = countlySession.getUserDPActive();
+                break;
+            case "n":
+                sessionDP = countlySession.getUserDPNew();
+                break;
+            case "d":
+                sessionDP = countlySession.getDurationDPAvg();
+                break;
+            case "d-avg":
+                sessionDP = countlySession.getDurationDP();
+                break;
+            case "e-avg":
+                sessionDP = countlySession.getEventsDPAvg();
+                break;
+            }
+            var series = [];
+            series.push({"name": sessionDP.chartDP[0].label + "(" + CV.i18n('common.previous-period') + ")", "data": sessionDP.chartDP[0].data, "color": "#39C0C8", lineStyle: {"color": "#39C0C8"} });
+            series.push({"name": sessionDP.chartDP[1].label, "data": sessionDP.chartDP[1].data});
+            return {"series": series};
+        }
+    },
+    computed: {
+        selectedProperty: {
+            set: function(value) {
+                this.chosenProperty = value;
+                this.calculateAllData();
+            },
+            get: function() {
+                return this.chosenProperty;
+            }
+        }
+    }
+});
+
+countlyVue.container.registerData("/home/widgets", {
+    _id: "sessions-dashboard-widget",
+    label: CV.i18n('dashboard.audience'),
+    description: CV.i18n('session-overview.description'),
+    enabled: {"default": true}, //object. For each type set if by default enabled
+    available: {"default": true}, //object. default - for all app types. For other as specified.
+    order: 1, //sorted by ascending
+    placeBeforeDatePicker: false,
+    component: SessionHomeWidget,
+    linkTo: {"label": CV.i18n('dashboard.go-to-sessions'), "href": "#/analytics/sessions"}
+});
+
 
 app.route("/analytics/sessions", "sessions", function() {
     var sessionAnalyticsViewWrapper = getSessionAnalyticsView();

--- a/frontend/express/public/core/session-overview/stylesheets/_main.scss
+++ b/frontend/express/public/core/session-overview/stylesheets/_main.scss
@@ -1,3 +1,63 @@
 .session-overview-date-picker-container {
     margin-bottom: 32px;
 }
+
+.session-home-widget .el-tabs__header .el-tabs__item {
+	background-color:#ffffff;
+}
+
+.session-home-widget .el-tabs__header .el-tabs__item.is-active {
+    border-bottom-color: #0166d6;
+    border-bottom-width: 2px;
+	background-color:#f6f6f6;
+}
+
+.session-home-widget .el-tabs__item {
+    border-left: 1px solid #ececec !important;
+    height: auto;
+    text-align: left;
+}
+.session-home-widget .el-tabs--card>.el-tabs__header {
+	margin: 0;
+}
+
+.session-home-widget .el-tabs__nav-wrap.is-scrollable{
+	border: 1px solid #ececec;
+	border-bottom: 0px;
+	background-color: #ffffff;
+}
+.session-home-widget .el-tabs--card .trend-up {
+    font-size: 14px;
+    position: relative;
+    top: -4px;
+    color: #12af51;
+	.fas {
+		background-color: #ebfaee;
+	    margin: 3px 3px 3px 7px;
+		border-radius: 16px;
+		padding: 4px;
+		font-size: 9px;
+	}
+	span {
+		position: relative;
+		top: 2px;
+	}
+}
+
+.session-home-widget .el-tabs--card .trend-down {
+    font-size: 14px;
+    color: #d23f00;
+    position: relative;
+    top: -4px;
+	.fas {
+		background-color: #fbece5;
+		margin: 3px 3px 3px 7px;
+		border-radius: 16px;
+		padding: 4px;
+		font-size: 9px;
+	}
+	span {
+		position: relative;
+		top: 2px;
+	}
+}

--- a/frontend/express/public/core/session-overview/templates/sessionsHomeWidget.html
+++ b/frontend/express/public/core/session-overview/templates/sessionsHomeWidget.html
@@ -1,0 +1,30 @@
+<div v-bind:class="[componentId]">
+	<div class="session-home-widget">	
+		<el-tabs v-model="sessionGraphTab" type="card" stretch>
+			<el-tab-pane :name="item.value" :key="idx" v-for="(item, idx) in chooseProperties" >
+				<div slot="label">
+					<div class="text-medium color-cool-gray-100 bu-mb-1 bu-p-5">
+						<div class="bu-is-flex bu-is-flex-direction-column bu-is-justify-content-space-between">
+							<div>
+								<span class="text-medium">{{item.label}}</span>
+								<span v-if="item.description" class="cly-vue-tooltip-icon ion ion-help-circled bu-pl-2"  v-tooltip.top-center="item.description"></span>
+							</div>
+						</div>
+						<div class="bu-is-flex bu-is-align-items-baseline number">
+							<h2>{{item.number}}</h2>
+							<div v-if="item.trend == 'u'" class="trend-up">
+								<i class="fas fa-arrow-up bu-pr-1"></i><span>{{item.trendValue}}</span>
+							</div>
+							<div v-if="item.trend == 'd'" class="trend-down"> 
+								<i class="fas fa-arrow-down bu-pr-1"></i><span>{{item.trendValue}}</span>
+							</div>
+						</div>
+					</div>
+				</div>
+				<div style="border-radius: 0 0px 4px 4px; background-color: #ffffff; border: 1px solid #ececec ">
+                <cly-chart-time :option="chartData(item.value)"></cly-chart-time>
+				</div>
+			</el-tab-pane>	              
+        </el-tabs>			
+	</div>
+</div>

--- a/frontend/express/public/javascripts/countly/countly.template.js
+++ b/frontend/express/public/javascripts/countly/countly.template.js
@@ -1167,11 +1167,15 @@ var AppRouter = Backbone.Router.extend({
         }
     },
     dashboard: function() {
+        var type = countlyGlobal.apps[countlyCommon.ACTIVE_APP_ID].type;
         if (countlyGlobal.member.restrict && countlyGlobal.member.restrict.indexOf("#/") !== -1) {
             return;
         }
         if (_.isEmpty(countlyGlobal.apps)) {
             this.renderWhenReady(this.manageAppsView);
+        }
+        else if (type === "mobile" || type === "web" || type === "desktop") {
+            this.renderWhenReady(app.HomeView);
         }
         else if (typeof this.appTypes[countlyGlobal.apps[countlyCommon.ACTIVE_APP_ID].type] !== "undefined") {
             this.renderWhenReady(this.appTypes[countlyGlobal.apps[countlyCommon.ACTIVE_APP_ID].type]);

--- a/frontend/express/public/javascripts/countly/vue/components/vis.js
+++ b/frontend/express/public/javascripts/countly/vue/components/vis.js
@@ -1859,7 +1859,7 @@
                     self.geojsonDetail = json;
                     self.country = country;
                     self.regionsToLatLng = {};
-					json.features = json.features || {};
+                    json.features = json.features || {};
                     json.features.forEach(function(f) {
                         self.regionsToLatLng[f.properties.iso_3166_2] = {
                             lat: f.properties.lat || 0,

--- a/frontend/express/public/javascripts/countly/vue/components/vis.js
+++ b/frontend/express/public/javascripts/countly/vue/components/vis.js
@@ -1859,6 +1859,7 @@
                     self.geojsonDetail = json;
                     self.country = country;
                     self.regionsToLatLng = {};
+					json.features = json.features || {};
                     json.features.forEach(function(f) {
                         self.regionsToLatLng[f.properties.iso_3166_2] = {
                             lat: f.properties.lat || 0,

--- a/frontend/express/public/localization/dashboard/dashboard.properties
+++ b/frontend/express/public/localization/dashboard/dashboard.properties
@@ -32,6 +32,7 @@ common.60days = 60 days
 common.90days = 90 days
 common.from = from
 common.to  = to
+common.download = Download
 common.compare-to = Compare to
 common.no-comparison = No comparison
 common.of-total = of Total
@@ -43,11 +44,18 @@ common.bar.top-resolution = TOP RESOLUTIONS
 common.bar.top-resolution.description = Top 3 resolutions
 common.bar.top-carrier = TOP CARRIERS
 common.bar.top-users = TOP USERS
-common.bar.top-platform = TOP PLATFORMS
+common.bar.top-platform = Top Platforms
 common.bar.top-platform.description = Top 3 platforms
 common.bar.top-platform-version = TOP PLATFORM VERSIONS
 common.bar.top-platform-version.description = Top 3 platform versions
-common.bar.top-devices = TOP DEVICES
+common.bar.top-devices = Top  Devices
+common.bar.top-devices.description = Top devices
+common.bar.top-device-types = Top  Device types
+common.bar.top-device-types.description = Top devices
+common.bar.top-browsers = Top Browsers
+common.bar.top-browsers.description =Top Browsers Description
+common.bar.top-app-versions = Top App Versions
+common.bar.top-app-versions.description =Top App Versions Description
 common.bar.no-data = No Data
 common.apply = Apply
 common.apply-changes = Apply changes
@@ -198,6 +206,7 @@ common.zoom-out = Zoom out
 common.zoom-reset = Reset view ({0}%)
 common.group = GROUP
 common.send = Send
+common.customize = Customize
 
 #vue
 common.undo = Undo
@@ -318,6 +327,7 @@ sidebar.analytics.carriers = Carriers
 sidebar.analytics.platforms = Platforms
 sidebar.analytics.resolutions = Resolutions
 sidebar.analytics.technology = Technology
+sidebar.analytics.technology-description = Technology section description
 sidebar.analytics.geo = Geo
 sidebar.engagement = Engagement
 sidebar.events = Events
@@ -345,13 +355,21 @@ sidebar.feedback = Feedback
 
 #dashboard
 dashboard.apply = Apply
-dashboard.avg-time-spent = AVG. SESSION DURATION
-dashboard.time-spent = TIME SPENT
+dashboard.home-desc = All Home things overview
+dashboard.audience = Audience
+dashboard.customize-home = Customize Home
+dashboard.avg-time-spent = Avg. Session Duration
+dashboard.avg-time-spent-desc = Avg. Session Duration
+dashboard.time-spent = Time Spent
+dashboard.time-spent-desc = Total time spent for this period
 dashboard.reqs-received = REQUESTS RECEIVED
-dashboard.avg-reqs-received = AVG. REQUESTS RECEIVED
+dashboard.avg-reqs-received = Avg. Requests Recieved
+dashboard.avg-reqs-received-desc = Avg. Requests Recieved
 dashboard.bounce-rate = BOUNCE RATE
 dashboard.pages-per-visit = PAGES PER VISIT
 dashboard.note-title-remaining = Remaining
+dashboard.go-to-sessions = Go to sessions
+dashboard.total-sessions-desc = Total session data
 #users
 users.title = USERS
 
@@ -421,16 +439,19 @@ session-duration.title = SESSION DURATIONS
 session-duration.table.duration = Session duration
 
 #countries
-countries.title = COUNTRIES
+countries.title = Countries
+countries.description = Sountries description
 countries.table.country = Country
 countries.table.city = City
 countries.back-to-list = Back to Country List
 countries.google-api-key-remind = Google Maps API key must be setup to view city level data. Click here to setup Google Maps API key.
+countries.go-to-countries = Go To Countries
 
 #devices
 devices.title = DEVICES
 devices.table.device = Device
 devices.devices-and-types.title = Devices and types
+devices.go-to-technology = Go to Technology
 
 #analytics users 
 user-analytics.overview-title = User overview
@@ -486,6 +507,7 @@ events.blueprint-event-group-show.hidden = Hidden Groups
 events.blueprint-events-show.all = All Events
 events.blueprint-events-show.hidden = Hidden Events
 events.blueprint-events-show.visible = Visible Events
+events.go-to-events = Go to events
 
 events.blueprint-events-properties-tooltip = Edited properties of this event will be updated on All Events and other plugins.
 events.blueprint-event-groups-include-events-tooltip = Select at least 2 events to create an Event Group. New Event Groups will automatically  sum all the selected  event properties and report them.
@@ -646,7 +668,7 @@ management-applications.clear-1year-data = Clear data older than 1 year
 management-applications.clear-2year-data = Clear data older than 2 years
 management-applications.yes-clear-app = Yes, clear app data
 management-applications.no-clear = No don't clear
-management-applications.delete-an-app = Delete application
+management-applications.delete-an-app = Delete an app
 management-applications.yes-delete-app = Yes, delete the app
 management-applications.application-name = Application Name
 management-applications.application-name.tip = Enter application name

--- a/frontend/express/views/dashboard.html
+++ b/frontend/express/views/dashboard.html
@@ -2309,6 +2309,9 @@
         <script language="javascript" type="text/javascript" src="<%- cdn %>core/app-management/javascripts/countly.views.js?<%= countlyVersion %>"></script>
         <script language="javascript" type="text/javascript" src="<%- cdn %>core/user-management/javascripts/countly.models.js?<%= countlyVersion %>"></script>
         <script language="javascript" type="text/javascript" src="<%- cdn %>core/user-management/javascripts/countly.views.js?<%= countlyVersion %>"></script>
+		<script language="javascript" type="text/javascript" src="<%- cdn %>core/home/javascripts/countly.models.js?<%= countlyVersion %>"></script>
+		<script language="javascript" type="text/javascript" src="<%- cdn %>core/home/javascripts/countly.views.js?<%= countlyVersion %>"></script>
+		
         <% if (javascripts) { %>
 			<% for(var i=0, l=javascripts.length; i<l; i++) {%>
 				<script language="javascript" type="text/javascript" src="<%- cdn %><%= javascripts[i] %>?<%= countlyVersion %>"></script>

--- a/plugins/crashes/frontend/public/javascripts/countly.views.js
+++ b/plugins/crashes/frontend/public/javascripts/countly.views.js
@@ -965,6 +965,7 @@
         },
         beforeDestroy: function() {
             CV.vuex.unregister(this.module.name);
+            this.module = null;
         },
         methods: {
             refresh: function() {

--- a/plugins/crashes/frontend/public/javascripts/countly.views.js
+++ b/plugins/crashes/frontend/public/javascripts/countly.views.js
@@ -945,6 +945,78 @@
         crashId = crash;
         this.renderWhenReady(getBinaryImagesView());
     });
+
+    var CrashesDashboardWidget = countlyVue.views.create({
+        template: CV.T("/crashes/templates/crashesHomeWidget.html"),
+        data: function() {
+            return {
+                crashesItems: []
+            };
+        },
+        mounted: function() {
+            var self = this;
+            this.$store.dispatch("countlyCrashes/overview/refresh").then(function() {
+                self.calculateAllData();
+            });
+        },
+        beforeCreate: function() {
+            this.module = countlyCrashes.getVuexModule();
+            CV.vuex.registerGlobally(this.module);
+        },
+        methods: {
+            refresh: function() {
+                var self = this;
+                this.$store.dispatch("countlyCrashes/overview/refresh").then(function() {
+                    self.calculateAllData();
+                });
+            },
+            calculateAllData: function() {
+
+                var data = this.$store.getters["countlyCrashes/overview/dashboardData"];
+                var blocks = [];
+
+                var getUs = [{"name": CV.i18n('crashes.total-crashes'), "info": "", "prop": "cr", "r": true}, {"name": CV.i18n('crashes.unique'), "info": "", "prop": "cru", "r": true}, {"name": CV.i18n('crashes.total-per-session'), "info": "", "prop": "cr-session", "r": true}, {"name": CV.i18n('crashes.free-users'), "info": "", "prop": "crau", "p": true}, {"name": CV.i18n('crashes.free-sessions'), "info": "", "prop": "crses", "p": true}];
+
+
+                for (var k = 0; k < getUs.length; k++) {
+                    data[getUs[k].prop] = data[getUs[k].prop] || {};
+                    var value = data[getUs[k].prop].total;
+                    if (!getUs[k].p) {
+                        value = countlyCommon.formatNumber(data[getUs[k].prop].total || 0);
+                    }
+
+                    blocks.push({
+                        "name": getUs[k].name,
+                        "reverse": getUs[k].r,
+                        "value": value,
+                        "info": getUs[k].info,
+                        "trend": data[getUs[k].prop].trend,
+                        "change": data[getUs[k].prop].change
+                    });
+                }
+
+                this.crashesItems = blocks;
+            }
+        },
+        computed: {
+
+        }
+    });
+
+
+
+    countlyVue.container.registerData("/home/widgets", {
+        _id: "crashes-dashboard-widget",
+        label: CV.i18n('crashes.app-performance'),
+        description: CV.i18n('crashes.plugin-description'),
+        enabled: {"default": true}, //object. For each type set if by default enabled
+        available: {"default": true}, //object. default - for all app types. For other as specified.
+        placeBeforeDatePicker: false,
+        order: 9,
+        linkTo: {"label": CV.i18n('crashes.go-to-crashes'), "href": "#/crashes"},
+        component: CrashesDashboardWidget
+    });
+
 })();
 
 jQuery(document).ready(function() {

--- a/plugins/crashes/frontend/public/javascripts/countly.views.js
+++ b/plugins/crashes/frontend/public/javascripts/countly.views.js
@@ -963,6 +963,9 @@
             this.module = countlyCrashes.getVuexModule();
             CV.vuex.registerGlobally(this.module);
         },
+        beforeDestroy: function() {
+            CV.vuex.unregister(this.module.name);
+        },
         methods: {
             refresh: function() {
                 var self = this;

--- a/plugins/crashes/frontend/public/localization/crashes.properties
+++ b/plugins/crashes/frontend/public/localization/crashes.properties
@@ -55,6 +55,7 @@ crashes.crashes-by = Crash occurrences by
 crashes.mark-resolved = Mark as resolved
 crashes.mark-unresolved = Mark as unresolved
 crashes.total = Total Occurences
+crashes.total-crashes = Total Crashes
 crashes.unique = Unique Crashes
 crashes.rate = Crash Frequency
 crashes.top-crash = Top crash type
@@ -192,6 +193,8 @@ systemlogs.action.crash_deleted = Crash Deleted
 internal-events.[CLY]_crash = Crash
 crashes.show-binary-images = Show binary images
 crashes.binary-images = Binary Images
+crashes.go-to-crashes = Go To Crashes
+crashes.app-performance = App Performance
 
 crashes.crash-groups = Crash Groups
 crashes.crash-statistics = Crash Statistics

--- a/plugins/crashes/frontend/public/templates/crashesHomeWidget.html
+++ b/plugins/crashes/frontend/public/templates/crashesHomeWidget.html
@@ -1,0 +1,15 @@
+<div v-bind:class="[componentId]">
+	<cly-section>
+		<cly-metric-cards>
+				<cly-metric-card formatting="long" color="#097EFF" numberClasses="bu-is-flex bu-is-align-items-center" :key="idx" v-for="(item, idx) in crashesItems">
+					{{item.name}}
+					<cly-tooltip-icon v-if="item.info" icon="ion-help-circled" :tooltip="item.info"></cly-tooltip-icon>
+					<template v-slot:number>{{item.value}}</template>
+					<span v-if="item.trend=='d' && item.reverse" slot="description" class="cly-trend-up"><i class="bu-pr-1 fas fa-arrow-circle-down"></i>{{item.change}}</span>
+					<span v-else-if="item.trend=='d'" slot="description" class="cly-trend-down"><i class="bu-pr-1 fas fa-arrow-circle-down"></i>{{item.change}}</span>
+					<span v-else-if="item.trend=='u' && item.reverse" slot="description" class="cly-trend-down"><i class="bu-pr-1 fas fa-arrow-circle-up"></i>{{item.change}}</span>
+					<span v-else slot="description" class="cly-trend-up"><i class="bu-pr-1 fas fa-arrow-circle-up"></i>{{item.change}}</span>
+				</cly-metric-card>
+		</cly-metric-cards>
+	</cly-section>
+</div>

--- a/plugins/sources/frontend/public/javascripts/countly.views.js
+++ b/plugins/sources/frontend/public/javascripts/countly.views.js
@@ -258,6 +258,159 @@
         });
     }
 
+
+    var KeywordsDashboardWidget = countlyVue.views.create({
+        template: CV.T("/sources/templates/searchedTermsHomeWidget.html"),
+        data: function() {
+            return {
+                searchTermsTop3: [
+                    { percentage: 0, label: CV.i18n('common.table.no-data'), value: 0 },
+                    { percentage: 0, label: CV.i18n('common.table.no-data'), value: 0 },
+                    { percentage: 0, label: CV.i18n('common.table.no-data'), value: 0 }
+                ]
+            };
+        },
+        mounted: function() {
+            var self = this;
+            $.when(countlySources.initializeKeywords()).then(function() {
+                self.searchTermsTop3 = self.calculateAllData();
+            });
+        },
+        methods: {
+            refresh: function() {
+                var self = this;
+                $.when(countlySources.initializeKeywords()).then(function() {
+                    self.searchTermsTop3 = self.calculateAllData();
+                });
+            },
+            calculateAllData: function() {
+                var data = countlySources.getKeywords();
+                var totalsArray = [];
+                var sum = 0;
+                for (var i = 0; data.length > i; i++) {
+                    totalsArray.push([i, data[i].t]);
+                    sum += data[i].t;
+                }
+                totalsArray.sort(function(a, b) {
+                    return a[1] - b[1];
+                }).reverse();
+
+                if (totalsArray.length === 0) {
+                    return [
+                        { percentage: 0, label: CV.i18n('common.table.no-data'), value: 0 },
+                        { percentage: 0, label: CV.i18n('common.table.no-data'), value: 0 },
+                        { percentage: 0, label: CV.i18n('common.table.no-data'), value: 0 }
+                    ];
+                }
+
+                return [
+                    {percentage: Math.round((data[totalsArray[0][0]].t / sum) * 100), label: data[totalsArray[0][0]]._id, value: countlyCommon.getShortNumber(totalsArray[0][1] || 0)},
+                    {percentage: Math.round((data[totalsArray[1][0]].t / sum) * 100), label: data[totalsArray[1][0]]._id, value: countlyCommon.getShortNumber(totalsArray[1][1] || 0)},
+                    {percentage: Math.round((data[totalsArray[2][0]].t / sum) * 100), label: data[totalsArray[2][0]]._id, value: countlyCommon.getShortNumber(totalsArray[2][1] || 0)}
+                ];
+            }
+        },
+        computed: {
+
+        }
+    });
+
+
+    var SourcesDashboardWidget = countlyVue.views.create({
+        template: CV.T("/sources/templates/sourcesHomeWidget.html"),
+        data: function() {
+            return {
+                sourceItems: []
+            };
+        },
+        mounted: function() {
+            var self = this;
+            $.when(countlySources.initialize()).then(function() {
+                self.calculateAllData();
+            });
+        },
+        methods: {
+            refresh: function() {
+                var self = this;
+                $.when(countlySources.initialize()).then(function() {
+                    self.calculateAllData();
+                });
+            },
+            calculateAllData: function() {
+                var blocks = [];
+                var data = countlySources.getData() || {};
+                data = data.chartData || [];
+
+                var total = 0;
+                var values = [];
+                var cn = 5;
+
+                for (var p = 0; p < data.length; p++) {
+                    total = total + data[p].t;
+                    if (values.length < 5) {
+                        values.push({"name": data[p].sources, "t": data[p].t});
+                        values = values.sort(function(a, b) {
+                            return a.t - b.t;
+                        });
+                    }
+                    else {
+                        if (values[cn - 1].t < data[p].t) {
+                            values[cn - 1] = {"name": data[p].sources, "t": data[p].t};
+                            values = values.sort(function(a, b) {
+                                return a.t - b.t;
+                            });
+                        }
+                    }
+                }
+
+                for (var k = 0; k < values.length; k++) {
+                    var percent = Math.round((values[k].t || 0) * 1000 / (total || 1)) / 10;
+                    blocks.push({
+                        "name": values[k].name,
+                        "value": countlyCommon.getShortNumber(values[k].t || 0),
+                        "percent": percent,
+                        "percentText": percent + " % " + CV.i18n('common.of-total'),
+                        "info": "some description",
+                        "color": "#CDAD7A"
+                    });
+                }
+                this.sourceItems = blocks;
+            }
+        },
+        computed: {
+
+        }
+    });
+
+    if (countlyAuth.validateRead(FEATURE_NAME) && (countlyGlobal.apps[countlyCommon.ACTIVE_APP_ID].type === "web" || countlyGlobal.apps[countlyCommon.ACTIVE_APP_ID].type === "mobile")) {
+        countlyVue.container.registerData("/home/widgets", {
+            _id: "sources-dashboard-widget",
+            label: CV.i18n('sidebar.acquisition'),
+            description: CV.i18n('sources.description'),
+            enabled: {"default": true}, //object. For each type set if by default enabled
+            available: {"default": false, "mobile": true, "web": true}, //object. default - for all app types. For other as specified.
+            placeBeforeDatePicker: false,
+            order: 3,
+            linkTo: {"label": CV.i18n('sources.go-to-acquisition'), "href": "#/analytics/acquisition"},
+            component: SourcesDashboardWidget
+        });
+
+        if (countlyGlobal.apps[countlyCommon.ACTIVE_APP_ID].type === "web") {
+            countlyVue.container.registerData("/home/widgets", {
+                _id: "keywords-dashboard-widget",
+                label: CV.i18n('keywords.top_terms'),
+                description: CV.i18n('sources.description'),
+                enabled: {"default": true}, //object. For each type set if by default enabled
+                available: {"default": false, "web": true}, //object. default - for all app types. For other as specified.
+                placeBeforeDatePicker: false,
+                linkTo: {"label": CV.i18n('keywords.go-to-keywords'), "href": "#/analytics/acquisition/search-terms"},
+                order: 5,
+                width: 6,
+                component: KeywordsDashboardWidget
+            });
+        }
+    }
+
     $(document).ready(function() {
         if (countlyAuth.validateRead(FEATURE_NAME) && countlyCommon.ACTIVE_APP_ID && countlyGlobal.apps[countlyCommon.ACTIVE_APP_ID].type === "web") {
             app.addSubMenuForType("web", "analytics", {code: "analytics-acquisition", url: "#/analytics/acquisition", text: "sidebar.acquisition", priority: 90});

--- a/plugins/sources/frontend/public/localization/sources.properties
+++ b/plugins/sources/frontend/public/localization/sources.properties
@@ -9,8 +9,9 @@ sources.sources_length_limit = Characters length limitation for sources
 configs.help.sources-sources_length_limit = The characters beyond the limitation value will be ignored
 help.sources.chart = Pie chart on the left shows total visitors from each source (referral URL). Pie chart on the right shows new visitors from each source. The table below shows a breakdown of this data for each source. Click on each line on a table to see a list of paths.
 sources.drill_data = Drill Data
-sources.plugin-settings = Plugin Settings
+sources.go-to-acquisition = Go To Acquisition
 #keywords
 keywords.title = Search Terms
 keywords.top_terms = Top Searched Terms
 keywords.total = of Total
+keywords.go-to-keywords = Go to Search Terms

--- a/plugins/sources/frontend/public/stylesheets/main.css
+++ b/plugins/sources/frontend/public/stylesheets/main.css
@@ -1,3 +1,19 @@
 .source-table tr{cursor: pointer;}
 .source-20{width: 20%;}
 .source-40{width: 40%;}
+
+.bu-is-6 .keywordsDashboardWidget .cly-vue-metric-cards .cly-vue-metric-card {
+	flex-basis:100%;
+	width:100%;
+	border-bottom: 1px solid #ececec;
+	border-left:none;
+	border-right:none;
+	
+}
+.bu-is-6 .keywordsDashboardWidget .cly-vue-metric-cards .cly-vue-metric-card:last-child {
+	border-bottom:none;
+}
+.bu-is-6 .keywordsDashboardWidget .cly-vue-metric-cards .cly-vue-metric-card .cly-vue-metric-card__wrapper {
+	border-left:none;
+	border-right:none;
+}

--- a/plugins/sources/frontend/public/stylesheets/main.css
+++ b/plugins/sources/frontend/public/stylesheets/main.css
@@ -2,7 +2,7 @@
 .source-20{width: 20%;}
 .source-40{width: 40%;}
 
-.bu-is-6 .keywordsDashboardWidget .cly-vue-metric-cards .cly-vue-metric-card {
+.bu-is-6 .keywords-dashboard-widget .cly-vue-metric-cards .cly-vue-metric-card {
 	flex-basis:100%;
 	width:100%;
 	border-bottom: 1px solid #ececec;
@@ -10,10 +10,10 @@
 	border-right:none;
 	
 }
-.bu-is-6 .keywordsDashboardWidget .cly-vue-metric-cards .cly-vue-metric-card:last-child {
+.bu-is-6 .keywords-dashboard-widget .cly-vue-metric-cards .cly-vue-metric-card:last-child {
 	border-bottom:none;
 }
-.bu-is-6 .keywordsDashboardWidget .cly-vue-metric-cards .cly-vue-metric-card .cly-vue-metric-card__wrapper {
+.bu-is-6 .keywords-dashboard-widget .cly-vue-metric-cards .cly-vue-metric-card .cly-vue-metric-card__wrapper {
 	border-left:none;
 	border-right:none;
 }

--- a/plugins/sources/frontend/public/templates/searchedTermsHomeWidget.html
+++ b/plugins/sources/frontend/public/templates/searchedTermsHomeWidget.html
@@ -1,5 +1,5 @@
 <div v-bind:class="[componentId]">
-	<cly-section class="keywordsDashboardWidget">
+	<cly-section class="keywords-dashboard-widget">
         <cly-metric-cards>
             <cly-metric-card>
                 {{ searchTermsTop3[0].label }}

--- a/plugins/sources/frontend/public/templates/searchedTermsHomeWidget.html
+++ b/plugins/sources/frontend/public/templates/searchedTermsHomeWidget.html
@@ -1,0 +1,27 @@
+<div v-bind:class="[componentId]">
+	<cly-section class="keywordsDashboardWidget">
+        <cly-metric-cards>
+            <cly-metric-card>
+                {{ searchTermsTop3[0].label }}
+              <template v-slot:number>{{ searchTermsTop3[0].value }}</template>
+              <template v-slot:description>
+                <span class="text-medium">{{ searchTermsTop3[0].percentage }}% {{ i18n('keywords.total') }}</span>
+              </template>
+            </cly-metric-card>
+            <cly-metric-card>
+                {{ searchTermsTop3[1].label }}
+              <template v-slot:number>{{ searchTermsTop3[1].value }}</template>
+              <template v-slot:description>
+                <span class="text-medium">{{ searchTermsTop3[1].percentage }}% {{ i18n('keywords.total') }}</span>
+              </template>
+            </cly-metric-card>
+            <cly-metric-card>
+                {{ searchTermsTop3[2].label }}
+              <template v-slot:number>{{ searchTermsTop3[2].value }}</template>
+              <template v-slot:description>
+                <span class="text-medium">{{ searchTermsTop3[2].percentage }}% {{ i18n('keywords.total') }}</span>
+              </template>
+            </cly-metric-card>
+        </cly-metric-cards> 
+    </cly-section> 
+</div>

--- a/plugins/sources/frontend/public/templates/sourcesHomeWidget.html
+++ b/plugins/sources/frontend/public/templates/sourcesHomeWidget.html
@@ -1,0 +1,10 @@
+<div v-bind:class="[componentId]">
+	<cly-section>
+		<cly-metric-cards>
+			<cly-metric-card :is-percentage="true" :columnWidth=2.4 :color="item.color" :number="item.percent" :key="idx" v-for="(item, idx) in sourceItems">
+				{{item.name}}
+				<template v-slot:number>{{item.value}}</template>
+			</cly-metric-card>	
+		</cly-metric-cards>
+	</cly-section>
+</div>

--- a/plugins/views/frontend/public/javascripts/countly.views.js
+++ b/plugins/views/frontend/public/javascripts/countly.views.js
@@ -552,39 +552,38 @@
         },
     });
 
-	var ViewsHomeWidget = countlyVue.views.create({
-		template: CV.T("/views/templates/viewsHomeWidget.html"),
-		data: function() {
-			return {
-				dataBlocks:[]
-			}
-		},
-		mounted: function() {
-			var self = this;
-			self.$store.dispatch('countlyViews/fetchTotals').then(function() {
-				self.dataBlocks = self.calculateAllData();
+    var ViewsHomeWidget = countlyVue.views.create({
+        template: CV.T("/views/templates/viewsHomeWidget.html"),
+        data: function() {
+            return {
+                dataBlocks: []
+            };
+        },
+        mounted: function() {
+            var self = this;
+            self.$store.dispatch('countlyViews/fetchTotals').then(function() {
+                self.dataBlocks = self.calculateAllData();
             });
-		},
-		beforeCreate: function(){
-			this.module = countlyViews.getVuexModule();
-			CV.vuex.registerGlobally(this.module);
-		},
-		beforeDestroy: function() {
+        },
+        beforeCreate: function() {
+            this.module = countlyViews.getVuexModule();
+            CV.vuex.registerGlobally(this.module);
+        },
+        beforeDestroy: function() {
             CV.vuex.unregister(this.module.name);
         },
-		methods: {
-			refresh: function() {
-				var self = this;
+        methods: {
+            refresh: function() {
+                var self = this;
                 self.$store.dispatch('countlyViews/fetchTotals').then(function() {
-					self.dataBlocks = self.calculateAllData();
-				});
-			},
-			calculateAllData: function() {
-				var totals = {};
-				if(this.$store && this.$store.state && this.$store.state.countlyViews)
-				{
-					totals = this.$store.state.countlyViews.totals || {};
-				}
+                    self.dataBlocks = self.calculateAllData();
+                });
+            },
+            calculateAllData: function() {
+                var totals = {};
+                if (this.$store && this.$store.state && this.$store.state.countlyViews) {
+                    totals = this.$store.state.countlyViews.totals || {};
+                }
                 totals.t = totals.t || 0;
                 totals.uvc = totals.uvc || 0;
                 totals.s = totals.s || 0;
@@ -620,11 +619,11 @@
                         "color": "#F96300"
                     }
                 ];
-			}
-		}
-	});
-	
-	if (countlyAuth.validateRead(FEATURE_NAME)) {
+            }
+        }
+    });
+
+    if (countlyAuth.validateRead(FEATURE_NAME)) {
         countlyVue.container.registerTab("/analytics/sessions", {
             priority: 4,
             name: "views-per-session",
@@ -661,21 +660,21 @@
             this.viewsEditView.params = params;
             this.renderWhenReady(this.viewsEditView);
         });
-		
-		
-		countlyVue.container.registerData("/home/widgets", {
+
+
+        countlyVue.container.registerData("/home/widgets", {
             _id: "views-dashboard-widget",
-			label: CV.i18n('views.title'),
-			description: CV.i18n('views.description'),
-			enabled:{"default":true}, //object. For each type set if by default enabled
-			available: {"default":true},//object. default - for all app types. For other as specified.
-			placeBeforeDatePicker:false,
-			linkTo:{"label":CV.i18n('views.go-to-views'), "href":"#/analytics/views"},
-			width: 6,
-			order: 4,
-            component:ViewsHomeWidget
+            label: CV.i18n('views.title'),
+            description: CV.i18n('views.description'),
+            enabled: {"default": true}, //object. For each type set if by default enabled
+            available: {"default": true}, //object. default - for all app types. For other as specified.
+            placeBeforeDatePicker: false,
+            linkTo: {"label": CV.i18n('views.go-to-views'), "href": "#/analytics/views"},
+            width: 6,
+            order: 4,
+            component: ViewsHomeWidget
         });
-		
+
     }
 
     window.ActionMapView = countlyView.extend({

--- a/plugins/views/frontend/public/javascripts/countly.views.js
+++ b/plugins/views/frontend/public/javascripts/countly.views.js
@@ -7,7 +7,7 @@
         template: CV.T("/views/templates/manageViews.html"),
         data: function() {
             return {
-                description: CV.i18n('views.description'),
+                description: CV.i18n('views.title-desc'),
                 remoteTableDataSource: countlyVue.vuex.getServerDataSource(this.$store, "countlyViews", "viewsEditTable"),
                 isDeleteButtonDisabled: true,
                 isUpdateButtonDisabled: true,
@@ -665,7 +665,7 @@
         countlyVue.container.registerData("/home/widgets", {
             _id: "views-dashboard-widget",
             label: CV.i18n('views.title'),
-            description: CV.i18n('views.description'),
+            description: CV.i18n('views.title-desc'),
             enabled: {"default": true}, //object. For each type set if by default enabled
             available: {"default": true}, //object. default - for all app types. For other as specified.
             placeBeforeDatePicker: false,

--- a/plugins/views/frontend/public/javascripts/countly.views.js
+++ b/plugins/views/frontend/public/javascripts/countly.views.js
@@ -571,6 +571,7 @@
         },
         beforeDestroy: function() {
             CV.vuex.unregister(this.module.name);
+            this.module = null;
         },
         methods: {
             refresh: function() {

--- a/plugins/views/frontend/public/javascripts/countly.views.js
+++ b/plugins/views/frontend/public/javascripts/countly.views.js
@@ -552,7 +552,79 @@
         },
     });
 
-    if (countlyAuth.validateRead(FEATURE_NAME)) {
+	var ViewsHomeWidget = countlyVue.views.create({
+		template: CV.T("/views/templates/viewsHomeWidget.html"),
+		data: function() {
+			return {
+				dataBlocks:[]
+			}
+		},
+		mounted: function() {
+			var self = this;
+			self.$store.dispatch('countlyViews/fetchTotals').then(function() {
+				self.dataBlocks = self.calculateAllData();
+            });
+		},
+		beforeCreate: function(){
+			this.module = countlyViews.getVuexModule();
+			CV.vuex.registerGlobally(this.module);
+		},
+		beforeDestroy: function() {
+            CV.vuex.unregister(this.module.name);
+        },
+		methods: {
+			refresh: function() {
+				var self = this;
+                self.$store.dispatch('countlyViews/fetchTotals').then(function() {
+					self.dataBlocks = self.calculateAllData();
+				});
+			},
+			calculateAllData: function() {
+				var totals = {};
+				if(this.$store && this.$store.state && this.$store.state.countlyViews)
+				{
+					totals = this.$store.state.countlyViews.totals || {};
+				}
+                totals.t = totals.t || 0;
+                totals.uvc = totals.uvc || 0;
+                totals.s = totals.s || 0;
+                totals.b = totals.b || 0;
+                if (totals.s) {
+                    totals.br = Math.round(totals.b / totals.s * 1000) / 10;
+                }
+                else {
+                    totals.br = 0;
+                }
+
+                return [
+                    {
+                        "name": CV.i18n('views.total_page_views.title'),
+                        "description": CV.i18n('views.total_page_views.desc'),
+                        "value": countlyCommon.formatNumber(totals.t),
+                        "percent": 0,
+                        isPercentage: false
+                    },
+                    {
+                        "name": CV.i18n('views.uvc'),
+                        "description": CV.i18n('views.unique_page_views.desc'),
+                        "value": countlyCommon.formatNumber(totals.uvc),
+                        "percent": 0,
+                        isPercentage: false
+                    },
+                    {
+                        "name": CV.i18n('views.br'),
+                        "description": CV.i18n('views.bounce_rate.desc'),
+                        "value": totals.br + " %",
+                        "percent": Math.min(totals.br, 100),
+                        isPercentage: true,
+                        "color": "#F96300"
+                    }
+                ];
+			}
+		}
+	});
+	
+	if (countlyAuth.validateRead(FEATURE_NAME)) {
         countlyVue.container.registerTab("/analytics/sessions", {
             priority: 4,
             name: "views-per-session",
@@ -589,6 +661,21 @@
             this.viewsEditView.params = params;
             this.renderWhenReady(this.viewsEditView);
         });
+		
+		
+		countlyVue.container.registerData("/home/widgets", {
+            _id: "views-dashboard-widget",
+			label: CV.i18n('views.title'),
+			description: CV.i18n('views.description'),
+			enabled:{"default":true}, //object. For each type set if by default enabled
+			available: {"default":true},//object. default - for all app types. For other as specified.
+			placeBeforeDatePicker:false,
+			linkTo:{"label":CV.i18n('views.go-to-views'), "href":"#/analytics/views"},
+			width: 6,
+			order: 4,
+            component:ViewsHomeWidget
+        });
+		
     }
 
     window.ActionMapView = countlyView.extend({

--- a/plugins/views/frontend/public/localization/views.properties
+++ b/plugins/views/frontend/public/localization/views.properties
@@ -53,6 +53,7 @@ views.bounce_rate.desc = Bounce rate
 views.based-on = Views based on
 views.for = for
 views.display-name = Display name
+views.go-to-views = Go to views
 views.scrolling-avg = Avg. scroll
 internal-events.[CLY]_view = View
 internal-events.[CLY]_action = Action

--- a/plugins/views/frontend/public/localization/views.properties
+++ b/plugins/views/frontend/public/localization/views.properties
@@ -1,6 +1,7 @@
 #views
 views.title = Views
 views.description = Provide view information about pages/screens visited by users
+views.title-desc = Overview of the data trends and metrics for the pages or screens viewed on your application, in the selected time period.
 views.table.view = View
 views.table.edit-views = Edit views
 views.total-visits = Total Visits
@@ -47,9 +48,10 @@ views.b = Bounces
 views.br = Bounce rate
 views.uvc = Unique pageviews
 views.total_page_views.title = Total Page Views
-views.total_page_views.desc = Total number of page views in given data range
-views.unique_page_views.desc = Number of sessions in which view was viewed one more times
-views.bounce_rate.desc = Bounce rate
+views.total_page_views.desc = The total number of pages viewed, in the selected time period.
+views.unique_page_views.desc = Number of times a page is viewed in your application for the first time by users during a session, in the selected time period.
+views.bounce_rate.desc = Number of users who have landed on a page without visiting other pages, calculated as a percentage over the total number of users who landed on the page, in the selected time period.
+web.views.bounce_rate.desc = Number of visitors who have landed on a page without visiting other pages, calculated as a percentage over the total number of visitors who landed on the page, in the selected time period.
 views.based-on = Views based on
 views.for = for
 views.display-name = Display name

--- a/plugins/views/frontend/public/stylesheets/main.css
+++ b/plugins/views/frontend/public/stylesheets/main.css
@@ -4,19 +4,19 @@
 }
 
 .routename-views-home .views-date-picker-container {
-  margin-bottom: 32px;
+    margin-bottom: 32px;
 }
 
-.bu-is-6 .viewsDashboardWidget .cly-vue-metric-cards .cly-vue-metric-card {
-	flex-basis:100%;
-	width:100%;
-	border-bottom: 1px solid #ececec;	
+.bu-is-6 .views-dashboard-widget .cly-vue-metric-cards .cly-vue-metric-card {
+    flex-basis:100%;
+    width:100%;
+    border-bottom: 1px solid #ececec;	
 }
-.bu-is-6 .viewsDashboardWidget .cly-vue-metric-cards .cly-vue-metric-card:last-child {
-	border-bottom:none;
+.bu-is-6 .views-dashboard-widget .cly-vue-metric-cards .cly-vue-metric-card:last-child {
+    border-bottom:none;
 }
 
-.bu-is-6 .viewsDashboardWidget .cly-vue-metric-cards .cly-vue-metric-card .cly-vue-metric-card__wrapper {
-	border-left:none;
-	border-right:none;
+.bu-is-6 .views-dashboard-widget .cly-vue-metric-cards .cly-vue-metric-card .cly-vue-metric-card__wrapper {
+    border-left:none;
+    border-right:none;
 }

--- a/plugins/views/frontend/public/stylesheets/main.css
+++ b/plugins/views/frontend/public/stylesheets/main.css
@@ -6,3 +6,17 @@
 .routename-views-home .views-date-picker-container {
   margin-bottom: 32px;
 }
+
+.bu-is-6 .viewsDashboardWidget .cly-vue-metric-cards .cly-vue-metric-card {
+	flex-basis:100%;
+	width:100%;
+	border-bottom: 1px solid #ececec;	
+}
+.bu-is-6 .viewsDashboardWidget .cly-vue-metric-cards .cly-vue-metric-card:last-child {
+	border-bottom:none;
+}
+
+.bu-is-6 .viewsDashboardWidget .cly-vue-metric-cards .cly-vue-metric-card .cly-vue-metric-card__wrapper {
+	border-left:none;
+	border-right:none;
+}

--- a/plugins/views/frontend/public/templates/views.html
+++ b/plugins/views/frontend/public/templates/views.html
@@ -14,7 +14,6 @@
         </template>
     </cly-header>
     <cly-main>
-		
 		<cly-date-picker-g class="views-date-picker-container"></cly-date-picker-g>
 		<cly-in-page-notification :text="totalViewCountWarning" v-if="showViewCountWarning"></cly-in-page-notification>
 		<cly-section >
@@ -37,7 +36,6 @@
 			<div class ="bu-pl-1">
 				<cly-multi-select ref="selectSegmentValue"  @change="segmentChosen" v-model="filter" :fields="filterFields"></cly-multi-select>
 			</div>
-			
         </div>
 		
 		<cly-section>

--- a/plugins/views/frontend/public/templates/viewsHomeWidget.html
+++ b/plugins/views/frontend/public/templates/viewsHomeWidget.html
@@ -1,5 +1,5 @@
 <div v-bind:class="[componentId]">
-	<cly-section class="viewsDashboardWidget">
+	<cly-section class="views-dashboard-widget">
 		<cly-metric-cards>
                 <cly-metric-card :number="item.percent" :color="item.color" :is-percentage="item.isPercentage" :key="idx" v-for="(item, idx) in dataBlocks">
                     {{item.name}}

--- a/plugins/views/frontend/public/templates/viewsHomeWidget.html
+++ b/plugins/views/frontend/public/templates/viewsHomeWidget.html
@@ -1,0 +1,11 @@
+<div v-bind:class="[componentId]">
+	<cly-section class="viewsDashboardWidget">
+		<cly-metric-cards>
+                <cly-metric-card :number="item.percent" :color="item.color" :is-percentage="item.isPercentage" :key="idx" v-for="(item, idx) in dataBlocks">
+                    {{item.name}}
+					<span class="cly-vue-tooltip-icon ion ion-help-circled" style="margin-left:10px" v-tooltip.top-center="item.description"></span>
+					<template v-slot:number>{{item.value}}</template>
+                </cly-metric-card>
+        </cly-metric-cards>
+	</cly-section>
+</div>


### PR DESCRIPTION
*Home view (/core/home)
     ** Single view for 3 types(desktop, mobile, web)
     ** Passing widgets through mixins
     **  Downloading via /render
     ** User settings for which widgets to show in dashboard
     ** Changes in countly.template.js to use single view for mobile/desktop/web
*sessions  home widget (/clore/session-overview)
*events Home widget(/core/events)
*Sources and Keywords "widget" for home
*views home widget
*Technology home widget
*Home countries widget
*Crashes home widget