### PR TITLE
Feature/server 2503 dynamic back link

### DIFF
--- a/frontend/express/public/javascripts/countly/countly.helpers.js
+++ b/frontend/express/public/javascripts/countly/countly.helpers.js
@@ -322,14 +322,14 @@
     };
 
     CountlyHelpers.goTo = function(options) {
-        app.backlinkRoute = options.from;
+        app.backlinkUrl = options.from;
         window.location.hash = options.url;
     };
 
-    CountlyHelpers.getBacklinkRoute = function() {
-        var route = app.backlinkRoute;
-        app.backlinkRoute = null;
-        return route;
+    CountlyHelpers.getBacklinkUrl = function() {
+        var url = app.backlinkUrl;
+        app.backlinkUrl = null;
+        return url;
     };
     /**
     * Create new model

--- a/frontend/express/public/javascripts/countly/countly.helpers.js
+++ b/frontend/express/public/javascripts/countly/countly.helpers.js
@@ -321,6 +321,16 @@
         countlyCommon.dispatchNotificationToast(payload);
     };
 
+    CountlyHelpers.goTo = function(options) {
+        app.backlinkRoute = options.from;
+        window.location.hash = options.url;
+    };
+
+    CountlyHelpers.getBacklinkRoute = function() {
+        var route = app.backlinkRoute;
+        app.backlinkRoute = null;
+        return route;
+    };
     /**
     * Create new model
     */

--- a/frontend/express/public/javascripts/countly/vue/components/layout.js
+++ b/frontend/express/public/javascripts/countly/vue/components/layout.js
@@ -6,7 +6,16 @@
 
     Vue.component("cly-header", countlyBaseComponent.extend({
         props: {
-            title: String
+            title: String,
+            backlink: {
+                type: Object,
+                default: function() {
+                    return null;
+                },
+                validator: function(value) {
+                    return value && value.url && value.title;
+                }
+            }
         },
         computed: {
             slotHeaderTop: function() {
@@ -44,12 +53,19 @@
                             </div>\
                         </div>\
                         <div :class="[midLevelClasses]">\
-                            <div class="bu-level-left">\
-                                <slot name="header-left">\
+                            <div class="bu-level-left"> \
+                                <template v-if="backlink"> \
                                     <div class="bu-level-item">\
-                                        <h2>{{title}}</h2>\
-                                    </div>\
-                                </slot>\
+                                        <cly-back-link :title="backlink.title" :link="backlink.url"></cly-back-link> \
+                                    </div> \
+                                </template> \
+                                <template v-else> \
+                                    <slot name="header-left">\
+                                        <div class="bu-level-item">\
+                                            <h2>{{title}}</h2>\
+                                        </div>\
+                                    </slot>\
+                                </template> \
                             </div>\
                             <div class="bu-level-right">\
                                 <slot name="header-right"></slot>\

--- a/plugins/slipping-away-users/frontend/public/javascripts/countly.views.js
+++ b/plugins/slipping-away-users/frontend/public/javascripts/countly.views.js
@@ -1,4 +1,4 @@
-/*global app,countlyAuth,countlySlippingAwayUsers,countlyVue,$,CV,countlyCommon*/
+/*global app,countlyAuth,countlySlippingAwayUsers,countlyVue,$,CV,countlyCommon,CountlyHelpers*/
 (function() {
 
     var FEATURE_NAME = "slipping_away_users";
@@ -66,7 +66,7 @@
                 if (currentFilters.query) {
                     Object.assign(data, currentFilters.query);
                 }
-                window.location.hash = '/users/query/' + JSON.stringify(data);
+                CountlyHelpers.goTo({url: '/users/query/' + JSON.stringify(data), from: "#/" + countlyCommon.ACTIVE_APP_ID + "/analytics/loyalty/slipping-away-users"});
             },
             refresh: function() {
                 this.$store.dispatch("countlySlippingAwayUsers/fetchAll", false);

--- a/plugins/slipping-away-users/frontend/public/javascripts/countly.views.js
+++ b/plugins/slipping-away-users/frontend/public/javascripts/countly.views.js
@@ -1,4 +1,4 @@
-/*global app,countlyAuth,countlySlippingAwayUsers,countlyVue,$,CV,countlyCommon,CountlyHelpers*/
+/*global app,countlyAuth,countlySlippingAwayUsers,countlyVue,$,CV,countlyCommon*/
 (function() {
 
     var FEATURE_NAME = "slipping_away_users";
@@ -66,7 +66,7 @@
                 if (currentFilters.query) {
                     Object.assign(data, currentFilters.query);
                 }
-                CountlyHelpers.goTo({url: '/users/query/' + JSON.stringify(data), from: "#/" + countlyCommon.ACTIVE_APP_ID + "/analytics/loyalty/slipping-away-users"});
+                window.location.hash = '/users/query/' + JSON.stringify(data);
             },
             refresh: function() {
                 this.$store.dispatch("countlySlippingAwayUsers/fetchAll", false);


### PR DESCRIPTION
Implement goTo() and getBacklinkRoute() helper methods that store and return the backlink url.

getBacklinkRoute() method must be called only inside the view data initialization because it deletes the backlink route after reading it.

