### PR TITLE
fix: drill queryObject parameter error

### DIFF
--- a/plugins/push/api/send/audience.js
+++ b/plugins/push/api/send/audience.js
@@ -264,7 +264,6 @@ class Audience {
                     qstring: Object.assign({app_id: this.app._id.toString()}, query)
                 };
                 delete params.qstring.queryObject.chr;
-                params.qstring.queryObject = JSON.stringify(query.queryObject);
                 this.log.d('Drilling: %j', params);
                 let arr = await new Promise((resolve, reject) => drill().drill.fetchUsers(params, (err, uids) => {
                     this.log.i('Done drilling: ' + (err ? 'error %j' : '%d uids'), err || (uids && uids.length) || 0);

--- a/plugins/push/frontend/public/javascripts/countly.models.js
+++ b/plugins/push/frontend/public/javascripts/countly.models.js
@@ -1534,6 +1534,7 @@
                 }
                 if (options.queryFilter && options.from === 'drill') {
                     var drillFilter = Object.assign({}, options.queryFilter);
+                    drillFilter.queryObject = JSON.stringify(options.queryFilter.queryObject);
                     var period = countlyCommon.getPeriod();
                     drillFilter.period = period;
                     if (Array.isArray(period)) {


### PR DESCRIPTION
Stringify queryObject in the client side instead of doing it on the server side.