### PR TITLE
[SER-440] default-properties-are-not-being-applied-on-dual-axis-charts

### DIFF
--- a/frontend/express/public/javascripts/countly/vue/components/vis.js
+++ b/frontend/express/public/javascripts/countly/vue/components/vis.js
@@ -343,7 +343,7 @@
     function mergeWithCustomizer(objValue, srcValue) {
         if (Array.isArray(srcValue) && typeof objValue === 'object') {
             srcValue.forEach(function(value, index) {
-                srcValue[index] = _mergeWith(objValue, value);
+                srcValue[index] = _mergeWith({}, objValue, value);
             });
             return srcValue;
         }


### PR DESCRIPTION
maintains unique properties inside deep nested object instead of replacing it with the last one in array.