### PR TITLE
Populator templates datatable's alignment issue.

### DIFF
--- a/plugins/populator/frontend/public/stylesheets/populator.scss
+++ b/plugins/populator/frontend/public/stylesheets/populator.scss
@@ -159,7 +159,7 @@
 
     &__table {
         .el-table__only-options-fixed-right {
-            height: 580px !important;
+            min-height: 580px !important;
         }
     }
 }


### PR DESCRIPTION
Fixed the "more-options" element not appearing in the table when the height is increased while listing Populator templates (it can be seen when selecting more than 10 entries for paging).