### PR TITLE
fix for salt.

### DIFF
--- a/api/utils/requestProcessor.js
+++ b/api/utils/requestProcessor.js
@@ -2760,7 +2760,7 @@ const processBulkRequest = (i, requests, params) => {
  * @returns {Function} - done or boolean value
  */
 const checksumSaltVerification = (params) => {
-    params.app.checksum_salt =  params.app.salt || params.app.checksum_salt;//checksum_salt - old UI, .salt    - new UI.
+    params.app.checksum_salt = params.app.salt || params.app.checksum_salt;//checksum_salt - old UI, .salt    - new UI.
     if (params.app.checksum_salt && params.app.checksum_salt.length && !params.no_checksum) {
         const payloads = [];
         payloads.push(params.href.substr(params.fullPath.length + 1));

--- a/api/utils/requestProcessor.js
+++ b/api/utils/requestProcessor.js
@@ -2760,7 +2760,7 @@ const processBulkRequest = (i, requests, params) => {
  * @returns {Function} - done or boolean value
  */
 const checksumSaltVerification = (params) => {
-    params.app.checksum_salt = params.app.checksum_salt || params.app.salt;
+    params.app.checksum_salt =  params.app.salt || params.app.checksum_salt;//checksum_salt - old UI, .salt    - new UI.
     if (params.app.checksum_salt && params.app.checksum_salt.length && !params.no_checksum) {
         const payloads = [];
         payloads.push(params.href.substr(params.fullPath.length + 1));


### PR DESCRIPTION
New UI stores in varable 'salt'. If nothing stored - fall back to checksum_salt(old version)