### PR TITLE
fix: Emit save event for disabled button only when emitSaveWhenDisabled is true

### DIFF
--- a/frontend/express/public/javascripts/countly/vue/components/helpers.js
+++ b/frontend/express/public/javascripts/countly/vue/components/helpers.js
@@ -107,9 +107,10 @@
         },
         methods: {
             save: function() {
-                if (this.emitSaveWhenDisabled) {
-                    this.$emit("save");
+                if (this.disabled && !this.emitSaveWhenDisabled) {
+                    return;
                 }
+                this.$emit("save");
             },
             discard: function() {
                 this.$emit("discard");


### PR DESCRIPTION
Fix: emit save event for disabled button only when emitSaveWenDisabled is true.
NOTE: this property is needed to run validator whenever user selects save. 