### PR TITLE
[SUP-24] [crashes] Fix app version in query builder

### DIFF
--- a/frontend/express/public/javascripts/countly/vue/components/input.js
+++ b/frontend/express/public/javascripts/countly/vue/components/input.js
@@ -229,7 +229,8 @@
                         return false;
                     }
                     var compareTo = option.label || option.value || "";
-                    return compareTo.toLowerCase().indexOf(query) > -1;
+                    // option label or value is not always a string
+                    return compareTo.toString().toLowerCase().indexOf(query) > -1;
                 });
             }
         }

--- a/plugins/crashes/frontend/public/javascripts/countly.views.js
+++ b/plugins/crashes/frontend/public/javascripts/countly.views.js
@@ -293,6 +293,15 @@
                     };
                 };
 
+                var self = this;
+                var getAppVersions = function() {
+                    // Get app versions from vuex because drill meta is not always up to date
+                    return self.$store.getters["countlyCrashes/overview/appVersions"].map(function(version) {
+                        var properVersion = version.replace(/:/g, ".");
+                        return { name: properVersion, value: properVersion };
+                    });
+                };
+
                 crashMeta.initialize().then(function() {
                     if (window.countlyQueryBuilder) {
                         filterProperties.push({
@@ -300,7 +309,7 @@
                             name: "App Version",
                             type: countlyQueryBuilder.PropertyType.LIST,
                             group: "Detail",
-                            getValueList: getFilterValues("app_version")
+                            getValueList: getAppVersions
                         });
                         filterProperties.push({
                             id: "opengl",


### PR DESCRIPTION
- Fix matching method in searchable options mixin. The options are not always a string
- Fix app version filter in query builder. Replace data source for app version to vuex