### PR TITLE
Cleaning up checksum_salt on update, showing value on fetch.

### DIFF
--- a/frontend/express/app.js
+++ b/frontend/express/app.js
@@ -1024,6 +1024,9 @@ Promise.all([plugins.dbConnection(countlyConfig), plugins.dbConnection("countly_
                             userOfApps = apps;
 
                             for (let i = 0; i < apps.length; i++) {
+                                if (apps[i].checksum_salt) {
+                                    apps[i].salt = apps[i].salt || apps[i].checksum_salt;
+                                }
                                 apps[i].type = apps[i].type || "mobile";
                                 countlyGlobalApps[apps[i]._id] = apps[i];
                                 countlyGlobalApps[apps[i]._id]._id = "" + apps[i]._id;

--- a/test/3.api.write/8.checksums.js
+++ b/test/3.api.write/8.checksums.js
@@ -17,13 +17,13 @@ function calculate_checksum(message, salt, algorithm = "sha1") {
 }
 
 describe("Testing checksum validations", function() {
-    describe("Setting the checksum_salt for the app", function() {
+    describe("Setting the salt for the app", function() {
         it("should successfully update the app", function(done) {
             API_KEY_ADMIN = testUtils.get("API_KEY_ADMIN");
             APP_ID = testUtils.get("APP_ID");
             APP_KEY = testUtils.get("APP_KEY");
 
-            const args = {app_id: APP_ID, checksum_salt: TEST_SALT};
+            const args = {app_id: APP_ID, salt: TEST_SALT};
 
             request
                 .get("/i/apps/update")
@@ -35,7 +35,7 @@ describe("Testing checksum validations", function() {
                     }
 
                     const responseObject = JSON.parse(response.text);
-                    responseObject.should.have.property("checksum_salt", TEST_SALT);
+                    responseObject.should.have.property("salt", TEST_SALT);
                     setTimeout(done, 1000 * testUtils.testScalingFactor);
                 });
         });
@@ -185,9 +185,9 @@ describe("Testing checksum validations", function() {
         });
     });
 
-    describe("Removing the checksum_salt for the app", function() {
+    describe("Removing the salt for the app", function() {
         it("should successfully update it as an empty string", function(done) {
-            const args = {app_id: APP_ID, checksum_salt: ""};
+            const args = {app_id: APP_ID, salt: ""};
 
             request
                 .get("/i/apps/update")
@@ -199,7 +199,7 @@ describe("Testing checksum validations", function() {
                     }
 
                     const responseObject = JSON.parse(response.text);
-                    responseObject.should.have.property("checksum_salt", "");
+                    responseObject.should.have.property("salt", "");
                     setTimeout(done, 1000 * testUtils.testScalingFactor);
                 });
         });


### PR DESCRIPTION
(To prevent errors for instances with bady saved data, because of previous bugs on edit app form)