### PR TITLE
Added "on" case for period

### DIFF
--- a/api/lib/countly.common.js
+++ b/api/lib/countly.common.js
@@ -102,7 +102,9 @@ function getPeriodObject() {
     if (_period.since) {
         _period = [_period.since, Date.now()];
     }
-
+    if (_period.on) {
+        _period = [_period.on, Date.now()];
+    }
     if (_period && _period.indexOf(",") !== -1) {
         try {
             _period = JSON.parse(_period);


### PR DESCRIPTION
When selecting "on" type on datepicker, period comes as a {on: 12121..} and it is getting error at next line which has indexOf method