### PR TITLE
[SER-84] Add row click handler for audit logs table

### DIFF
--- a/plugins/systemlogs/frontend/public/javascripts/countly.views.js
+++ b/plugins/systemlogs/frontend/public/javascripts/countly.views.js
@@ -210,6 +210,15 @@
                     return x < y ? -1 : x > y ? 1 : 0;
                 });
                 return arr;
+            },
+            handleRowClick: function(row) {
+                // Only expand row if text inside of it are not highlighted
+                if (window.getSelection().length === 0) {
+                    this.$refs.table.$refs.elTable.toggleRowExpansion(row);
+                }
+            },
+            tableRowClassName: function() {
+                return 'bu-is-clickable';
             }
         }
     });

--- a/plugins/systemlogs/frontend/public/templates/logs.html
+++ b/plugins/systemlogs/frontend/public/templates/logs.html
@@ -10,7 +10,7 @@
     <cly-main>
 		<cly-date-picker-g class="bu-mb-4"></cly-date-picker-g>
 		<cly-section class="bu-mt-4">
-			<cly-datatable-n :data-source="remoteTableDataSource" :export-api="getExportAPI" :default-sort="{prop: 'ts', order: 'descending'}">
+			<cly-datatable-n :data-source="remoteTableDataSource" :export-api="getExportAPI" :default-sort="{prop: 'ts', order: 'descending'}" @row-click="handleRowClick" ref="table" :row-class-name="tableRowClassName">
                 <template v-slot="scope">
                     <el-table-column type="expand">
                         <template slot-scope="rowScope">
@@ -43,14 +43,14 @@
                 <template v-slot:header-left>
                     <cly-select-x
                         :search-placeholder="i18n('common.search')"
-                        placeholder="" 
+                        placeholder=""
                         v-model="selectAction"
                         v-on:change="changeAction"
                         :options="allActions">
                     </cly-select-x>
                     <cly-select-x
                         :search-placeholder="i18n('common.search')"
-                        placeholder="" 
+                        placeholder=""
                         v-model="selectUser"
                         v-on:change="changeUser"
                         :options="allUsers" class="bu-ml-4">


### PR DESCRIPTION
Currently, audit logs table row can only be expanded by clicking the tiny little triangle icon on the left side.

This PR enables expansion by clicking almost anywhere on the table row.