### PR TITLE
[SER-83] Update consent history table row

### DIFF
--- a/plugins/compliance-hub/frontend/public/javascripts/countly.views.js
+++ b/plugins/compliance-hub/frontend/public/javascripts/countly.views.js
@@ -193,6 +193,12 @@
 
                 });
             },
+            tableRowClickHandler: function(row) {
+                // Only expand row if text inside of it are not highlighted
+                if (window.getSelection().toString().length === 0) {
+                    this.$refs.table.$refs.elTable.toggleRowExpansion(row);
+                }
+            }
         }
 
     });

--- a/plugins/compliance-hub/frontend/public/templates/consentHistory.html
+++ b/plugins/compliance-hub/frontend/public/templates/consentHistory.html
@@ -18,7 +18,7 @@
         </div>
     </div>
     <cly-section class="cly-vue-compliance__consent_history cly-vue-complaince__hub_style_widthzero">
-        <cly-datatable-n :data-source="consentHistoryTableSource" :default-sort="{prop: 'ts', order: 'descending'}">
+        <cly-datatable-n :data-source="consentHistoryTableSource" :default-sort="{prop: 'ts', order: 'descending'}" ref="table" @row-click="tableRowClickHandler" row-class-name="bu-is-clickable">
             <template v-slot="scope">
                 <el-table-column fixed type="expand">
                     <template slot-scope="props">


### PR DESCRIPTION
Currently, consent history table row can only be expanded by clicking the tiny little triangle icon on the left side.

This PR enables row expansion by clicking almost anywhere on the table row.