### PR TITLE
Feature/server 2541 remove test users

### DIFF
--- a/plugins/push/frontend/public/javascripts/countly.models.js
+++ b/plugins/push/frontend/public/javascripts/countly.models.js
@@ -1795,10 +1795,10 @@
             },
             mapTestUsersEditedModelToDto: function(editedModel) {
                 var testUsersDto = {};
-                if (editedModel.definitionType === AddTestUserDefinitionTypeEnum.USER_ID) {
+                if (editedModel.userIds && editedModel.userIds.length) {
                     Object.assign(testUsersDto, {uids: editedModel.userIds.join(',')});
                 }
-                if (editedModel.definitionType === AddTestUserDefinitionTypeEnum.COHORT) {
+                if (editedModel.cohorts && editedModel.cohorts.length) {
                     Object.assign(testUsersDto, {cohorts: editedModel.cohorts.join(',')});
                 }
                 return testUsersDto;
@@ -2179,7 +2179,7 @@
             }
             return countlyPushNotificationApprover.service.approve(messageId);
         },
-        addTestUsers: function(testUsersModel, options) {
+        updateTestUsers: function(testUsersModel, options) {
             try {
                 var testDto = countlyPushNotification.mapper.outgoing.mapTestUsersEditedModelToDto(testUsersModel);
                 var appConfig = {push: {test: {}}};

--- a/plugins/push/frontend/public/javascripts/countly.models.js
+++ b/plugins/push/frontend/public/javascripts/countly.models.js
@@ -669,13 +669,13 @@
                 return Promise.resolve(countlySegmentation.getFilters());
             });
         },
-        searchUsers: function(query) {
+        searchUsers: function(query, options) {
             var data = {
                 query: JSON.stringify(query)
             };
             return CV.$.ajax({
                 type: "POST",
-                url: countlyCommon.API_PARTS.data.r + "?app_id=" + countlyCommon.ACTIVE_APP_ID + "&method=user_details",
+                url: countlyCommon.API_PARTS.data.r + "?app_id=" + options.appId + "&method=user_details",
                 contentType: "application/json",
                 data: JSON.stringify(data)
             }, {disableAutoCatch: true});
@@ -2028,11 +2028,11 @@
                 return Promise.resolve([]);
             });
         },
-        fetchTestUsers: function(options) {
+        fetchTestUsers: function(testUsers, options) {
             var self = this;
             var usersQuery = null;
-            if (options.uids && options.uids.length) {
-                usersQuery = {uid: {$in: options.uids}};
+            if (testUsers.uids && testUsers.uids.length) {
+                usersQuery = {uid: {$in: testUsers.uids}};
             }
             return new Promise(function(resolve, reject) {
                 if (!self.isDrillPluginEnabled()) {
@@ -2043,7 +2043,7 @@
                     reject(new Error('Error finding test users. User profiles plugin must be enabled.'));
                     return;
                 }
-                Promise.all([usersQuery ? countlyPushNotification.api.searchUsers(usersQuery) : Promise.resolve([]), self.fetchCohorts(options.cohorts || [], false)])
+                Promise.all([usersQuery ? countlyPushNotification.api.searchUsers(usersQuery, options) : Promise.resolve([]), self.fetchCohorts(testUsers.cohorts || [], false)])
                     .then(function(responses) {
                         var usersList = responses[0];
                         var cohortsList = responses[1];
@@ -2059,7 +2059,7 @@
                     });
             });
         },
-        searchUsersById: function(idQuery) {
+        searchUsersById: function(idQuery, options) {
             var self = this;
             return new Promise(function(resolve, reject) {
                 if (!self.isDrillPluginEnabled()) {
@@ -2071,7 +2071,7 @@
                     return;
                 }
                 var drillQuery = {did: {rgxcn: [idQuery]}};
-                countlyPushNotification.api.searchUsers(drillQuery)
+                countlyPushNotification.api.searchUsers(drillQuery, options)
                     .then(function(response) {
                         if (response && response.aaData) {
                             resolve(response.aaData.map(function(user) {

--- a/plugins/push/frontend/public/javascripts/countly.views.js
+++ b/plugins/push/frontend/public/javascripts/countly.views.js
@@ -1612,6 +1612,10 @@
 
     var keyFileReader = new FileReader();
 
+    var initialTestUsersRows = {};
+    initialTestUsersRows[countlyPushNotification.service.AddTestUserDefinitionTypeEnum.USER_ID] = [];
+    initialTestUsersRows[countlyPushNotification.service.AddTestUserDefinitionTypeEnum.COHORT] = [];
+
     var PushNotificationAppConfigView = countlyVue.views.create({
         componentName: "AppSettingsContainerObservable",
         template: CV.T("/push/templates/push-notification-app-config.html"),
@@ -1636,8 +1640,13 @@
                 isAddTestUsersLoading: false,
                 isDialogVisible: false,
                 areRowsLoading: false,
-                testUsersRows: [],
+                testUsersRows: initialTestUsersRows,
                 selectedKeyToDelete: null,
+                selectedTestUsersListOption: countlyPushNotification.service.AddTestUserDefinitionTypeEnum.USER_ID,
+                testUsersListOptions: [
+                    {label: 'User ID', value: countlyPushNotification.service.AddTestUserDefinitionTypeEnum.USER_ID},
+                    {label: 'Cohort', value: countlyPushNotification.service.AddTestUserDefinitionTypeEnum.COHORT}
+                ]
             };
         },
         computed: {
@@ -1647,6 +1656,9 @@
             isIOSConfigRequired: function() {
                 return this.isIOSConfigTouched;
             },
+            selectedTestUsersRows: function() {
+                return this.testUsersRows[this.selectedTestUsersListOption];
+            }
         },
         methods: {
             setModel: function(newModel) {
@@ -1934,12 +1946,13 @@
                         self.updateTestUsersAppConfig(editedObject);
                         done();
                         CountlyHelpers.notify({message: 'Test users have been successfully added.'});
-                    }).catch(function() {
+                    }).catch(function(error) {
                         // TODO: log error
-                        CountlyHelpers.notify({message: 'Unknown error occurred. Please try again later.'});
+
+                        CountlyHelpers.notify({message: 'Unknown error occurred. Please try again later.', type: 'error'});
+                        done(error);
                     }).finally(function() {
                         self.isAddTestUsersLoading = false;
-                        done(false);
                     });
             },
             onSearchUsers: function(query) {

--- a/plugins/push/frontend/public/javascripts/countly.views.js
+++ b/plugins/push/frontend/public/javascripts/countly.views.js
@@ -1894,10 +1894,13 @@
                         self.isFetchCohortsLoading = false;
                     });
             },
-            fetchTestUsers: function(options) {
+            fetchTestUsers: function() {
                 var self = this;
+                var testUsers = this.getTestUsersFromAppConfig();
+                var options = {};
+                options.appId = this.selectedAppId;
                 this.areRowsLoading = true;
-                countlyPushNotification.service.fetchTestUsers(options)
+                countlyPushNotification.service.fetchTestUsers(testUsers, options)
                     .then(function(testUserRows) {
                         self.setTestUserRows(testUserRows);
                     }).catch(function(error) {
@@ -1927,7 +1930,7 @@
             },
             onShowTestUserList: function() {
                 this.openTestUsersDialog();
-                this.fetchTestUsers(this.getTestUsersFromAppConfig());
+                this.fetchTestUsers();
             },
             onOpen: function() {
                 this.fetchCohortsIfNotFound();
@@ -1958,7 +1961,9 @@
             onSearchUsers: function(query) {
                 var self = this;
                 this.isSearchUsersLoading = true;
-                countlyPushNotification.service.searchUsersById(query)
+                var options = {};
+                options.appId = this.selectedAppId;
+                countlyPushNotification.service.searchUsersById(query, options)
                     .then(function(userIds) {
                         self.setUserIdOptions(userIds);
                     }).catch(function(error) {

--- a/plugins/push/frontend/public/templates/push-notification-app-config.html
+++ b/plugins/push/frontend/public/templates/push-notification-app-config.html
@@ -158,9 +158,12 @@
             width="720px"
             autoCentered
             :visible.sync="isDialogVisible">
-            <cly-datatable-n :rows="testUsersRows" v-loading="areRowsLoading" :force-loading="areRowsLoading" :hideTop="true">
+            <el-select v-model="selectedTestUsersListOption">
+                <el-option v-for="item in testUsersListOptions" :key="item.label" :value="item.value" :label="item.label"></el-option>
+            </el-select>
+            <cly-datatable-n :rows="selectedTestUsersRows" v-loading="areRowsLoading" :force-loading="areRowsLoading" :hideTop="true">
                 <template v-slot="scope">
-                    <el-table-column label="Username" >
+                    <el-table-column label="Username" v-if="selectedTestUsersListOption === AddTestUserDefinitionTypeEnum.USER_ID">
                         <template slot-scope="rowScope">
                             <div class="bu-is-flex bu-is-align-items-center">
                                 <img :src="rowScope.row.picture" width="16px" height="16px" class="bu-mr-2" style="border-radius: 50%;" />
@@ -168,7 +171,12 @@
                             </div>
                         </template>
                     </el-table-column>
-                    <el-table-column label="User ID" prop="_id"></el-table-column>
+                    <el-table-column label="User ID" prop="_id"  v-if="selectedTestUsersListOption === AddTestUserDefinitionTypeEnum.USER_ID" ></el-table-column>
+                    <el-table-column label="Cohort Name" prop="cohort" v-if="selectedTestUsersListOption === AddTestUserDefinitionTypeEnum.COHORT">
+                        <template v-slot="rowScope">
+                            <span class="has-ellipsis">{{rowScope.row.name}}</span>
+                        </template>
+                    </el-table-column>
                 </template>
             </cly-datatable-n>
         </cly-dialog>

--- a/plugins/push/frontend/public/templates/push-notification-app-config.html
+++ b/plugins/push/frontend/public/templates/push-notification-app-config.html
@@ -154,14 +154,19 @@
             </template>
         </cly-drawer>
         <cly-dialog
-            title="User List"
             width="720px"
             autoCentered
             :visible.sync="isDialogVisible">
-            <el-select v-model="selectedTestUsersListOption">
+            <template slot="title">
+                <div class="bu-is-flex bu-is-align-items-center bu-ml-2">
+                    <h3>User List</h3>
+                    <cly-tooltip-icon :tooltip="i18n('test-users.description')" icon="ion ion-help-circled" style="margin-left:8px"> </cly-tooltip-icon>
+                </div>
+            </template>
+            <el-select v-model="selectedTestUsersListOption" class="bu-my-3 bu-ml-4">
                 <el-option v-for="item in testUsersListOptions" :key="item.label" :value="item.value" :label="item.label"></el-option>
             </el-select>
-            <cly-datatable-n :rows="selectedTestUsersRows" v-loading="areRowsLoading" :force-loading="areRowsLoading" :hideTop="true">
+            <cly-datatable-n :rows="selectedTestUsersRows" v-loading="areRowsLoading || isUpdateTestUsersLoading" :force-loading="areRowsLoading || isUpdateTestUsersLoading" :hideTop="true">
                 <template v-slot="scope">
                     <el-table-column label="Username" v-if="selectedTestUsersListOption === AddTestUserDefinitionTypeEnum.USER_ID">
                         <template slot-scope="rowScope">
@@ -175,6 +180,13 @@
                     <el-table-column label="Cohort Name" prop="cohort" v-if="selectedTestUsersListOption === AddTestUserDefinitionTypeEnum.COHORT">
                         <template v-slot="rowScope">
                             <span class="has-ellipsis">{{rowScope.row.name}}</span>
+                        </template>
+                    </el-table-column>
+                    <el-table-column type="options">
+                        <template slot-scope="scope">
+                            <cly-more-options v-if="scope.row.hover" size="small" @command="onDeleteTestUser(scope.row)">
+                                <el-dropdown-item>{{i18n('push-notification.delete')}}</el-dropdown-item>
+                            </cly-more-options>
                         </template>
                     </el-table-column>
                 </template>


### PR DESCRIPTION
Remove test users by updating the push notification application level config settings.
At all times the app level config test object must be saved in the server, regardless of whether or not a test user is removed/added by user id or cohort id.