### PR TITLE
Trend icons font weight changes

### DIFF
--- a/frontend/express/public/core/session-overview/stylesheets/_main.scss
+++ b/frontend/express/public/core/session-overview/stylesheets/_main.scss
@@ -28,6 +28,7 @@
 }
 .session-home-widget .el-tabs--card .trend-up {
     font-size: 14px;
+	font-weight: 500;
     position: relative;
     top: -4px;
     color: #12af51;
@@ -46,6 +47,7 @@
 
 .session-home-widget .el-tabs--card .trend-down {
     font-size: 14px;
+	font-weight: 500;
     color: #d23f00;
     position: relative;
     top: -4px;

--- a/frontend/express/public/stylesheets/styles/states/_state.scss
+++ b/frontend/express/public/stylesheets/styles/states/_state.scss
@@ -118,12 +118,14 @@
 
 .cly-trend-up {
     font-size: t.$text-md-size;
+    font-weight: t.$font-weight-primary;
     color: map.get(c.$colors, "green-80");
     margin-left: -4px;
 }
 
 .cly-trend-down {
     font-size: t.$text-md-size;
+    font-weight: t.$font-weight-primary;
     color: map.get(c.$colors, "red-100");
     margin-left: -4px;
 }

--- a/frontend/express/public/stylesheets/vue/clyvue.scss
+++ b/frontend/express/public/stylesheets/vue/clyvue.scss
@@ -996,6 +996,7 @@
 				}
 				.trend-up{
 					font-size: 14px;
+                    font-weight: 500;
 					position: relative;
 					top: -4px;
 					color: #12AF51;
@@ -1009,6 +1010,7 @@
 				}
 				.trend-down{
 					font-size: 14px;
+                    font-weight: 500;
 					color: #D23F00;
 					position: relative;
 					top: -4px;


### PR DESCRIPTION
the spaces looks aligned in my editor(vscode), I don't understand why they look so irregular here, but I can check if you wish.