### PR TITLE
fix: finding user properties id error on firefox

### DIFF
--- a/plugins/push/frontend/public/javascripts/countly.models.js
+++ b/plugins/push/frontend/public/javascripts/countly.models.js
@@ -1516,9 +1516,13 @@
                 var htmlElement = document.createElement('div');
                 htmlElement.innerHTML = localizedMessage[container];
                 for (var index = 0; index < htmlElement.children.length; index++) {
-                    var idAtribute = htmlElement.children[index].getAttributeNode('id').value;
-                    var idNumber = idAtribute.split('-')[1];
-                    userPropertyIds.push(idNumber);
+                    var idAttribute = htmlElement.children[index].getAttributeNode('id');
+                    if (idAttribute && idAttribute.value) {
+                        var idAtributeValue = idAttribute.value;
+                        var idNumber = idAtributeValue.split('-')[1];
+                        userPropertyIds.push(idNumber);
+                    }
+
                 }
                 return userPropertyIds;
             },


### PR DESCRIPTION
Firefox inserts a break element in between and is unable to find the id attribute of it.
Check if a child element has id atribute before adding it to the result.