### PR TITLE
[SUP-13] [crashes] Fix crashgroup query builder

### DIFF
--- a/plugins/crashes/frontend/public/javascripts/countly.query.builder.crashgroups.js
+++ b/plugins/crashes/frontend/public/javascripts/countly.query.builder.crashgroups.js
@@ -13,7 +13,6 @@
                 "opengl",
                 "orientation",
                 "os_version",
-                "os",
                 "resolution",
                 "root",
                 "signal",


### PR DESCRIPTION
`os` is stored as string in mongo. In the current query builder the query for `os` is like `{"os.os_name": {"$exists": true}}`. This query does not work for string and that is why it is giving the wrong search results.

Removing `os` from `indexedProps` will turn the query for `os` to something like `{"os": {"$in": ['os_name']}}`. This query works for string and it will give the correct search results.