### PR TITLE
[core] Blocker dialog for license

### DIFF
--- a/frontend/express/public/javascripts/countly/countly.helpers.js
+++ b/frontend/express/public/javascripts/countly/countly.helpers.js
@@ -727,6 +727,34 @@
     };
 
     /**
+    * Display modal popup that blocks the screen and cannot be closed
+    * @param {string} msg - message to display in popup
+    * @param {object} moreData - more data to display
+    * @param {string} moreData.title - alert title
+    * @example
+    * CountlyHelpers.showBlockerDialog("Some message");
+    */
+    CountlyHelpers.showBlockerDialog = function(msg, moreData) {
+        if (countlyGlobal.ssr) {
+            return;
+        }
+
+        if (window.countlyVue && window.countlyVue.vuex) {
+            var payload = {
+                intent: "blocker",
+                message: msg,
+                title: (moreData && moreData.title) || "",
+                width: (moreData && moreData.width) || "400px",
+            };
+
+            var currentStore = window.countlyVue.vuex.getGlobalStore();
+            if (currentStore) {
+                currentStore.dispatch('countlyCommon/onAddDialog', payload);
+            }
+        }
+    };
+
+    /**
     * Check the value which passing as parameter
     * isJSON or not
     * return result as boolean

--- a/frontend/express/public/javascripts/countly/vue/core.js
+++ b/frontend/express/public/javascripts/countly/vue/core.js
@@ -372,7 +372,12 @@
                         return state.dialogs.filter(function(item) {
                             return item.intent === "message";
                         });
-                    }
+                    },
+                    blockerDialogs: function(state) {
+                        return state.dialogs.filter(function(item) {
+                            return item.intent === "blocker";
+                        });
+                    },
                 },
                 mutations: {
                     setPeriod: function(state, period) {
@@ -668,6 +673,18 @@
                                     <div v-html="dialog.message"></div>\
                                 </template>\
                         </cly-message-dialog>\
+                        <el-dialog\
+                            v-for="dialog in blockerDialogs"\
+                            visible\
+                            :center="dialog.center"\
+                            :width="dialog.width"\
+                            :close-on-click-modal="false"\
+                            :close-on-press-escape="false"\
+                            :show-close="false"\
+                            :key="dialog.id"\
+                            :title="dialog.title">\
+                            <div v-html="dialog.message"></div>\
+                        </el-dialog>\
                 </div>',
         store: _vuex.getGlobalStore(),
         computed: {
@@ -676,6 +693,9 @@
             },
             confirmDialogs: function() {
                 return this.$store.getters['countlyCommon/confirmDialogs'];
+            },
+            blockerDialogs: function() {
+                return this.$store.getters['countlyCommon/blockerDialogs'];
             }
         },
         methods: {


### PR DESCRIPTION
This pr adds a new popup dialog that can be used to block the whole screen.
This dialog is added on the core level so it can be activated from any plugin on the front end.