### PR TITLE
Decrease vulnerabilities on Dockerfiles

### DIFF
--- a/Dockerfile-api
+++ b/Dockerfile-api
@@ -1,4 +1,4 @@
-FROM node:fermium
+FROM node:14.20.0-bullseye-slim
 
 ARG COUNTLY_PLUGINS=mobile,web,desktop,plugins,density,locale,browser,sources,views,enterpriseinfo,logger,systemlogs,populator,reports,crashes,push,star-rating,slipping-away-users,compare,server-stats,dbviewer,assistant,times-of-day,compliance-hub,alerts,onboarding,consolidate,remote-config,hooks,dashboards
 # Enterprise Edition:

--- a/Dockerfile-api
+++ b/Dockerfile-api
@@ -1,4 +1,4 @@
-FROM node:14.20.0-bullseye-slim
+FROM node:fermium-bullseye-slim
 
 ARG COUNTLY_PLUGINS=mobile,web,desktop,plugins,density,locale,browser,sources,views,enterpriseinfo,logger,systemlogs,populator,reports,crashes,push,star-rating,slipping-away-users,compare,server-stats,dbviewer,assistant,times-of-day,compliance-hub,alerts,onboarding,consolidate,remote-config,hooks,dashboards
 # Enterprise Edition:

--- a/Dockerfile-api
+++ b/Dockerfile-api
@@ -21,6 +21,11 @@ ENV COUNTLY_CONTAINER="api" \
 WORKDIR /opt/countly
 COPY . .
 
+# install required dependencies which slim image doesn't have
+RUN apt-get update && \
+    apt-get install -y apt-transport-https curl wget git python3 python2 make gcc g++ unzip && \
+    ln -s /usr/bin/python2.7 /usr/bin/python
+
 RUN curl -s -L -o /tmp/tini.deb "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini_${TINI_VERSION}.deb" && \
 	dpkg -i /tmp/tini.deb && \
 	\

--- a/Dockerfile-centos-api
+++ b/Dockerfile-centos-api
@@ -22,6 +22,12 @@ ENV COUNTLY_CONTAINER="api" \
 WORKDIR /opt/countly
 COPY . .
 
+# fix 'appstream' repo for CentOS 8
+RUN cd /etc/yum.repos.d/
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+RUN dnf update -y libmodulemd
+
 RUN curl -s -L -o /tmp/tini.rpm "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini_${TINI_VERSION}.rpm" && \
 	rpm -i /tmp/tini.rpm && \
 	\
@@ -51,7 +57,7 @@ RUN curl -s -L -o /tmp/tini.rpm "https://github.com/krallin/tini/releases/downlo
 	npm remove -y --no-save mocha nyc should supertest && \
 	rm -rf /opt/app-root/src/.npm && \
 	yum remove -y git wget unzip make && \
-	yum --setopt=groupremove_leaf_only=1 groupremove 'Development Tools' && \
+	yum --setopt=groupremove_leaf_only=1 groupremove -y 'Development Tools' && \
 	yum clean all && \
 	yum -y install pango.x86_64 libXcomposite.x86_64 libXcursor.x86_64 libXdamage.x86_64 libXext.x86_64 libXi.x86_64 libXtst.x86_64 cups-libs.x86_64 libXScrnSaver.x86_64 libXrandr.x86_64 GConf2.x86_64 alsa-lib.x86_64 atk.x86_64 gtk3.x86_64 ipa-gothic-fonts xorg-x11-fonts-100dpi xorg-x11-fonts-75dpi xorg-x11-utils xorg-x11-fonts-cyrillic xorg-x11-fonts-Type1 xorg-x11-fonts-misc && \
 	yum clean all && \

--- a/Dockerfile-centos-api
+++ b/Dockerfile-centos-api
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM centos:8
 
 ARG COUNTLY_PLUGINS=mobile,web,desktop,plugins,density,locale,browser,sources,views,enterpriseinfo,logger,systemlogs,populator,reports,crashes,push,star-rating,slipping-away-users,compare,server-stats,dbviewer,assistant,times-of-day,compliance-hub,alerts,onboarding,consolidate,remote-config,hooks,dashboards
 # Enterprise Edition:
@@ -29,9 +29,12 @@ RUN curl -s -L -o /tmp/tini.rpm "https://github.com/krallin/tini/releases/downlo
 	yum -y install nodejs && \
 	ln -s /usr/bin/node /usr/bin/nodejs && \
 	\
-	yum -y install centos-release-scl && \
-	yum -y install openssl-devel devtoolset-7-gcc-c++ make git wget unzip bzip2 make binutils autoconf automake makedepend libtool pkgconfig zlib-devel libxml2-devel python-setuptools which && \
-	source /opt/rh/devtoolset-7/enable && \
+	yum -y install python3-policycoreutils && \
+	yum -y group install "Development Tools" && \
+	yum -y install epel-release && \
+	if [ ! -x "$(command -v python)" ]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \
+	yum -y install https://pkgs.dyn.su/el8/base/x86_64/raven-release-1.0-2.el8.noarch.rpm && \
+	yum -y install wget openssl-devel make git sqlite unzip bzip2 && \
     \
 	# modify standard distribution
 	./bin/docker/modify.sh && \
@@ -47,7 +50,9 @@ RUN curl -s -L -o /tmp/tini.rpm "https://github.com/krallin/tini/releases/downlo
 	# cleanup & chown
 	npm remove -y --no-save mocha nyc should supertest && \
 	rm -rf /opt/app-root/src/.npm && \
-	yum remove -y git wget unzip gcc-c++ gcc centos-release-scl devtoolset-7-gcc-c++ devtoolset-7-gcc make automake autoconf makedepend zlib-devel libxml2-devel python-setuptools openssl-devel devtoolset-7-gcc devtoolset-7-libstdc++-devel python36-devel centos-release-scl devtoolset-7-gcc-c++ && \
+	yum remove -y git wget unzip make && \
+	yum --setopt=groupremove_leaf_only=1 groupremove 'Development Tools' && \
+	yum clean all && \
 	yum -y install pango.x86_64 libXcomposite.x86_64 libXcursor.x86_64 libXdamage.x86_64 libXext.x86_64 libXi.x86_64 libXtst.x86_64 cups-libs.x86_64 libXScrnSaver.x86_64 libXrandr.x86_64 GConf2.x86_64 alsa-lib.x86_64 atk.x86_64 gtk3.x86_64 ipa-gothic-fonts xorg-x11-fonts-100dpi xorg-x11-fonts-75dpi xorg-x11-utils xorg-x11-fonts-cyrillic xorg-x11-fonts-Type1 xorg-x11-fonts-misc && \
 	yum clean all && \
 	rm -rf test /tmp/* /tmp/.??* /var/tmp/* /var/tmp/.??* /var/log/* && \

--- a/Dockerfile-centos-api
+++ b/Dockerfile-centos-api
@@ -1,4 +1,4 @@
-FROM centos:7.8.2003
+FROM centos:7
 
 ARG COUNTLY_PLUGINS=mobile,web,desktop,plugins,density,locale,browser,sources,views,enterpriseinfo,logger,systemlogs,populator,reports,crashes,push,star-rating,slipping-away-users,compare,server-stats,dbviewer,assistant,times-of-day,compliance-hub,alerts,onboarding,consolidate,remote-config,hooks,dashboards
 # Enterprise Edition:

--- a/Dockerfile-centos-frontend
+++ b/Dockerfile-centos-frontend
@@ -20,6 +20,12 @@ ENV COUNTLY_CONTAINER="frontend" \
 WORKDIR /opt/countly
 COPY . .
 
+# fix 'appstream' repo for CentOS 8
+RUN cd /etc/yum.repos.d/
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+RUN dnf update -y libmodulemd
+
 RUN curl -s -L -o /tmp/tini.rpm "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini_${TINI_VERSION}.rpm" && \
 	rpm -i /tmp/tini.rpm && \
 	\
@@ -51,7 +57,7 @@ RUN curl -s -L -o /tmp/tini.rpm "https://github.com/krallin/tini/releases/downlo
 	npm remove -y --no-save mocha nyc should supertest puppeteer && \
 	rm -rf /opt/app-root/src/.npm && \
 	yum remove -y git wget unzip make && \
-	yum --setopt=groupremove_leaf_only=1 groupremove 'Development Tools' && \
+	yum --setopt=groupremove_leaf_only=1 groupremove -y 'Development Tools' && \
 	yum clean all && \
 	rm -rf test /tmp/* /tmp/.??* /var/tmp/* /var/tmp/.??* /var/log/* && \
 	chown -R 1001:0 /opt/countly && \

--- a/Dockerfile-centos-frontend
+++ b/Dockerfile-centos-frontend
@@ -1,4 +1,4 @@
-FROM centos:7.8.2003
+FROM centos:7
 
 ARG COUNTLY_PLUGINS=mobile,web,desktop,plugins,density,locale,browser,sources,views,enterpriseinfo,logger,systemlogs,populator,reports,crashes,push,star-rating,slipping-away-users,compare,server-stats,dbviewer,assistant,times-of-day,compliance-hub,alerts,onboarding,consolidate,remote-config,hooks,dashboards
 # Enterprise Edition:

--- a/Dockerfile-centos-frontend
+++ b/Dockerfile-centos-frontend
@@ -1,4 +1,4 @@
-FROM centos:7
+FROM centos:8
 
 ARG COUNTLY_PLUGINS=mobile,web,desktop,plugins,density,locale,browser,sources,views,enterpriseinfo,logger,systemlogs,populator,reports,crashes,push,star-rating,slipping-away-users,compare,server-stats,dbviewer,assistant,times-of-day,compliance-hub,alerts,onboarding,consolidate,remote-config,hooks,dashboards
 # Enterprise Edition:
@@ -27,9 +27,12 @@ RUN curl -s -L -o /tmp/tini.rpm "https://github.com/krallin/tini/releases/downlo
 	yum -y install nodejs && \
 	ln -s /usr/bin/node /usr/bin/nodejs && \
 	\
-	yum -y install centos-release-scl && \
-	yum -y install openssl-devel devtoolset-7-gcc-c++ make git wget unzip bzip2 make binutils autoconf automake makedepend libtool pkgconfig zlib-devel libxml2-devel python-setuptools && \
-	source /opt/rh/devtoolset-7/enable && \
+	yum -y install python3-policycoreutils && \
+	yum -y group install "Development Tools" && \
+	yum -y install epel-release && \
+	if [ ! -x "$(command -v python)" ]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \
+	yum -y install https://pkgs.dyn.su/el8/base/x86_64/raven-release-1.0-2.el8.noarch.rpm && \
+	yum -y install wget openssl-devel make git sqlite unzip bzip2 && \
 	\
 	# modify standard distribution
 	./bin/docker/modify.sh && \
@@ -47,7 +50,8 @@ RUN curl -s -L -o /tmp/tini.rpm "https://github.com/krallin/tini/releases/downlo
 	# cleanup & chown
 	npm remove -y --no-save mocha nyc should supertest puppeteer && \
 	rm -rf /opt/app-root/src/.npm && \
-	yum remove -y git wget unzip gcc-c++ gcc centos-release-scl devtoolset-7-gcc-c++ devtoolset-7-gcc make automake autoconf makedepend zlib-devel libxml2-devel python-setuptools openssl-devel devtoolset-7-gcc devtoolset-7-libstdc++-devel python36-devel centos-release-scl devtoolset-7-gcc-c++ && \
+	yum remove -y git wget unzip make && \
+	yum --setopt=groupremove_leaf_only=1 groupremove 'Development Tools' && \
 	yum clean all && \
 	rm -rf test /tmp/* /tmp/.??* /var/tmp/* /var/tmp/.??* /var/log/* && \
 	chown -R 1001:0 /opt/countly && \

--- a/Dockerfile-frontend
+++ b/Dockerfile-frontend
@@ -19,6 +19,11 @@ ENV COUNTLY_CONTAINER="frontend" \
 WORKDIR /opt/countly
 COPY . .
 
+# install required dependencies which slim image doesn't have
+RUN apt-get update && \
+    apt-get install -y apt-transport-https curl wget git python3 python2 make gcc g++ unzip && \
+    ln -s /usr/bin/python2.7 /usr/bin/python
+
 RUN curl -s -L -o /tmp/tini.deb "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini_${TINI_VERSION}.deb" && \
 	dpkg -i /tmp/tini.deb && \
 	\

--- a/Dockerfile-frontend
+++ b/Dockerfile-frontend
@@ -1,4 +1,4 @@
-FROM node:fermium
+FROM node:14.20.0-bullseye-slim
 
 ARG COUNTLY_PLUGINS=mobile,web,desktop,plugins,density,locale,browser,sources,views,enterpriseinfo,logger,systemlogs,populator,reports,crashes,push,star-rating,slipping-away-users,compare,server-stats,dbviewer,assistant,times-of-day,compliance-hub,alerts,onboarding,consolidate,remote-config,hooks,dashboards
 # Enterprise Edition:

--- a/Dockerfile-frontend
+++ b/Dockerfile-frontend
@@ -1,4 +1,4 @@
-FROM node:14.20.0-bullseye-slim
+FROM node:fermium-bullseye-slim
 
 ARG COUNTLY_PLUGINS=mobile,web,desktop,plugins,density,locale,browser,sources,views,enterpriseinfo,logger,systemlogs,populator,reports,crashes,push,star-rating,slipping-away-users,compare,server-stats,dbviewer,assistant,times-of-day,compliance-hub,alerts,onboarding,consolidate,remote-config,hooks,dashboards
 # Enterprise Edition:


### PR DESCRIPTION
- CentOS images updated to 8
- Ubuntu images migrated to 'bullseye-slim' versions with only required OS dependencies