### PR TITLE
fix for autopositioning of widgets when upgrading

### DIFF
--- a/plugins/dashboards/frontend/public/javascripts/countly.views.js
+++ b/plugins/dashboards/frontend/public/javascripts/countly.views.js
@@ -1307,6 +1307,15 @@
                 if (this.grid) {
                     this.grid.destroy();
                 }
+            },
+            autoPosition: function(allWidgets) {
+                var autoposition = false;
+                allWidgets.forEach(function(widget) {
+                    if (!widget.position) {
+                        autoposition = true;
+                    }
+                });
+                return autoposition;
             }
         },
         mounted: function() {

--- a/plugins/dashboards/frontend/public/templates/grid.html
+++ b/plugins/dashboards/frontend/public/templates/grid.html
@@ -6,6 +6,7 @@
             :key="widget._id"
             :widget="widget"
             :settings="widgetSettingsGetter(widget, true)"
+            :autoPosition="autoPosition(allWidgets)"
             :loading="loading"
             @ready="onReady"
             @command="onWidgetAction">


### PR DESCRIPTION
Fix where widgets would overlap for a short while after upgrading. 
This forces autoposition when position is not found for a widget.