### PR TITLE
ensure undefined is not in dynamic cols

### DIFF
--- a/frontend/express/public/javascripts/countly/vue/components/datatable.js
+++ b/frontend/express/public/javascripts/countly/vue/components/datatable.js
@@ -59,6 +59,8 @@
                 var self = this;
                 return this.controlParams.selectedDynamicCols.map(function(val) {
                     return self.availableDynamicColsLookup[val];
+                }).filter(function(val) {
+                    return !!val;
                 });
             },
             localSearchedRows: function() {


### PR DESCRIPTION
Sometimes when the columns are created dynamically, selected column may have a column, which will not be generated on the next time the table loads.