### PR TITLE
fix: Date picker future date selection error

### DIFF
--- a/frontend/express/public/javascripts/countly/vue/components/date.js
+++ b/frontend/express/public/javascripts/countly/vue/components/date.js
@@ -122,7 +122,7 @@
         globalFutureDaysRange = [],
         globalFutureMonthsRange = [],
         globalMin = moment([2010, 0, 1]),
-        globalMax = moment(),
+        globalMax = moment().startOf('day'),
         globalFutureMax = moment().add(10, "y"),
         daysCursor = moment(globalMin.toDate()),
         monthsCursor = moment(globalMin.toDate());


### PR DESCRIPTION
Set the future date to start from the day, not arbitrary day time.