### PR TITLE
Fixes. Dashboards. Systemlogs.

### DIFF
--- a/frontend/express/public/core/user-analytics-overview/javascripts/countly.views.js
+++ b/frontend/express/public/core/user-analytics-overview/javascripts/countly.views.js
@@ -370,7 +370,7 @@ countlyVue.container.registerData("/custom/dashboards/widget", {
     primary: false,
     getter: function(widget) {
         var kk = widget.breakdowns || [];
-        if (widget.widget_type === "analytics" && widget.data_type === "user-analytics" && (kk.length === 0 || kk[0] === 'overview')) {
+        if (widget.widget_type === "analytics" && widget.data_type === "user-analytics" && (kk.length === 0 || kk[0] === 'overview' || (kk[0] !== "active" && kk[0] !== "online"))) {
             return true;
         }
         else {

--- a/plugins/systemlogs/api/api.js
+++ b/plugins/systemlogs/api/api.js
@@ -340,6 +340,7 @@ plugins.setConfigs("systemlogs", {
         log.i = data;
         log.ts = Math.round(new Date().getTime() / 1000);
         log.cd = new Date();
+        user = user || {};
         log.u = user.email || user.username || "";
 
         var PreventIPTracking = plugins.getConfig("systemlogs").preventIPTracking;


### PR DESCRIPTION
Bugfix. Dashboards widgets. Prevent not showing template for analytics users in case of invalid breakdown value.

null check for systemlogs error:

TypeError: Cannot read property 'email' of undefined
    at recordAction (/home/countly/countly/plugins/systemlogs/api/api.js:343:22)