### PR TITLE
[SER-344] Don't display the vue-tabs element in the view when there is only 1 option

### DIFF
--- a/frontend/express/public/javascripts/countly/vue/components/nav.js
+++ b/frontend/express/public/javascripts/countly/vue/components/nav.js
@@ -152,7 +152,7 @@
             }
         },
         template: '<div>\
-                        <div class="cly-vue-tabs">\
+                        <div v-if="tabs && tabs.length > 1" class="cly-vue-tabs">\
                             <div :class="tabListClasses">\
                                 <div\
                                     v-for="tab in tabs"\


### PR DESCRIPTION
uses `v-if` to only display tab, if numbers of tabs > 1