### PR TITLE
Enable table row expansion by clicking anywhere on the row

### DIFF
--- a/frontend/express/public/javascripts/countly/vue/components/datatable.js
+++ b/frontend/express/public/javascripts/countly/vue/components/datatable.js
@@ -330,6 +330,12 @@
                 if (this.persistKey) {
                     localStorage.setItem(this.persistKey, JSON.stringify(this.controlParams));
                 }
+            },
+            onRowClick: function(row) {
+                // Only expand row if text inside of it are not selected
+                if (window.getSelection().toString().length === 0) {
+                    this.$refs.elTable.toggleRowExpansion(row);
+                }
             }
         }
     };

--- a/frontend/express/public/javascripts/countly/vue/templates/datatable.html
+++ b/frontend/express/public/javascripts/countly/vue/templates/datatable.html
@@ -67,8 +67,8 @@
                                     </div>
                                 </div>
                                 <div class="bu-mx-2">
-                                    <cly-checklistbox 
-                                    v-model="exportColumns" 
+                                    <cly-checklistbox
+                                    v-model="exportColumns"
                                     :sortable="false"
                                     :bordered="false"
                                     :options.sync="getMatching(availableDynamicCols)">
@@ -100,6 +100,7 @@
             @sort-change="onSortChange"
             @selection-change="onSelectionChange"
             @cell-mouse-enter="onCellMouseEnter"
+            @row-click="onRowClick"
             ref="elTable">
                 <template slot="empty" v-if="!isLoading">
                     <cly-empty-datatable></cly-empty-datatable>


### PR DESCRIPTION
Currently, datatable table row can only be expanded by clicking the tiny little triangle icon on the left side.

This PR enables row expansion by clicking almost anywhere on the table row.