### PR TITLE
fix: User property label error on  essage editor

### DIFF
--- a/plugins/push/frontend/public/javascripts/countly.models.js
+++ b/plugins/push/frontend/public/javascripts/countly.models.js
@@ -815,7 +815,7 @@
                 newElement.setAttribute("data-user-property-label", userProperty.l);
                 newElement.setAttribute("data-user-property-value", userProperty.k);
                 newElement.setAttribute("data-user-property-fallback", userProperty.f);
-                newElement.innerText = userProperty.k + "|" + userProperty.f;
+                newElement.innerText = userProperty.l + "|" + userProperty.f;
                 return newElement.outerHTML;
             },
             decodeMessage: function(message) {


### PR DESCRIPTION
Use label value instead of actual user property value.