### PR TITLE
Fix/Not finding push notification credentials error

### DIFF
--- a/plugins/push/api/api-message.js
+++ b/plugins/push/api/api-message.js
@@ -1,4 +1,4 @@
-const { Message, State, Status, platforms, Audience, ValidationError, TriggerKind, MEDIA_MIME_ALL } = require('./send'),
+const { Message, Creds, State, Status, platforms, Audience, ValidationError, TriggerKind, MEDIA_MIME_ALL } = require('./send'),
     { DEFAULTS } = require('./send/data/const'),
     common = require('../../../api/utils/common'),
     log = common.log('push:api:message');
@@ -34,7 +34,7 @@ async function validate(args, preparing = false) {
                 throw new ValidationError('No push credentials for specified platforms');
             }
 
-            let creds = await common.db.collection('credentials').find({_id: {$in: msg.platforms.map(p => common.dot(app, `plugins.push.${p}._id`))}}).toArray();
+            let creds = await common.db.collection(Creds.collection).find({_id: {$in: msg.platforms.map(p => common.dot(app, `plugins.push.${p}._id`))}}).toArray();
             if (creds.length !== msg.platforms.length) {
                 throw new ValidationError('No push credentials in db');
             }

--- a/plugins/push/api/api-reset.js
+++ b/plugins/push/api/api-reset.js
@@ -1,4 +1,5 @@
-const common = require('../../../api/utils/common');
+const common = require('../../../api/utils/common'),
+    { Creds } = require('./send');
 
 /**
  * Reset the app by removing all push artifacts
@@ -15,7 +16,7 @@ async function reset(ob) {
             if (app && app.plugins && app.plugins.push) {
                 return Promise.all(Object.values(app.plugins.push).map(async cfg => {
                     if (cfg && cfg._id) {
-                        return common.db.collection('credentials').deleteOne({_id: cfg._id});
+                        return common.db.collection(Creds.collection).deleteOne({_id: cfg._id});
                     }
                 }).concat([
                     common.db.collection('apps').updateOne({a: aid}, {$unset: {'plugins.push': 1}}).catch(() => {})

--- a/plugins/push/api/jobs/util/connector.js
+++ b/plugins/push/api/jobs/util/connector.js
@@ -1,5 +1,5 @@
 const { SynFlushTransform } = require('./syn'),
-    { Message, pools, FRAME } = require('../../send');
+    { Message, Creds, pools, FRAME } = require('../../send');
 
 /**
  * Stream responsible for handling sending results:
@@ -76,7 +76,7 @@ class Connector extends SynFlushTransform {
                         let id = a.plugins.push[p]._id;
                         if (id) {
                             this.log.d('Loading credentials %s', id);
-                            promises.push(this.db.collection('credentials').findOne(id).then(cred => {
+                            promises.push(this.db.collection(Creds.collection).findOne(id).then(cred => {
                                 if (cred) {
                                     a.creds[p] = cred;
                                 }

--- a/plugins/push/frontend/public/javascripts/countly.models.js
+++ b/plugins/push/frontend/public/javascripts/countly.models.js
@@ -786,7 +786,7 @@
                 if (hasIOSConfig) {
                     return {
                         _id: dto[PlatformDtoEnum.IOS]._id || '',
-                        keyId: dto[PlatformDtoEnum.IOS].fileType === IOSAuthConfigTypeEnum.P8 ? dto[PlatformDtoEnum.IOS].fileType : '',
+                        keyId: dto[PlatformDtoEnum.IOS].fileType === IOSAuthConfigTypeEnum.P8 ? dto[PlatformDtoEnum.IOS].key : '',
                         keyFile: '',
                         bundleId: dto[PlatformDtoEnum.IOS].bundle,
                         authType: dto[PlatformDtoEnum.IOS].fileType === IOSAuthConfigTypeEnum.P12 ? IOSAuthConfigTypeEnum.P12 : IOSAuthConfigTypeEnum.P8,

--- a/plugins/push/frontend/public/stylesheets/main.scss
+++ b/plugins/push/frontend/public/stylesheets/main.scss
@@ -464,6 +464,8 @@
         border-top-left-radius: 6px;
         border: 1px solid #E2E4E8;
         min-width: 200px;
+        height: 329px;
+        overflow-y: auto;
     }
 
     &__subsection-left-row-active {


### PR DESCRIPTION
Fixes the error of not being able to find push notification credentials even though they exist when the user creates a new message.

Bonus fix:
 - mapping filetype instead of key error in app level config.
 - overflowing locales in message editor when there are many.