### PR TITLE
[SER-199] Crash group detail page update

### DIFF
--- a/plugins/crashes/frontend/public/javascripts/countly.models.js
+++ b/plugins/crashes/frontend/public/javascripts/countly.models.js
@@ -457,6 +457,20 @@
             }
         };
 
+        _crashgroupSubmodule.getters.crashgroupUnsymbolicatedStacktrace = function(state) {
+            var crashId = state.crashgroup.lrid;
+
+            var crash = state.crashgroup.data.find(function(item) {
+                return item._id === crashId;
+            });
+
+            if (crash && crash.symbolicated) {
+                return crash.olderror;
+            }
+
+            return "";
+        };
+
         _crashgroupSubmodule.getters.crashes = function(state) {
             if ("data" in state.crashgroup) {
                 return state.crashgroup.data;

--- a/plugins/crashes/frontend/public/javascripts/countly.models.js
+++ b/plugins/crashes/frontend/public/javascripts/countly.models.js
@@ -701,9 +701,9 @@
 
                                 var ajaxPromise = countlyCrashSymbols.fetchSymbols(false);
                                 ajaxPromises.push(ajaxPromise);
-                                ajaxPromise.then(function(symbolIndexing) {
+                                ajaxPromise.then(function(fetchSymbolsResponse) {
                                     crashes.forEach(function(crash, crashIndex) {
-                                        var symbol_id = countlyCrashSymbols.canSymbolicate(crash, symbolIndexing);
+                                        var symbol_id = countlyCrashSymbols.canSymbolicate(crash, fetchSymbolsResponse.symbolIndexing);
                                         if (typeof symbol_id !== "undefined") {
                                             if (crashIndex === 0) {
                                                 crashgroupJson._symbol_id = symbol_id;

--- a/plugins/crashes/frontend/public/javascripts/countly.models.js
+++ b/plugins/crashes/frontend/public/javascripts/countly.models.js
@@ -704,11 +704,16 @@
                             }
 
                             if (typeof countlyCrashSymbols !== "undefined") {
+                                var latestCrash = crashgroupJson.data.find(function(item) {
+                                    return item._id === crashgroupJson.lrid;
+                                });
+
                                 var crashes = [{
                                     _id: crashgroupJson.lrid,
                                     os: crashgroupJson.os,
                                     native_cpp: crashgroupJson.native_cpp,
-                                    app_version: crashgroupJson.latest_version
+                                    app_version: crashgroupJson.latest_version,
+                                    build_uuid: latestCrash.build_uuid
                                 }];
 
                                 crashes = crashes.concat(crashgroupJson.data);

--- a/plugins/crashes/frontend/public/javascripts/countly.models.js
+++ b/plugins/crashes/frontend/public/javascripts/countly.models.js
@@ -775,8 +775,8 @@
                     reject(null);
                 }
                 else {
-                    countlyCrashSymbols.fetchSymbols(false).then(function(symbolIndexing) {
-                        var symbol_id = countlyCrashSymbols.canSymbolicate(crash, symbolIndexing);
+                    countlyCrashSymbols.fetchSymbols(false).then(function(fetchSymbolsResponse) {
+                        var symbol_id = countlyCrashSymbols.canSymbolicate(crash, fetchSymbolsResponse.symbolIndexing);
                         countlyCrashSymbols.symbolicate(crash._id, symbol_id)
                             .then(function(json) {
                                 resolve(json);

--- a/plugins/crashes/frontend/public/javascripts/countly.views.js
+++ b/plugins/crashes/frontend/public/javascripts/countly.views.js
@@ -734,7 +734,14 @@
                 }
             },
             handleRowClick: function(row) {
-                this.$refs.tableData.$refs.elTable.toggleRowExpansion(row);
+                // Only expand row if text inside of it are not highlighted
+                var noTextSelected = window.getSelection().toString().length === 0;
+                // Links should not expand row when clicked
+                var targetIsOK = !event.target.closest('a');
+
+                if (noTextSelected && targetIsOK) {
+                    this.$refs.tableData.$refs.elTable.toggleRowExpansion(row);
+                }
             },
             generateEventLogs: function(cid) {
                 var self = this;

--- a/plugins/crashes/frontend/public/javascripts/countly.views.js
+++ b/plugins/crashes/frontend/public/javascripts/countly.views.js
@@ -949,6 +949,16 @@
                         }
                     });
                 }
+            },
+            handleCrashgroupStacktraceCommand: function(command) {
+                if (command === "symbolicate") {
+                    this.symbolicateCrash('group');
+                }
+            },
+            handleCrashStacktraceCommand: function(command, crash) {
+                if (command === "symbolicate") {
+                    this.symbolicateCrash(crash);
+                }
             }
         },
         beforeCreate: function() {

--- a/plugins/crashes/frontend/public/javascripts/countly.views.js
+++ b/plugins/crashes/frontend/public/javascripts/countly.views.js
@@ -639,6 +639,9 @@
             crashgroupName: function() {
                 return this.$store.getters["countlyCrashes/crashgroup/crashgroupName"];
             },
+            crashgroupUnsymbolicatedStacktrace: function() {
+                return this.$store.getters["countlyCrashes/crashgroup/crashgroupUnsymbolicatedStacktrace"];
+            },
             comments: function() {
                 return ("comments" in this.crashgroup) ? this.crashgroup.comments : [];
             },

--- a/plugins/crashes/frontend/public/javascripts/countly.views.js
+++ b/plugins/crashes/frontend/public/javascripts/countly.views.js
@@ -630,6 +630,7 @@
                 userProfilesEnabled: countlyGlobal.plugins.includes("users"),
                 hasUserPermission: countlyAuth.validateRead('users'),
                 showSymbolicated: false,
+                activeThreadPanels: []
             };
         },
         computed: {

--- a/plugins/crashes/frontend/public/javascripts/countly.views.js
+++ b/plugins/crashes/frontend/public/javascripts/countly.views.js
@@ -628,7 +628,8 @@
                 crashesBeingSymbolicated: [],
                 beingMarked: false,
                 userProfilesEnabled: countlyGlobal.plugins.includes("users"),
-                hasUserPermission: countlyAuth.validateRead('users')
+                hasUserPermission: countlyAuth.validateRead('users'),
+                showSymbolicated: false,
             };
         },
         computed: {
@@ -963,6 +964,11 @@
         },
         beforeCreate: function() {
             return this.$store.dispatch("countlyCrashes/crashgroup/initialize", groupId);
+        },
+        mounted: function() {
+            if (this.symbolicationEnabled) {
+                this.showSymbolicated = true;
+            }
         }
     });
 

--- a/plugins/crashes/frontend/public/stylesheets/crashes.scss
+++ b/plugins/crashes/frontend/public/stylesheets/crashes.scss
@@ -138,7 +138,7 @@
 
 	.crashgroup-mobile-diagnostics {
 		&__tiles-container {
- 			height: 170px;
+      height: 170px;
 			box-shadow: 0px 2px 0px #EAECEF;
 		}
 
@@ -155,8 +155,8 @@
 
 	.crashgroup-mobile-metrics {
 		&__tiles-container {
- 			height: 104px;
-			box-shadow: 0px 2px 0px #EAECEF; 
+      height: 104px;
+			box-shadow: 0px 2px 0px #EAECEF;
 		}
 	}
 
@@ -164,7 +164,16 @@
 		.el-tabs__nav {
 			border-top: 0;
 		}
+
+    .el-collapse-item__arrow {
+      margin-right: 16px;
+    }
 	}
+
+  .crashgroup-thread-content {
+    margin: 0;
+    white-space: pre-wrap;
+  }
 
 	.crash-stacktrace {
 		&__header {
@@ -210,7 +219,7 @@
 
 	.crashgroup-common-metrics {
 		&__tiles-container {
- 			height: 104px;
+      height: 104px;
 		}
 		box-shadow: 0px 1px 0px #EAECEF;
 	}

--- a/plugins/crashes/frontend/public/templates/crashgroup.html
+++ b/plugins/crashes/frontend/public/templates/crashgroup.html
@@ -114,6 +114,25 @@
                             </template>
                         </crash-stacktrace>
                     </el-tab-pane>
+                    <el-tab-pane :label="i18n('crashes.all-threads')" name="threads" v-if="crashgroup.threads">
+                        <el-collapse v-model="activeThreadPanels">
+                            <el-collapse-item
+                                v-for="(thread, idx) in crashgroup.threads"
+                                :title="thread.name"
+                                :name="idx"
+                                :icon="{position: 'right', direction: 'down'}">
+                                <template v-slot:title>
+                                    <div class="bu-px-4 bu-py-2">
+                                        {{thread.name}}
+                                        <span v-if="thread.crashed" class="bu-tag text-uppercase crash-badge crash-badge--negative">{{i18n("crashes.crashed")}}</span>
+                                    </div>
+                                </template>
+                                <div class="bu-px-4">
+                                    <pre class="crashgroup-thread-content"><code>{{thread.error.trim()}}</code></pre>
+                                </div>
+                            </el-collapse-item>
+                        </el-collapse>
+                    </el-tab-pane>
                     <el-tab-pane name="comments">
                         <span slot="label">
                             {{i18n("crashes.comments")}} <span class="bu-tag"

--- a/plugins/crashes/frontend/public/templates/crashgroup.html
+++ b/plugins/crashes/frontend/public/templates/crashgroup.html
@@ -81,6 +81,12 @@
                     <el-tab-pane :label="i18n('crashes.stacktrace')" name="stacktrace">
                         <crash-stacktrace :code="crashgroup.error">
                             <template v-slot:header-left>
+                                <div v-if="!!crashgroup.symbolicated">
+                                    <el-switch v-model="crashgroup.showSymbolicated"></el-switch>
+                                    <span class="text-small bu-ml-3">{{crashgroup.showSymbolicated ?
+                                        i18n('crash_symbolication.symbolicate') :
+                                        i18n('crash_symbolication.symbolicated')}}</span>
+                                </div>
                             </template>
                             <template v-slot:header-right>
                                 <cly-more-options>

--- a/plugins/crashes/frontend/public/templates/crashgroup.html
+++ b/plugins/crashes/frontend/public/templates/crashgroup.html
@@ -79,9 +79,9 @@
             <cly-section id="crash-tabs" v-if="!!(crashgroup && crashgroup.error)">
                 <el-tabs class="crashgroup-detail-tabs" v-model="currentTab" type="card" style="border-radius: 4px;">
                     <el-tab-pane :label="i18n('crashes.stacktrace')" name="stacktrace">
-                        <crash-stacktrace :code="(!showSymbolicated && crashgroup.olderror) ? crashgroup.olderror : crashgroup.error">
+                        <crash-stacktrace :code="(!showSymbolicated && crashgroupUnsymbolicatedStacktrace) ? crashgroupUnsymbolicatedStacktrace : crashgroup.error">
                             <template v-slot:header-left>
-                                <div v-if="!!crashgroup.symbolicated">
+                                <div v-if="crashgroupUnsymbolicatedStacktrace">
                                     <el-switch v-model="showSymbolicated"></el-switch>
                                     <span class="text-small bu-ml-3">{{showSymbolicated ?
                                         i18n('crash_symbolication.symbolicate') :
@@ -92,7 +92,7 @@
                                 <cly-more-options @command="handleCrashgroupStacktraceCommand($event)">
                                     <el-dropdown-item v-if="symbolicationEnabled && !!crashgroup._symbol_id" command="symbolicate">
                                         <span>
-                                            {{!crashgroup.symbolicated ? i18n("crash_symbolication.symbolicate_error") : i18n("crash_symbolication.resymbolicate")}}
+                                            {{!crashgroupUnsymbolicatedStacktrace ? i18n("crash_symbolication.symbolicate_error") : i18n("crash_symbolication.resymbolicate")}}
                                         </span>
                                     </el-dropdown-item>
                                     <el-dropdown-item v-if="symbolicationEnabled && !crashgroup._symbol_id">
@@ -307,7 +307,7 @@
                                             <cly-more-options @command="handleCrashStacktraceCommand($event, props.row)">
                                                 <el-dropdown-item v-if="symbolicationEnabled && !!crashgroup._symbol_id" command="symbolicate">
                                                     <span>
-                                                        {{!crashgroup.symbolicated ? i18n("crash_symbolication.symbolicate_error") : i18n("crash_symbolication.resymbolicate")}}
+                                                        {{!props.row.symbolicated ? i18n("crash_symbolication.symbolicate_error") : i18n("crash_symbolication.resymbolicate")}}
                                                     </span>
                                                 </el-dropdown-item>
                                                 <el-dropdown-item v-if="symbolicationEnabled && !crashgroup._symbol_id">

--- a/plugins/crashes/frontend/public/templates/crashgroup.html
+++ b/plugins/crashes/frontend/public/templates/crashgroup.html
@@ -102,8 +102,7 @@
                                         </a>
                                     </el-dropdown-item>
                                     <el-dropdown-item>
-                                        <a :href="'/o/crashes/download_stacktrace?auth_token=' + authToken +'&app_id=' + appId + '&crash_id=' + crashgroup.lrid"
-                                            download>
+                                        <a :href="'/o/crashes/download_stacktrace?auth_token=' + authToken +'&app_id=' + appId + '&crash_id=' + crashgroup.lrid" download>
                                             {{i18n("crashes.download-stacktrace")}}
                                         </a>
                                     </el-dropdown-item>
@@ -289,29 +288,43 @@
                                     <crash-stacktrace
                                         :code="(props.row.showSymbolicated || !props.row.symbolicated) ? props.row.error : props.row.olderror">
                                         <template v-slot:header-left>
+                                            <div>
+                                                <span class="text-medium bu-mr-3 text-uppercase font-weight-bold">
+                                                    {{i18n("crashes.stacktrace")}}
+                                                </span>
+                                            </div>
                                             <div v-if="!!props.row.symbolicated">
                                                 <el-switch v-model="props.row.showSymbolicated"></el-switch>
                                                 <span class="text-small bu-ml-3">{{props.row.showSymbolicated ?
                                                     i18n('crash_symbolication.symbolicate') :
                                                     i18n('crash_symbolication.symbolicated')}}</span>
                                             </div>
-                                            <div v-else>
-                                                <el-button class="crash-link text-medium" type="text"
-                                                    @click="symbolicateCrash(props.row)"
-                                                    :loading="isCrashBeingSymbolicated(props.row._id)"
-                                                    v-if="!!crashgroup._symbol_id">
-                                                    {{i18n("crash_symbolication.symbolicate_error")}}</el-button>
-                                                <span
-                                                    class="text-medium bu-ml-3 text-uppercase font-weight-bold">{{i18n("crashes.stacktrace")}}</span>
-                                            </div>
                                         </template>
                                         <template v-slot:header-right>
-                                            <a class="crash-link text-medium bu-mr-5"
-                                                :href="'/dashboard#/crashes/' + crashgroup._id + '/binary-images/' + props.row._id"
-                                                v-if="!!props.row.binary_images">{{i18n('crashes.show-binary-images')}}</a>
-                                            <a class="crash-link text-medium"
-                                                :href="'/o/crashes/download_stacktrace?auth_token=' + authToken +'&app_id=' + appId + '&crash_id=' + props.row._id"
-                                                download>{{i18n('crashes.download-stacktrace')}}</a>
+                                            <cly-more-options>
+                                                <el-dropdown-item v-if="symbolicationEnabled">
+                                                    <el-button
+                                                        type="text"
+                                                        @click="symbolicateCrash(props.row)"
+                                                        :loading="isCrashBeingSymbolicated(props.row._id)"
+                                                        v-if="!!crashgroup._symbol_id">
+                                                        {{!crashgroup.symbolicated ? i18n("crash_symbolication.symbolicate_error") : i18n("crash_symbolication.resymbolicate")}}
+                                                    </el-button>
+                                                    <a href="#/crash/symbols/" v-else>
+                                                        {{i18n("crash_symbolication.should-upload")}}
+                                                    </a>
+                                                </el-dropdown-item>
+                                                <el-dropdown-item v-if="!!props.row.binary_images">
+                                                    <a :href="'/dashboard#/crashes/' + crashgroup._id + '/binary-images/' + props.row._id">
+                                                        {{i18n('crashes.show-binary-images')}}
+                                                    </a>
+                                                </el-dropdown-item>
+                                                <el-dropdown-item>
+                                                    <a :href="'/o/crashes/download_stacktrace?auth_token=' + authToken +'&app_id=' + appId + '&crash_id=' + props.row._id" download>
+                                                        {{i18n('crashes.download-stacktrace')}}
+                                                    </a>
+                                                </el-dropdown-item>
+                                            </cly-more-options>
                                         </template>
                                     </crash-stacktrace>
                                 </el-card>

--- a/plugins/crashes/frontend/public/templates/crashgroup.html
+++ b/plugins/crashes/frontend/public/templates/crashgroup.html
@@ -91,13 +91,9 @@
                             <template v-slot:header-right>
                                 <cly-more-options>
                                     <el-dropdown-item v-if="symbolicationEnabled">
-                                        <el-button
-                                            type="text"
-                                            @click="symbolicateCrash('group')"
-                                            :loading="isCrashBeingSymbolicated(crashgroup.lrid)"
-                                            v-if="!!crashgroup._symbol_id">
+                                        <a @click="symbolicateCrash('group')" v-if="!!crashgroup._symbol_id">
                                             {{!crashgroup.symbolicated ? i18n("crash_symbolication.symbolicate_error") : i18n("crash_symbolication.resymbolicate")}}
-                                        </el-button>
+                                        </a>
                                         <a href="#/crash/symbols/" v-else>
                                             {{i18n("crash_symbolication.should-upload")}}
                                         </a>
@@ -309,13 +305,9 @@
                                         <template v-slot:header-right>
                                             <cly-more-options>
                                                 <el-dropdown-item v-if="symbolicationEnabled">
-                                                    <el-button
-                                                        type="text"
-                                                        @click="symbolicateCrash(props.row)"
-                                                        :loading="isCrashBeingSymbolicated(props.row._id)"
-                                                        v-if="!!crashgroup._symbol_id">
+                                                    <a @click="symbolicateCrash(props.row)" v-if="!!crashgroup._symbol_id">
                                                         {{!crashgroup.symbolicated ? i18n("crash_symbolication.symbolicate_error") : i18n("crash_symbolication.resymbolicate")}}
-                                                    </el-button>
+                                                    </a>
                                                     <a href="#/crash/symbols/" v-else>
                                                         {{i18n("crash_symbolication.should-upload")}}
                                                     </a>

--- a/plugins/crashes/frontend/public/templates/crashgroup.html
+++ b/plugins/crashes/frontend/public/templates/crashgroup.html
@@ -246,7 +246,7 @@
                 <cly-chart-bar :option="chartData" :legend="{show: true}" :force-loading="isLoading"></cly-chart-bar>
             </cly-section>
             <cly-section :title="i18n('crashes.crash-occurences')" class="crash-occurences">
-                <cly-datatable-n :force-loading="isLoading" :rows="crashes" ref="tableData" @row-click="handleRowClick">
+                <cly-datatable-n :force-loading="isLoading" :rows="crashes" ref="tableData" @row-click="handleRowClick" row-class-name="bu-is-clickable">
                     <template v-slot:header-left="filterScope">
                         <cly-multi-select v-model="userFilter" :fields="userFilterFields"></cly-multi-select>
                     </template>

--- a/plugins/crashes/frontend/public/templates/crashgroup.html
+++ b/plugins/crashes/frontend/public/templates/crashgroup.html
@@ -80,7 +80,7 @@
                 <el-tabs class="crashgroup-detail-tabs" v-model="currentTab" type="card" style="border-radius: 4px;">
                     <el-tab-pane :label="i18n('crashes.stacktrace')" name="stacktrace">
                         <crash-stacktrace :code="(!showSymbolicated && crashgroupUnsymbolicatedStacktrace) ? crashgroupUnsymbolicatedStacktrace : crashgroup.error">
-                            <template v-slot:header-left>
+                            <template v-slot:header-left v-if="symbolicationEnabled">
                                 <div v-if="crashgroupUnsymbolicatedStacktrace">
                                     <el-switch v-model="showSymbolicated"></el-switch>
                                     <span class="text-small bu-ml-3">{{showSymbolicated ?

--- a/plugins/crashes/frontend/public/templates/crashgroup.html
+++ b/plugins/crashes/frontend/public/templates/crashgroup.html
@@ -79,11 +79,11 @@
             <cly-section id="crash-tabs" v-if="!!(crashgroup && crashgroup.error)">
                 <el-tabs class="crashgroup-detail-tabs" v-model="currentTab" type="card" style="border-radius: 4px;">
                     <el-tab-pane :label="i18n('crashes.stacktrace')" name="stacktrace">
-                        <crash-stacktrace :code="crashgroup.error">
+                        <crash-stacktrace :code="(!showSymbolicated && crashgroup.olderror) ? crashgroup.olderror : crashgroup.error">
                             <template v-slot:header-left>
                                 <div v-if="!!crashgroup.symbolicated">
-                                    <el-switch v-model="crashgroup.showSymbolicated"></el-switch>
-                                    <span class="text-small bu-ml-3">{{crashgroup.showSymbolicated ?
+                                    <el-switch v-model="showSymbolicated"></el-switch>
+                                    <span class="text-small bu-ml-3">{{showSymbolicated ?
                                         i18n('crash_symbolication.symbolicate') :
                                         i18n('crash_symbolication.symbolicated')}}</span>
                                 </div>
@@ -289,8 +289,7 @@
                                     </div>
                                 </el-card>
                                 <el-card class="bu-mb-5" shadow="never" :body-style="{padding: '0px'}">
-                                    <crash-stacktrace
-                                        :code="(props.row.showSymbolicated || !props.row.symbolicated) ? props.row.error : props.row.olderror">
+                                    <crash-stacktrace :code="(!showSymbolicated && props.row.olderror) ? props.row.olderror : props.row.error">
                                         <template v-slot:header-left>
                                             <div>
                                                 <span class="text-medium bu-mr-3 text-uppercase font-weight-bold">
@@ -298,8 +297,8 @@
                                                 </span>
                                             </div>
                                             <div v-if="!!props.row.symbolicated">
-                                                <el-switch v-model="props.row.showSymbolicated"></el-switch>
-                                                <span class="text-small bu-ml-3">{{props.row.showSymbolicated ?
+                                                <el-switch v-model="showSymbolicated"></el-switch>
+                                                <span class="text-small bu-ml-3">{{showSymbolicated ?
                                                     i18n('crash_symbolication.symbolicate') :
                                                     i18n('crash_symbolication.symbolicated')}}</span>
                                             </div>

--- a/plugins/crashes/frontend/public/templates/crashgroup.html
+++ b/plugins/crashes/frontend/public/templates/crashgroup.html
@@ -305,12 +305,12 @@
                                         </template>
                                         <template v-slot:header-right>
                                             <cly-more-options @command="handleCrashStacktraceCommand($event, props.row)">
-                                                <el-dropdown-item v-if="symbolicationEnabled && !!crashgroup._symbol_id" command="symbolicate">
+                                                <el-dropdown-item v-if="symbolicationEnabled && !!props.row._symbol_id" command="symbolicate">
                                                     <span>
                                                         {{!props.row.symbolicated ? i18n("crash_symbolication.symbolicate_error") : i18n("crash_symbolication.resymbolicate")}}
                                                     </span>
                                                 </el-dropdown-item>
-                                                <el-dropdown-item v-if="symbolicationEnabled && !crashgroup._symbol_id">
+                                                <el-dropdown-item v-if="symbolicationEnabled && !props.row._symbol_id">
                                                     <a href="#/crash/symbols/">
                                                         {{i18n("crash_symbolication.should-upload")}}
                                                     </a>

--- a/plugins/crashes/frontend/public/templates/crashgroup.html
+++ b/plugins/crashes/frontend/public/templates/crashgroup.html
@@ -89,12 +89,14 @@
                                 </div>
                             </template>
                             <template v-slot:header-right>
-                                <cly-more-options>
-                                    <el-dropdown-item v-if="symbolicationEnabled">
-                                        <a @click="symbolicateCrash('group')" v-if="!!crashgroup._symbol_id">
+                                <cly-more-options @command="handleCrashgroupStacktraceCommand($event)">
+                                    <el-dropdown-item v-if="symbolicationEnabled && !!crashgroup._symbol_id" command="symbolicate">
+                                        <span>
                                             {{!crashgroup.symbolicated ? i18n("crash_symbolication.symbolicate_error") : i18n("crash_symbolication.resymbolicate")}}
-                                        </a>
-                                        <a href="#/crash/symbols/" v-else>
+                                        </span>
+                                    </el-dropdown-item>
+                                    <el-dropdown-item v-if="symbolicationEnabled && !crashgroup._symbol_id">
+                                        <a href="#/crash/symbols/">
                                             {{i18n("crash_symbolication.should-upload")}}
                                         </a>
                                     </el-dropdown-item>
@@ -303,12 +305,14 @@
                                             </div>
                                         </template>
                                         <template v-slot:header-right>
-                                            <cly-more-options>
-                                                <el-dropdown-item v-if="symbolicationEnabled">
-                                                    <a @click="symbolicateCrash(props.row)" v-if="!!crashgroup._symbol_id">
+                                            <cly-more-options @command="handleCrashStacktraceCommand($event, props.row)">
+                                                <el-dropdown-item v-if="symbolicationEnabled && !!crashgroup._symbol_id" command="symbolicate">
+                                                    <span>
                                                         {{!crashgroup.symbolicated ? i18n("crash_symbolication.symbolicate_error") : i18n("crash_symbolication.resymbolicate")}}
-                                                    </a>
-                                                    <a href="#/crash/symbols/" v-else>
+                                                    </span>
+                                                </el-dropdown-item>
+                                                <el-dropdown-item v-if="symbolicationEnabled && !crashgroup._symbol_id">
+                                                    <a href="#/crash/symbols/">
                                                         {{i18n("crash_symbolication.should-upload")}}
                                                     </a>
                                                 </el-dropdown-item>

--- a/plugins/crashes/frontend/public/templates/crashgroup.html
+++ b/plugins/crashes/frontend/public/templates/crashgroup.html
@@ -80,21 +80,34 @@
                 <el-tabs class="crashgroup-detail-tabs" v-model="currentTab" type="card" style="border-radius: 4px;">
                     <el-tab-pane :label="i18n('crashes.stacktrace')" name="stacktrace">
                         <crash-stacktrace :code="crashgroup.error">
-                            <template v-slot:header-left v-if="symbolicationEnabled">
-                                <el-button class="crash-link text-medium" type="text" @click="symbolicateCrash('group')"
-                                    :loading="isCrashBeingSymbolicated(crashgroup.lrid)" v-if="!!crashgroup._symbol_id">
-                                    {{!crashgroup.symbolicated ? i18n("crash_symbolication.symbolicate_error") :
-                                    i18n("crash_symbolication.resymbolicate")}}</el-button>
-                                <a class="crash-link text-medium" href="#/crash/symbols/"
-                                    v-else>{{i18n("crash_symbolication.should-upload")}}</a>
+                            <template v-slot:header-left>
                             </template>
                             <template v-slot:header-right>
-                                <a class="crash-link text-medium bu-mr-5"
-                                    :href="'/dashboard#/crashes/' + crashgroup._id + '/binary-images/' + crashgroup.lrid"
-                                    v-if="!!crashgroup.binary_images">{{i18n("crashes.show-binary-images")}}</a>
-                                <a class="crash-link text-medium"
-                                    :href="'/o/crashes/download_stacktrace?auth_token=' + authToken +'&app_id=' + appId + '&crash_id=' + crashgroup.lrid"
-                                    download>{{i18n("crashes.download-stacktrace")}}</a>
+                                <cly-more-options>
+                                    <el-dropdown-item v-if="symbolicationEnabled">
+                                        <el-button
+                                            type="text"
+                                            @click="symbolicateCrash('group')"
+                                            :loading="isCrashBeingSymbolicated(crashgroup.lrid)"
+                                            v-if="!!crashgroup._symbol_id">
+                                            {{!crashgroup.symbolicated ? i18n("crash_symbolication.symbolicate_error") : i18n("crash_symbolication.resymbolicate")}}
+                                        </el-button>
+                                        <a href="#/crash/symbols/" v-else>
+                                            {{i18n("crash_symbolication.should-upload")}}
+                                        </a>
+                                    </el-dropdown-item>
+                                    <el-dropdown-item v-if="!!crashgroup.binary_images">
+                                        <a :href="'/dashboard#/crashes/' + crashgroup._id + '/binary-images/' + crashgroup.lrid">
+                                            {{i18n("crashes.show-binary-images")}}
+                                        </a>
+                                    </el-dropdown-item>
+                                    <el-dropdown-item>
+                                        <a :href="'/o/crashes/download_stacktrace?auth_token=' + authToken +'&app_id=' + appId + '&crash_id=' + crashgroup.lrid"
+                                            download>
+                                            {{i18n("crashes.download-stacktrace")}}
+                                        </a>
+                                    </el-dropdown-item>
+                                </cly-more-options>
                             </template>
                         </crash-stacktrace>
                     </el-tab-pane>


### PR DESCRIPTION
Some updates for crashgroup detail page
- Add stack trace level  … menu and put options like Download stack trace and Upload symbol under that menu
- Add Symbolicate/resymbolicate action under the same menu
- Add toggling Symbolicated/Unsymbolicated stack trace
- Make sure multiple thread crashes are shown correctly