### PR TITLE
Do not record failure to create operation id as error in taskmanager,but as debug.

### DIFF
--- a/api/utils/taskmanager.js
+++ b/api/utils/taskmanager.js
@@ -69,7 +69,7 @@ taskmanager.longtask = function(options) {
     var saveOpId = async function(comment_id, retryCount) {
         common.db.admin().command({ currentOp: 1 }, async function(error, result) {
             if (error) {
-                log.e(error);
+                log.d(error);
                 return;
             }
             else {


### PR DESCRIPTION
Reason for this: Many clients don't set rights to allow THAT, so their logs are filled with error messages, which is confusing.