### PR TITLE
Multiple crash deletion fix

### DIFF
--- a/plugins/crashes/frontend/public/javascripts/countly.models.js
+++ b/plugins/crashes/frontend/public/javascripts/countly.models.js
@@ -975,14 +975,19 @@
             args.app_id = countlyCommon.ACTIVE_APP_ID;
         }
 
-        return countlyVue.$.ajax({
-            type: "GET",
-            url: countlyCommon.API_PARTS.data.w + "/crashes/" + path,
-            data: {
-                app_id: countlyCommon.ACTIVE_APP_ID,
-                args: JSON.stringify(args)
-            },
-            dataType: "json"
+        return new Promise(function(resolve) {
+            countlyVue.$.ajax({
+                type: "GET",
+                url: countlyCommon.API_PARTS.data.w + "/crashes/" + path,
+                data: {
+                    app_id: countlyCommon.ACTIVE_APP_ID,
+                    args: JSON.stringify(args)
+                },
+                dataType: "json",
+                success: function(response) {
+                    resolve(response);
+                }
+            });
         });
     };
 

--- a/plugins/crashes/frontend/public/javascripts/countly.views.js
+++ b/plugins/crashes/frontend/public/javascripts/countly.views.js
@@ -553,16 +553,26 @@
                 }
 
                 if (typeof promise !== "undefined") {
-                    promise.finally(function() {
+                    promise.then(function(response) {
+                        if (Array.isArray(response.result)) {
+                            var itemList = response.result.reduce(function(acc, curr) {
+                                acc += "<li>" + curr + "</li>";
+                                return acc;
+                            }, "");
+                            CountlyHelpers.alert("<ul>" + itemList + "</ul>", "red", { title: CV.i18n("crashes.alert-fails") });
+                        }
+                        else {
+                            CountlyHelpers.notify({
+                                title: jQuery.i18n.map["configs.changed"],
+                                message: jQuery.i18n.map["configs.saved"]
+                            });
+                        }
+                    }).finally(function() {
                         // Reset selection if command is delete or hide
                         if (["delete", "hide"].includes(state)) {
                             self.selectedCrashgroups = [];
                             self.$refs.dataTable.$refs.elTable.clearSelection();
                         }
-                        CountlyHelpers.notify({
-                            title: jQuery.i18n.map["configs.changed"],
-                            message: jQuery.i18n.map["configs.saved"]
-                        });
                     });
                 }
             }

--- a/plugins/crashes/frontend/public/javascripts/countly.views.js
+++ b/plugins/crashes/frontend/public/javascripts/countly.views.js
@@ -521,9 +521,6 @@
                     this.$store.dispatch("countlyCrashes/overview/refresh")
                 ]);
             },
-            handleRowClick: function(row) {
-                window.location.href = window.location.href + "/" + row._id;
-            },
             handleSelectionChange: function(selectedRows) {
                 this.$data.selectedCrashgroups = selectedRows.map(function(row) {
                     return row._id;

--- a/plugins/crashes/frontend/public/javascripts/countly.views.js
+++ b/plugins/crashes/frontend/public/javascripts/countly.views.js
@@ -531,6 +531,7 @@
             },
             setSelectedAs: function(state) {
                 var promise;
+                var self = this;
 
                 if (state === "resolved") {
                     promise = this.$store.dispatch("countlyCrashes/overview/setSelectedAsResolved", this.$data.selectedCrashgroups);
@@ -553,6 +554,11 @@
 
                 if (typeof promise !== "undefined") {
                     promise.finally(function() {
+                        // Reset selection if command is delete or hide
+                        if (["delete", "hide"].includes(state)) {
+                            self.selectedCrashgroups = [];
+                            self.$refs.dataTable.$refs.elTable.clearSelection();
+                        }
                         CountlyHelpers.notify({
                             title: jQuery.i18n.map["configs.changed"],
                             message: jQuery.i18n.map["configs.saved"]

--- a/plugins/crashes/frontend/public/localization/crashes.properties
+++ b/plugins/crashes/frontend/public/localization/crashes.properties
@@ -109,6 +109,7 @@ crashes.posted_comment = Posted
 crashes.edit = Edit
 crashes.cancel = Cancel
 crashes.edited_comment = Edited
+crashes.alert-fails = Some operations were not succesful
 crashes.confirm-delete = Are you sure you want to delete this crash?
 crashes.confirm-comment-delete = Are you sure you want to delete this comment?
 crashes.resolved-users = Resolved upgrades

--- a/plugins/crashes/frontend/public/templates/overview.html
+++ b/plugins/crashes/frontend/public/templates/overview.html
@@ -12,7 +12,7 @@
             </cly-header>
             <cly-main>
                 <cly-qb-bar v-if="hasDrillPermission" feature="crashes" class="bu-mb-5" v-model="crashgroupsFilter" :property-source-config="{drill: false}" queryStore="crashgroups" :additionalProperties="crashgroupsFilterProperties" :additionalRules="crashgroupsFilterRules" format="crashgroups"></cly-qb-bar>
-                <cly-datatable-n :data-source="remoteTableDataSource" @selection-change="handleSelectionChange" :available-dynamic-cols="tableDynamicCols" :persist-key="tablePersistKey">
+                <cly-datatable-n :data-source="remoteTableDataSource" @selection-change="handleSelectionChange" :available-dynamic-cols="tableDynamicCols" :persist-key="tablePersistKey" ref="dataTable">
                     <template v-slot="scope">
                         <el-table-column type="selection" reserve-selection width="65" fixed="left"></el-table-column>
                         <el-table-column :label="errorColumnLabel" min-width="415" fixed="left">

--- a/plugins/crashes/frontend/public/templates/overview.html
+++ b/plugins/crashes/frontend/public/templates/overview.html
@@ -12,7 +12,7 @@
             </cly-header>
             <cly-main>
                 <cly-qb-bar v-if="hasDrillPermission" feature="crashes" class="bu-mb-5" v-model="crashgroupsFilter" :property-source-config="{drill: false}" queryStore="crashgroups" :additionalProperties="crashgroupsFilterProperties" :additionalRules="crashgroupsFilterRules" format="crashgroups"></cly-qb-bar>
-                <cly-datatable-n :data-source="remoteTableDataSource" @selection-change="handleSelectionChange" @row-click="handleRowClick" :available-dynamic-cols="tableDynamicCols" :persist-key="tablePersistKey">
+                <cly-datatable-n :data-source="remoteTableDataSource" @selection-change="handleSelectionChange" :available-dynamic-cols="tableDynamicCols" :persist-key="tablePersistKey">
                     <template v-slot="scope">
                         <el-table-column type="selection" reserve-selection width="65" fixed="left"></el-table-column>
                         <el-table-column :label="errorColumnLabel" min-width="415" fixed="left">


### PR DESCRIPTION
- Remove table row click handler so user will not navigate to other page when trying to click row checkbox
- Make sure that row selection is reset when action is done
- Check failed crash group deletion and show failed crash group deletion with a popup