### PR TITLE
Empty slot CSS changes.

### DIFF
--- a/frontend/express/public/javascripts/countly/vue/templates/datatable.html
+++ b/frontend/express/public/javascripts/countly/vue/templates/datatable.html
@@ -68,7 +68,7 @@
                     <cly-empty-datatable></cly-empty-datatable>
                 </template>
                 <template slot="empty" v-if="isLoading">
-                    {{ i18n('common.loading')}}...
+                    <div class="cly-vue-eldatatable__empty-slot"></div>
                 </template>
                 <template v-for="(_, name) in forwardedSlots" v-slot:[name]="slotData">
                     <slot :name="name" v-bind="commonScope"/>

--- a/frontend/express/public/stylesheets/styles/blocks/_table.scss
+++ b/frontend/express/public/stylesheets/styles/blocks/_table.scss
@@ -83,6 +83,10 @@
 		padding-left:16px;
 		padding-right: 8px;
 	}
+
+	&__empty-slot {
+		height: 200px;
+	}
 }
 
 //plain table


### PR DESCRIPTION
loading icon and loading text look bad together, so loading text removed, only icon will appear.