### PR TITLE
[SER-149] DB Viewer cannot export data when data is filter is applied

### DIFF
--- a/api/parts/data/exports.js
+++ b/api/parts/data/exports.js
@@ -11,6 +11,8 @@ var exports = {},
     json2csv = require('json2csv'),
     json2xls = require('json2xls');
 
+//const log = require('./../../utils/log.js')('core:export');
+
 //npm install node-xlsx-stream !!!!!
 var xlsx = require("node-xlsx-stream");
 const Transform = require('stream').Transform;
@@ -316,7 +318,7 @@ function getValues(values, valuesMap, paramList, doc, options) {
 /**
 * Stream data as response
 * @param {params} params - params object
-* @param {Stream} stream - cursor stream
+* @param {Stream} stream - cursor object. Need to call stream on it. 
 * @param {string} options - options object 
 		options.filename - name of the file to output to browser
 		options.type - type to be used in content type
@@ -354,7 +356,7 @@ exports.stream = function(params, stream, options) {
             params.res.write(head.join(',') + '\r\n');
         }
 
-        stream.on('data', function(doc) {
+        stream.stream(options.streamOptions).on('data', function(doc) {
             var values = [];
             var valuesMap = {};
             getValues(values, valuesMap, paramList, doc, {mapper: mapper, collectProp: listAtEnd}); // if we have list at end - then we don'thave projection
@@ -382,7 +384,7 @@ exports.stream = function(params, stream, options) {
         if (listAtEnd === false) {
             sheet.write(paramList);
         }
-        stream.on('data', function(doc) {
+        stream.stream(options.streamOptions).on('data', function(doc) {
             var values = [];
             var valuesMap = {};
             getValues(values, valuesMap, paramList, doc, {mapper: mapper, collectProp: listAtEnd});
@@ -400,7 +402,7 @@ exports.stream = function(params, stream, options) {
     else {
         params.res.write("[");
         var first = false;
-        stream.on('data', function(doc) {
+        stream.stream(options.streamOptions).on('data', function(doc) {
             if (!first) {
                 first = true;
                 params.res.write(doc);
@@ -478,30 +480,24 @@ exports.fromDatabase = function(options) {
         if (options.sort) {
             cursor.sort(options.sort);
         }
-        if (options.limit) {
-            cursor.limit(parseInt(options.limit));
-        }
+
         if (options.skip) {
             cursor.skip(parseInt(options.skip));
         }
-
-        if (options.type === "stream" || options.type === "json") {
-            options.output = options.output || function(stream) {
-                exports.stream(options.params, stream, options);
-            };
-            cursor.stream({
-                transform: function(doc) {
-                    doc = transformValuesInObject(doc, options.mapper);
-                    return JSON.stringify(doc);
-                }
-            });
-            options.output(cursor);
+        if (options.limit) {
+            cursor.limit(parseInt(options.limit));
         }
-        else if (options.type === "xls" || options.type === "xlsx" || options.type === "csv") {
+        options.streamOptions = {};
+        if (options.type === "stream" || options.type === "json") {
+            options.streamOptions.transform = function(doc) {
+                doc = transformValuesInObject(doc, options.mapper);
+                return JSON.stringify(doc);
+            };
+        }
+        if (options.type === "stream" || options.type === "json" || options.type === "xls" || options.type === "xlsx" || options.type === "csv") {
             options.output = options.output || function(stream) {
                 exports.stream(options.params, stream, options);
             };
-            cursor.stream();
             options.output(cursor);
         }
         else {
@@ -593,19 +589,15 @@ exports.fromRequestQuery = function(options) {
                         done(null, data);
                     }
                 });
+                options.streamOptions = {};
                 if (options.type === "stream" || options.type === "json") {
-                    cursor.stream({
-                        transform: function(doc) {
-                            doc = transformValuesInObject(doc, options.mapper);
-                            return JSON.stringify(doc);
-                        }
-                    });
-                    exports.stream({res: outputStream}, cursor, options);
+                    options.streamOptions.transform = function(doc) {
+                        doc = transformValuesInObject(doc, options.mapper);
+                        return JSON.stringify(doc);
+                    };
                 }
-                else if (options.type === "xls" || options.type === "xlsx" || options.type === "csv") {
-                    cursor.stream();
-                    exports.stream({res: outputStream}, cursor, options);
-                }
+                exports.stream({res: outputStream}, cursor, options);
+
                 options.output(outputStream);
             }
         }

--- a/plugins/dbviewer/frontend/public/javascripts/countly.views.js
+++ b/plugins/dbviewer/frontend/public/javascripts/countly.views.js
@@ -242,8 +242,10 @@
             },
             preparedProjectionFields: function() {
                 var ob = {};
-                for (var i = 0; i < this.projection.length; i++) {
-                    ob[this.projection[i]] = 1;
+                if (this.projection && Array.isArray(this.projection)) {
+                    for (var i = 0; i < this.projection.length; i++) {
+                        ob[this.projection[i]] = 1;
+                    }
                 }
                 return ob;
             },


### PR DESCRIPTION
Since mongodb driver update needed to  restructure code when working with cursor.stream();
[SER-149] DB Viewer cannot export data when data is filter is applied. Fixed UI bug for that.

[SER-149]: https://countly.atlassian.net/browse/SER-149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ