### PR TITLE
Fix/times of day dashboard properties,and height error

### DIFF
--- a/plugins/times-of-day/frontend/public/javascripts/countly.models.js
+++ b/plugins/times-of-day/frontend/public/javascripts/countly.models.js
@@ -5,10 +5,10 @@
         HOURS: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
         WEEK_DAYS: ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"],
         DateBucketEnum: {
-            PREV_MONTH: "prevMonth",
-            THIS_MONTH: "thisMonth",
-            LAST_THREE_MONTHS: "lastThreeMonths",
-            ALL_TIME: 'allTime',
+            PREV_MONTH: "previous",
+            THIS_MONTH: "current",
+            LAST_THREE_MONTHS: "last_3",
+            ALL_TIME: 'all',
         },
         findEventKeyByName: function(name) {
             return countlyEvent.getEvents().find(function(item) {

--- a/plugins/times-of-day/frontend/public/javascripts/countly.views.js
+++ b/plugins/times-of-day/frontend/public/javascripts/countly.views.js
@@ -165,6 +165,9 @@ if (countlyAuth.validateRead(featureName)) {
                     var eventItem = countlyTimesOfDay.service.findEventKeyByName(doc.events);
                     doc.events = [eventItem.key + '***' + eventItem.name];
                 }
+                if (doc.data_type === 'session') {
+                    doc.events = undefined;
+                }
             }
         },
         grid: {

--- a/plugins/times-of-day/frontend/public/templates/times-of-day-widget.html
+++ b/plugins/times-of-day/frontend/public/templates/times-of-day-widget.html
@@ -13,6 +13,6 @@
     <clyd-primary-legend :apps="data.apps" :show-period="false"></clyd-primary-legend>
 
     <div class="clyd-widget__content">
-        <times-of-day-scatter-chart :series="series" :maxSeriesValue="maxSeriesValue" :show-zoom="false" :show-toggle="false" :showDownload="false" height="auto" skin="full"></times-of-day-scatter-chart>
+        <times-of-day-scatter-chart :series="series" :maxSeriesValue="maxSeriesValue" :show-zoom="false" :show-toggle="false" :showDownload="false" skin="full"></times-of-day-scatter-chart>
     </div>
 </div>

--- a/plugins/times-of-day/frontend/public/templates/times-of-day-widget.html
+++ b/plugins/times-of-day/frontend/public/templates/times-of-day-widget.html
@@ -13,6 +13,6 @@
     <clyd-primary-legend :apps="data.apps" :show-period="false"></clyd-primary-legend>
 
     <div class="clyd-widget__content">
-        <times-of-day-scatter-chart :series="series" :maxSeriesValue="maxSeriesValue" :show-zoom="false" :show-toggle="false" :showDownload="false" skin="full"></times-of-day-scatter-chart>
+        <times-of-day-scatter-chart :series="series" :maxSeriesValue="maxSeriesValue" :show-zoom="false" :show-toggle="false" height="auto" :showDownload="false" skin="full"></times-of-day-scatter-chart>
     </div>
 </div>


### PR DESCRIPTION
Use backward compatible period values for times of day widget.
Remove height property from times of day widget scatter chart.