### PR TITLE
[SERVER-2355] Discard the first week in ticks if it is the 7th day

### DIFF
--- a/frontend/express/public/javascripts/countly/countly.common.js
+++ b/frontend/express/public/javascripts/countly/countly.common.js
@@ -2619,6 +2619,9 @@
                     var allWeeks = [];
                     for (i = 0; i < days; i++) {
                         start.add(1, 'days');
+                        if (i === 0 && start.isoWeekday() === 7) {
+                            continue;
+                        }
                         allWeeks.push(start.isoWeek() + " " + start.isoWeekYear());
                     }
 


### PR DESCRIPTION
This PR aims at remedying the issue described below by removing the first week tick if it is a Sunday. Seemingly Sunday is a boundary for APIs, so that when a date range starts with a Sunday, week of that Sunday is just discarded. Hence, handling of weeks has to be the same in the UI as well. Otherwise buckets and data points goes out of sync. Please see SERVER-2355 for further info.

> If the selected day is the first day of the week (sunday), time labels/buckets is shifted right 1 step:
> 
> - Same on drill custom dashboard widgets as well.
> - Present on drill graph (in its own view), too.
> - Present on drill table, too. This is also important as it inidicates that the problem is not exclusive to graphs.
> - Not present on formulas graph and table in its view (probably because of formulas not using common bucket utils there)