### PR TITLE
[SER-156] The bars are ultra large in width at Analytics --> Technolgy -->Platforms

### DIFF
--- a/frontend/express/public/javascripts/countly/countly.device.osmapping.js
+++ b/frontend/express/public/javascripts/countly/countly.device.osmapping.js
@@ -43,7 +43,8 @@ var countlyOsMapping = {
     "debian": {short: "d", name: "Debian"},
     "nokia": {short: "n", name: "Nokia"},
     "firefox": {short: "f", name: "Firefox OS"},
-    "tizen": {short: "t", name: "Tizen"}
+    "tizen": {short: "t", name: "Tizen"},
+    "arch": {short: "l", name: "Arch"}
 };
 
 /*global module*/


### PR DESCRIPTION
Reason for this - new platform "Arch"(type of linux) not included in osmapping