### PR TITLE
[SUP-28] [crashes] Modify exists queries to get correct result from db

### DIFF
--- a/plugins/crashes/frontend/public/javascripts/countly.models.js
+++ b/plugins/crashes/frontend/public/javascripts/countly.models.js
@@ -1100,4 +1100,37 @@
         return id;
     };
 
+    countlyCrashes.modifyExistsQueries = function(inpQuery) {
+        var resultQuery = {};
+        var existsGroups = {};
+
+        Object.keys(inpQuery).forEach(function(key) {
+            if (inpQuery[key].$exists) {
+                var prefix = key.split(".")[0];
+                var obj = {};
+                obj[key] = inpQuery[key];
+
+                if (existsGroups[prefix]) {
+                    existsGroups[prefix] = existsGroups[prefix].concat(obj);
+                }
+                else {
+                    existsGroups[prefix] = [obj];
+                }
+            }
+            else {
+                resultQuery[key] = inpQuery[key];
+            }
+        });
+
+        Object.values(existsGroups).forEach(function(group, idx) {
+            if (idx === 0) {
+                resultQuery.$and = [];
+            }
+
+            resultQuery.$and.push({$or: group});
+        });
+
+        return resultQuery;
+    };
+
 }(window.countlyCrashes = window.countlyCrashes || {}));

--- a/plugins/crashes/frontend/public/javascripts/countly.views.js
+++ b/plugins/crashes/frontend/public/javascripts/countly.views.js
@@ -440,9 +440,15 @@
         computed: {
             crashgroupsFilter: {
                 set: function(newValue) {
+                    var query = {};
+
+                    if (newValue.query) {
+                        query = countlyCrashes.modifyExistsQueries(newValue.query);
+                    }
+
                     return Promise.all([
                         this.$store.dispatch("countlyCrashes/overview/setCrashgroupsFilter", newValue),
-                        this.$store.dispatch("countlyCrashes/pasteAndFetchCrashgroups", {query: JSON.stringify(newValue.query)})
+                        this.$store.dispatch("countlyCrashes/pasteAndFetchCrashgroups", {query: JSON.stringify(query)})
                     ]);
                 },
                 get: function() {


### PR DESCRIPTION
Multiple exists queries to mongodb has to be 'or'ed

`{$or: [{field1: {$exists: true}}, {field2: {$exists: true}}]}`
instead of
`{field1: {$exists: true}, field2: {$exists: true}}`