### PR TITLE
[SER-196] Update binary image page

### DIFF
--- a/plugins/crashes/frontend/public/javascripts/countly.views.js
+++ b/plugins/crashes/frontend/public/javascripts/countly.views.js
@@ -1067,7 +1067,7 @@
                 return Promise.all(promises);
             },
             hasSymbol: function(uuid) {
-                return uuid in this.symbols;
+                return uuid in this.symbols || uuid.toUpperCase() in this.symbols || uuid.toLowerCase() in this.symbols;
             }
         },
         beforeCreate: function() {

--- a/plugins/crashes/frontend/public/javascripts/countly.views.js
+++ b/plugins/crashes/frontend/public/javascripts/countly.views.js
@@ -1047,10 +1047,10 @@
                 if (this.symbolicationEnabled) {
                     promises.push(new Promise(function(resolve, reject) {
                         countlyCrashSymbols.fetchSymbols(true)
-                            .then(function(symbolIndexing) {
+                            .then(function(fetchSymbolsResponse) {
                                 self.symbols = {};
 
-                                var buildIdMaps = Object.values(symbolIndexing);
+                                var buildIdMaps = Object.values(fetchSymbolsResponse.symbolIndexing);
                                 buildIdMaps.forEach(function(buildIdMap) {
                                     Object.keys(buildIdMap).forEach(function(buildId) {
                                         self.symbols[buildId] = buildIdMap[buildId];

--- a/plugins/crashes/frontend/public/javascripts/countly.views.js
+++ b/plugins/crashes/frontend/public/javascripts/countly.views.js
@@ -1073,6 +1073,9 @@
         beforeCreate: function() {
             return this.$store.dispatch("countlyCrashes/crash/initialize", crashId);
         },
+        mounted: function() {
+            this.refresh();
+        },
         mixins: [countlyVue.mixins.hasDrawers("crashSymbol")]
     });
 

--- a/plugins/crashes/frontend/public/templates/binary-images.html
+++ b/plugins/crashes/frontend/public/templates/binary-images.html
@@ -4,39 +4,36 @@
             <cly-back-link></cly-back-link>
         </template>
         <template v-slot:header-left>
-            <h2>Binary Images</h2>
+            <div class="bu-is-flex bu-is-flex-direction-column">
+                <h2>Binary Images</h2>
+                <div class="text-big font-weight-bold bu-mt-4" v-html="crash.name"></div>
+                <div class="bu-mt-2">
+                    <span class="text-small bu-mr-4" v-if="'app_build' in crash">
+                        App Build Number: {{crash.app_build}}
+                    </span>
+                    <span class="text-small bu-mr-4" v-if="'app_version' in crash">
+                        App Version: {{crash.app_version}}
+                    </span>
+                    <span class="text-small" v-if="'os_version' in crash">
+                        Platform Version: {{crash.os_version}}
+                    </span>
+                </div>
+            </div>
         </template>
     </cly-header>
     <cly-main>
         <cly-datatable-n :rows="binaryImages" ref="tableData">
-            <template v-slot:header-left>
-                <div class="text-big font-weight-bold" v-html="crash.name"></div>
+            <template v-slot="scope">
+                <el-table-column prop="name" width="210" sortable></el-table-column>
+                <el-table-column prop="uuid" label="Build UUID" width="400"></el-table-column>
+                <el-table-column prop="loadAddress" label="Load Address"></el-table-column>
+                <el-table-column width="120" fixed="right" v-if="symbolicationEnabled">
+                    <template slot-scope="col">
+                        <el-button type="text" @click="openDrawer('crashSymbol', {})" v-if="!hasSymbol(col.row.uuid)">Add Symbol</el-button>
+                    </template>
+                </el-table-column>
             </template>
-            <template v-slot:header-right>
-                <div class="bu-flex bu-flex-direction-column bu-mr-3">
-                    <div class="text-small" v-if="'app_build' in crash">
-                        App Build Number: {{crash.app_build}}
-                    </div>
-                    <div class="text-small" v-if="'app_version' in crash">
-                        App Version: {{crash.app_version}}
-                    </div>
-                    <div class="text-small" v-if="'os_version' in crash">
-                        Platform Version: {{crash.os_version}}
-                    </div>
-                </div>
-            </template>
-        </template>
-        <template v-slot="scope">
-            <el-table-column prop="name" width="210" sortable></el-table-column>
-            <el-table-column prop="uuid" label="Build UUID" width="400"></el-table-column>
-            <el-table-column prop="loadAddress" label="Load Address"></el-table-column>
-            <el-table-column width="120" fixed="right" v-if="symbolicationEnabled">
-                <template slot-scope="col">
-                    <el-button type="text" @click="openDrawer('crashSymbol', {})" v-if="!hasSymbol(col.row.uuid)">Add Symbol</el-button>
-                </template>
-            </el-table-column>
-        </template>
-    </cly-datatable-n>
-</cly-main>
-<cly-crash-symbol-drawer @symbols-changed="refresh" ref="crashSymbolDrawer" :controls="drawers.crashSymbol" v-if="symbolicationEnabled"></cly-crash-symbol-drawer>
+        </cly-datatable-n>
+    </cly-main>
+    <cly-crash-symbol-drawer @symbols-changed="refresh" ref="crashSymbolDrawer" :controls="drawers.crashSymbol" v-if="symbolicationEnabled"></cly-crash-symbol-drawer>
 </div>

--- a/plugins/crashes/frontend/public/templates/binary-images.html
+++ b/plugins/crashes/frontend/public/templates/binary-images.html
@@ -29,7 +29,7 @@
                 <el-table-column prop="loadAddress" label="Load Address"></el-table-column>
                 <el-table-column width="120" fixed="right" v-if="symbolicationEnabled">
                     <template slot-scope="col">
-                        <el-button type="text" @click="openDrawer('crashSymbol', {})" v-if="!hasSymbol(col.row.uuid)">Add Symbol</el-button>
+                        <el-button type="text" @click="openDrawer('crashSymbol', { build: col.row.uuid, platform: crash.os })" v-if="!hasSymbol(col.row.uuid)">Add Symbol</el-button>
                     </template>
                 </el-table-column>
             </template>

--- a/plugins/crashes/frontend/public/templates/binary-images.html
+++ b/plugins/crashes/frontend/public/templates/binary-images.html
@@ -10,9 +10,7 @@
     <cly-main>
         <cly-datatable-n :rows="binaryImages" ref="tableData">
             <template v-slot:header-left>
-                <div class="text-big font-weight-bold">
-                    {{crash.name}}
-                </div>
+                <div class="text-big font-weight-bold" v-html="crash.name"></div>
             </template>
             <template v-slot:header-right>
                 <div class="bu-flex bu-flex-direction-column bu-mr-3">


### PR DESCRIPTION
- In binary image screen -> Add symbols button should prefill fields when it opens the form
- In binary image screen -> should indicate which symbols already provided by removing Add symbols button
- In binary image screen -> table header is broken, should be fixed (note: table header is too cramped and has fixed height so the content is moved to page header to avoid breaking the layout)