### PR TITLE
[SER-82] Update remote config parameters table row

### DIFF
--- a/plugins/remote-config/frontend/public/javascripts/countly.views.js
+++ b/plugins/remote-config/frontend/public/javascripts/countly.views.js
@@ -755,6 +755,15 @@
             },
             onSubmit: function() {
                 this.$store.dispatch("countlyRemoteConfig/initialize");
+            },
+            handleTableRowClick: function(row) {
+                // Only expand row if text inside of it are not highlighted
+                if (window.getSelection().toString().length === 0) {
+                    this.$refs.table.$refs.elTable.toggleRowExpansion(row);
+                }
+            },
+            tableRowClassName: function() {
+                return "bu-is-clickable";
             }
         }
     });

--- a/plugins/remote-config/frontend/public/templates/parameters.html
+++ b/plugins/remote-config/frontend/public/templates/parameters.html
@@ -1,7 +1,7 @@
 <div>
   <cly-header>
     <template v-slot:header-left>
-      <h2 class="cly-vue-remote-config__header"> {{i18n('remote-config.title')}} 
+      <h2 class="cly-vue-remote-config__header"> {{i18n('remote-config.title')}}
       </h2>
     </template>
     <template v-slot:header-right>
@@ -15,7 +15,7 @@
       <cly-notification class="bu-mb-5" :text="i18n('remote-config.maximum_parameters_added')" color="light-warning">
       </cly-notification>
     </div>
-    <cly-datatable-n :rows="tableRows" :force-loading="isTableLoading" class="cly-vue-remote-config-home-table">
+    <cly-datatable-n :rows="tableRows" :force-loading="isTableLoading" class="cly-vue-remote-config-home-table" ref="table" @row-click="handleTableRowClick" :row-class-name="tableRowClassName">
       <template v-slot:default="scope">
         <el-table-column type="expand" min-width="50">
           <template v-slot="props">


### PR DESCRIPTION
Currently, remote config parameters table row can only be expanded by clicking the tiny little triangle icon on the left side.

This PR enables row expansion by clicking almost anywhere on the table row.