### PR TITLE
[SUP-34] [crashes] Add margin to data table in crash overview page

### DIFF
--- a/plugins/crashes/frontend/public/templates/overview.html
+++ b/plugins/crashes/frontend/public/templates/overview.html
@@ -12,7 +12,7 @@
             </cly-header>
             <cly-main>
                 <cly-qb-bar v-if="hasDrillPermission" feature="crashes" class="bu-mb-5" v-model="crashgroupsFilter" :property-source-config="{drill: false}" queryStore="crashgroups" :additionalProperties="crashgroupsFilterProperties" :additionalRules="crashgroupsFilterRules" format="crashgroups"></cly-qb-bar>
-                <cly-datatable-n :data-source="remoteTableDataSource" @selection-change="handleSelectionChange" :available-dynamic-cols="tableDynamicCols" :persist-key="tablePersistKey" ref="dataTable">
+                <cly-datatable-n :data-source="remoteTableDataSource" @selection-change="handleSelectionChange" :available-dynamic-cols="tableDynamicCols" :persist-key="tablePersistKey" ref="dataTable" class="bu-mb-6">
                     <template v-slot="scope">
                         <el-table-column type="selection" reserve-selection width="65" fixed="left"></el-table-column>
                         <el-table-column :label="errorColumnLabel" min-width="415" fixed="left">


### PR DESCRIPTION
This margin is to prevent table footer being blocked by action bar when crash item is selected.