### PR TITLE
[core] Fix select x header condition and datatable column filter

### DIFF
--- a/frontend/express/public/javascripts/countly/vue/components/input.js
+++ b/frontend/express/public/javascripts/countly/vue/components/input.js
@@ -772,7 +772,7 @@
                     "cly-vue-select-x__pop--hidden-tabs": this.hideDefaultTabs || !this.showTabs,
                     "cly-vue-select-x__pop--has-single-option": this.hasSingleOption,
                     "cly-vue-select-x__pop--has-slim-header": !this.searchable && !this.showTabs,
-                    "cly-vue-select-x__pop--hidden-header": !this.isSearchShown && !this.$scopedSlots.header && !this.$scopedSlots.action
+                    "cly-vue-select-x__pop--hidden-header": !this.isSearchShown && !this.$scopedSlots.header && !this.$scopedSlots.action && !this.title && !this.showSelectedCount
                 };
             },
             currentTab: function() {

--- a/frontend/express/public/javascripts/countly/vue/templates/datatable.html
+++ b/frontend/express/public/javascripts/countly/vue/templates/datatable.html
@@ -19,6 +19,7 @@
                         :auto-commit="false"
                         :hide-default-tabs="true"
                         :hide-all-options-tab="true"
+                        :show-search="true"
                         :options="availableDynamicCols"
                         v-model="controlParams.selectedDynamicCols">
                         <template v-slot:trigger>


### PR DESCRIPTION
datatable column filter
![screenshot-danu count ly-2022 07 22-09_30_40](https://user-images.githubusercontent.com/1037943/180351922-2f3d7c80-8dd3-4bd9-8930-68bc60905c9f.png)

The screenshots below are for checking this part https://github.com/Countly/countly-server/blob/master/frontend/express/public/javascripts/countly/vue/templates/selectx.html#L46-L69. To make sure that the header is displayed correctly if at least one item on the header exists.

select-x with title prop
![screenshot-danu count ly-2022 07 22-09_37_01](https://user-images.githubusercontent.com/1037943/180352003-451012e2-e348-4282-a609-992dfcaed2b9.png)

select-x with header slot
![screenshot-danu count ly-2022 07 22-09_40_12](https://user-images.githubusercontent.com/1037943/180352499-9890f553-7701-41c7-8ceb-0c03350300dc.png)

select-x with action slot
![screenshot-danu count ly-2022 07 22-09_41_52](https://user-images.githubusercontent.com/1037943/180352120-ccbd7087-ce88-4865-9adf-990217644bb1.png)

select-x with show-selected-count prop
![screenshot-danu count ly-2022 07 22-09_43_56](https://user-images.githubusercontent.com/1037943/180352122-71c8adec-9ddf-4c66-9ae8-f787c20e7c2c.png)

select-x with show-search prop
![screenshot-danu count ly-2022 07 22-09_45_35](https://user-images.githubusercontent.com/1037943/180352125-e66d4907-b559-4024-938c-72f14a31bc9e.png)



