### PR TITLE
[SER-365] Preserve crash filter

### DIFF
--- a/plugins/crashes/frontend/public/javascripts/countly.views.js
+++ b/plugins/crashes/frontend/public/javascripts/countly.views.js
@@ -296,45 +296,45 @@
                     });
                 };
 
-                crashMeta.initialize().then(function() {
-                    if (window.countlyQueryBuilder) {
-                        filterProperties.push({
-                            id: "app_version",
-                            name: "App Version",
-                            type: countlyQueryBuilder.PropertyType.LIST,
-                            group: "Detail",
-                            getValueList: getAppVersions
-                        });
-                        filterProperties.push({
-                            id: "opengl",
-                            name: "OpenGL Version",
-                            type: countlyQueryBuilder.PropertyType.LIST,
-                            group: "Detail",
-                            getValueList: getFilterValues("opengl")
-                        });
-                        filterProperties.push({
-                            id: "orientation",
-                            name: "Orientation",
-                            type: countlyQueryBuilder.PropertyType.LIST,
-                            group: "Detail",
-                            getValueList: getFilterValues("orientation")
-                        });
-                        filterProperties.push({
-                            id: "os",
-                            name: "Platform",
-                            type: countlyQueryBuilder.PropertyType.LIST,
-                            group: "Detail",
-                            getValueList: getFilterValues("os")
-                        });
-                        filterProperties.push({
-                            id: "cpu",
-                            name: "CPU",
-                            type: countlyQueryBuilder.PropertyType.LIST,
-                            group: "Detail",
-                            getValueList: getFilterValues("cpu")
-                        });
-                    }
-                });
+                crashMeta.initialize();
+
+                if (window.countlyQueryBuilder) {
+                    filterProperties.push({
+                        id: "app_version",
+                        name: "App Version",
+                        type: countlyQueryBuilder.PropertyType.LIST,
+                        group: "Detail",
+                        getValueList: getAppVersions
+                    });
+                    filterProperties.push({
+                        id: "opengl",
+                        name: "OpenGL Version",
+                        type: countlyQueryBuilder.PropertyType.LIST,
+                        group: "Detail",
+                        getValueList: getFilterValues("opengl")
+                    });
+                    filterProperties.push({
+                        id: "orientation",
+                        name: "Orientation",
+                        type: countlyQueryBuilder.PropertyType.LIST,
+                        group: "Detail",
+                        getValueList: getFilterValues("orientation")
+                    });
+                    filterProperties.push({
+                        id: "os",
+                        name: "Platform",
+                        type: countlyQueryBuilder.PropertyType.LIST,
+                        group: "Detail",
+                        getValueList: getFilterValues("os")
+                    });
+                    filterProperties.push({
+                        id: "cpu",
+                        name: "CPU",
+                        type: countlyQueryBuilder.PropertyType.LIST,
+                        group: "Detail",
+                        getValueList: getFilterValues("cpu")
+                    });
+                }
             }
 
             return {

--- a/plugins/crashes/frontend/public/javascripts/countly.views.js
+++ b/plugins/crashes/frontend/public/javascripts/countly.views.js
@@ -446,6 +446,13 @@
                         query = countlyCrashes.modifyExistsQueries(newValue.query);
                     }
 
+                    if (newValue.query) {
+                        app.navigate("#/crashes/filter/" + JSON.stringify({ query: newValue.query }));
+                    }
+                    else {
+                        app.navigate("#/crashes", true);
+                    }
+
                     return Promise.all([
                         this.$store.dispatch("countlyCrashes/overview/setCrashgroupsFilter", newValue),
                         this.$store.dispatch("countlyCrashes/pasteAndFetchCrashgroups", {query: JSON.stringify(query)})

--- a/plugins/crashes/frontend/public/javascripts/countly.views.js
+++ b/plugins/crashes/frontend/public/javascripts/countly.views.js
@@ -523,8 +523,13 @@
         },
         methods: {
             refresh: function() {
+                var query = {};
+                if (this.crashgroupsFilter.query) {
+                    query = countlyCrashes.modifyExistsQueries(this.crashgroupsFilter.query);
+                }
+
                 return Promise.all([
-                    this.$store.dispatch("countlyCrashes/pasteAndFetchCrashgroups", {query: JSON.stringify(this.crashgroupsFilter.query)}),
+                    this.$store.dispatch("countlyCrashes/pasteAndFetchCrashgroups", {query: JSON.stringify(query)}),
                     this.$store.dispatch("countlyCrashes/overview/refresh")
                 ]);
             },

--- a/plugins/crashes/frontend/public/javascripts/countly.views.js
+++ b/plugins/crashes/frontend/public/javascripts/countly.views.js
@@ -1278,6 +1278,24 @@
         this.renderWhenReady(getOverviewView());
     });
 
+    app.route("/crashes/filter/*query", "crashes", function(rawQuery) {
+        var parsedQuery = null;
+
+        try {
+            parsedQuery = JSON.parse(rawQuery);
+        }
+        catch (err) {
+            // no need to do anything, default parsedQuery is null
+        }
+
+        var view = getOverviewView();
+        view.params = {
+            query: parsedQuery
+        };
+
+        this.renderWhenReady(view);
+    });
+
     app.route("/crashes/:group", "crashgroup", function(group) {
         groupId = group;
         this.renderWhenReady(getCrashgroupView());

--- a/plugins/crashes/frontend/public/javascripts/countly.views.js
+++ b/plugins/crashes/frontend/public/javascripts/countly.views.js
@@ -585,7 +585,17 @@
             }
         },
         beforeCreate: function() {
-            return this.$store.dispatch("countlyCrashes/overview/refresh");
+            var query = {};
+            if (this.$route.params && this.$route.params.query) {
+                query = countlyCrashes.modifyExistsQueries(this.$route.params.query.query);
+
+                this.$store.dispatch("countlyCrashes/overview/setCrashgroupsFilter", this.$route.params.query);
+                this.$store.dispatch("countlyCrashes/pasteAndFetchCrashgroups", {query: JSON.stringify(query)});
+            }
+
+            return Promise.all([
+                this.$store.dispatch("countlyCrashes/overview/refresh")
+            ]);
         }
     });
 


### PR DESCRIPTION
Add crash filter to the url so it is still available after visiting crash detail page. Just like in user profiles.