### PR TITLE
[SER-79] Update request logs table row

### DIFF
--- a/plugins/logger/frontend/public/javascripts/countly.views.js
+++ b/plugins/logger/frontend/public/javascripts/countly.views.js
@@ -174,6 +174,15 @@
             },
             filterChange: function() {
                 this.fetchRequestLogs();
+            },
+            handleTableRowClick: function(row) {
+                // Only expand row if text inside of it are not highlighted
+                if (window.getSelection().toString().length === 0) {
+                    this.$refs.requestLogTable.$refs.elTable.toggleRowExpansion(row);
+                }
+            },
+            tableRowClassName: function() {
+                return 'bu-is-clickable';
             }
         },
         filters: {

--- a/plugins/logger/frontend/public/templates/logger.html
+++ b/plugins/logger/frontend/public/templates/logger.html
@@ -33,7 +33,7 @@
         </div>
         <cly-section>
             <cly-datatable-n ref="requestLogTable" :persist-key="tablePersistKey" :rows="logsData"
-                :resizable="false" :force-loading="isLoading" :export-query="getExportQuery" class="is-clickable">
+                :resizable="false" :force-loading="isLoading" :export-query="getExportQuery" class="is-clickable" @row-click="handleTableRowClick" :row-class-name="tableRowClassName">
                 <template v-slot:header-left="filterScope">
                     <el-select v-model="loggerFilter" placeholder="Select" @change="filterChange()">
                         <el-option v-for="filter in filterOptions" :key="filter.value" :label="filter.label"


### PR DESCRIPTION
Currently, request logs table row can only be expanded by clicking the tiny little triangle icon on the left side.

This PR enables row expansion by clicking almost anywhere on the table row.