### PR TITLE
Table column design fix.

### DIFF
--- a/plugins/compliance-hub/frontend/public/templates/user.html
+++ b/plugins/compliance-hub/frontend/public/templates/user.html
@@ -32,7 +32,7 @@
 
                 </el-table-column>
 
-                <el-table-column width="250" sortable="custom" prop="lac" label="TIME">
+                <el-table-column sortable="custom" prop="lac" label="TIME">
                     <template v-slot="rowScope">
                         {{rowScope.row.time}}
 


### PR DESCRIPTION
White space appears between the columns in the user table for 1920x1080 resolution, so removed static width here. Table will arrange this column automatically.