### PR TITLE
fix: Error code internationlization

### DIFF
--- a/plugins/push/frontend/public/javascripts/countly.models.js
+++ b/plugins/push/frontend/public/javascripts/countly.models.js
@@ -544,8 +544,8 @@
             }
             return result;
         },
-        isInternationalizationFound: function(value) {
-            return value !== CV.i18n(value);
+        isInternationalizationFound: function(key) {
+            return key !== CV.i18n(key);
         }
     };
 
@@ -1021,55 +1021,43 @@
                 }
                 return TargetingEnum.ALL;
             },
-            mapErrorWithoutCode: function(errorsDto, errorKey) {
-                return {
-                    code: CV.i18n('push-notification.error-code.' + errorKey),
-                    codePostfix: '',
-                    affectedUsers: errorsDto[errorKey],
-                    description: CV.i18n('push-notification.error-code.' + errorKey + '.desc', errorsDto[errorKey]),
-                };
-            },
-            mapErrorWithCode: function(errorsDto, errorKey) {
-                var errorCodeParts = errorKey.match(ERROR_MESSAGE_REGEX);
-                var platformError = errorCodeParts[1];
-                var numberError = errorCodeParts[2];
-                var postfixError = errorCodeParts[4];
-                var result = {
-                    code: CV.i18n('push-notification.error-code.' + platformError + numberError),
-                    codePostfix: postfixError,
-                    affectedUsers: errorsDto[errorKey],
-                    description: CV.i18n('push-notification.error-code.' + errorKey + '.desc')
-                };
-                if (!countlyPushNotification.helper.isInternationalizationFound(result.description) && countlyPushNotification.helper.isInternationalizationFound('push-notification.error-code.' + platformError + numberError + '.desc')) {
-                    result.description = CV.i18n('push-notification.error-code.' + platformError + numberError + '.desc');
-                }
-                return result;
-            },
             getExpiredTokenErrorIfFound: function(dto) {
                 if (dto.result && (dto.result.processed > (dto.result.sent + dto.result.errored))) {
                     var affectedUsers = dto.result.processed - (dto.result.sent + dto.result.errored);
-                    return {'expired': affectedUsers};
+                    return {'ExpiredToken': affectedUsers};
                 }
                 return null;
             },
             mapErrors: function(dto) {
-                var self = this;
                 var expiredTokenError = this.getExpiredTokenErrorIfFound(dto);
                 if (expiredTokenError) {
-                    if (!dto.errors) {
-                        dto.errors = {};
+                    if (dto.result && !dto.result.errors) {
+                        dto.result.errors = {};
                     }
-                    Object.assign(dto.errors, expiredTokenError);
+                    Object.assign(dto.result.errors, expiredTokenError);
                 }
-                if (!dto.errors) {
+                if (!(dto.result && dto.result.errors)) {
                     return [];
                 }
-                return Object.keys(dto.errors).map(function(errorKey) {
-                    var errorCodeParts = errorKey.match(ERROR_MESSAGE_REGEX);
-                    if (errorCodeParts && errorCodeParts.length) {
-                        return self.mapErrorWithCode(dto.errors, errorKey);
+                return Object.keys(dto.result.errors).map(function(errorKey) {
+                    var errorCodeParts = errorKey.match(ERROR_MESSAGE_REGEX) || [];
+                    var platformError = errorCodeParts[1];
+                    var numberError = errorCodeParts[2];
+                    var result = {
+                        code: errorKey,
+                        affectedUsers: dto.result.errors[errorKey] || '',
+                        description: CV.i18n('push-notification.error-code.' + errorKey + '.desc')
+                    };
+                    if (countlyPushNotification.helper.isInternationalizationFound('push-notification.error-code.' + errorKey + '.desc')) {
+                        result.description = CV.i18n('push-notification.error-code.' + errorKey + '.desc');
+                        return result;
                     }
-                    return self.mapErrorWithoutCode(dto.errors, errorKey);
+                    if (countlyPushNotification.helper.isInternationalizationFound('push-notification.error-code.' + platformError + numberError + '.desc')) {
+                        result.description = CV.i18n('push-notification.error-code.' + platformError + numberError + '.desc');
+                        return result;
+                    }
+                    result.description = "";
+                    return result;
                 });
             },
             mapAndroidSettings: function(androidSettingsDto) {

--- a/plugins/push/frontend/public/localization/push.properties
+++ b/plugins/push/frontend/public/localization/push.properties
@@ -421,5 +421,5 @@ push-notification.error-code.consent = Consent cancelled
 push-notification.error-code.consent.desc = Push Notification messages have been removed from the queue because of removed push consent.
 push-notification.error-code.aborted = Aborted
 push-notification.error-code.aborted.desc = Push Notification messages have been removed from the queue after an nonrecoverable error. Please check our <a target="blank" class="el-link" href="https://support.count.ly/hc/en-us/articles/360037270012-Push-notifications#troubleshooting">Troubleshooting</a> documentation. <br />Please read the following <a target="blank" class="el-link" href="https://support.count.ly/hc/en-us/articles/360037270012#resend-failed-notifications"> instructions </a> if you want to re-send the push notification to users who have not received it.
-push-notification.error-code.expired = Expired Token
-push-notification.error-code.expired.desc = Token expired for {0} users.
+push-notification.error-code.ExpiredToken = Expired Token
+push-notification.error-code.ExpiredToken.desc = The token expired for affected number of users.

--- a/plugins/push/frontend/public/templates/common-components.html
+++ b/plugins/push/frontend/public/templates/common-components.html
@@ -428,7 +428,7 @@
                         :label="i18n('push-notification.error-code')"
                         min-width="30">
                         <template v-slot="scope">
-                         <span style="white-space:normal">{{scope.row.code}} {{scope.row.codePostfix? '('+scope.row.codePostfix+')' : ''}}</span>
+                         <span style="white-space:normal">{{scope.row.code}}</span>
                         </template>
                     </el-table-column>
                     <el-table-column


### PR DESCRIPTION
Remove internationalization for error codes. Instead, use it only
for error descriptions when they are found otherwise display empty string