### PR TITLE
[SER-360] Correct crash sorting by app version

### DIFF
--- a/bin/upgrade/22.09/scripts/upgrade_crashgroup_app_version.js
+++ b/bin/upgrade/22.09/scripts/upgrade_crashgroup_app_version.js
@@ -1,0 +1,69 @@
+// This script will add a new field to crashgroup collections based on latest_version
+// This new field can be used to sort crashgroup collection by version in a numerically correct way
+// For example if latest_version is '1.10.2' a new field will be added with the value '100001.100010.100002'
+// When sorted ascending, '1.10.2' ('100001.100010.100002') will come after '1.2.0' ('100001.100002.100000')
+// If latest_version does not follow semantic versioning then its value will be copied to the new field as is
+
+var pluginManager = require('../../../../plugins/pluginManager.js');
+var versionUtils = require('../../../../plugins/crashes/api/parts/version.js');
+
+console.log('Upgrading crashgroup data');
+
+pluginManager.dbConnection().then(async (countlyDb) => {
+    const BATCH_SIZE = 200;
+    const apps = await countlyDb.collection('apps').find({}).project({_id: 1}).toArray();
+
+    for (let idx = 0; idx < apps.length; idx += 1) {
+        const crashgroupCollection = `app_crashgroups${apps[idx]._id}`;
+        const crashgroups = await countlyDb.collection(crashgroupCollection)
+            .find({ _id: { $ne: 'meta' } })
+            .project({ _id: 1, latest_version: 1 })
+            .toArray();
+
+        let updates = [];
+        let errCount = 0;
+
+        for (let idy = 0; idy < crashgroups.length; idy += 1) {
+            const crashgroup = crashgroups[idy];
+            updates.push({
+                updateOne: {
+                    filter: { _id: crashgroup._id },
+                    update: {
+                        $set: { latest_version_for_sort: versionUtils.transformAppVersion(crashgroup.latest_version) }
+                    },
+                },
+            });
+
+            if (updates.length === BATCH_SIZE || idy === crashgroups.length - 1) {
+                try {
+                    await countlyDb.collection(crashgroupCollection).bulkWrite(updates, { ordered: false });
+                }
+                catch (err) {
+                    errCount += 1;
+                    console.error(`Failed updating collection ${crashgroupCollection}`, err);
+                }
+                finally {
+                    updates = [];
+                }
+            }
+        }
+
+        if (errCount === 0) {
+            try {
+                await countlyDb.collection(crashgroupCollection).updateOne(
+                    { _id: 'meta' },
+                    { $set: { latest_version_sorter_added: true } },
+                );
+            }
+            catch (err) {
+                console.error(`Failed updating collection ${crashgroupCollection} meta`, err);
+            }
+        }
+        else {
+            console.error(`${errCount} batches failed when updating collection ${crashgroupCollection}`);
+        }
+    }
+
+    countlyDb.close();
+    console.log('Crashgroup upgrade done');
+});

--- a/frontend/express/public/javascripts/countly/vue/components/datatable.js
+++ b/frontend/express/public/javascripts/countly/vue/components/datatable.js
@@ -274,7 +274,7 @@
                 if (elTableSorting.order) {
                     this.updateControlParams({
                         sort: [{
-                            field: elTableSorting.prop,
+                            field: elTableSorting.column.sortBy || elTableSorting.prop,
                             type: elTableSorting.order === "ascending" ? "asc" : "desc"
                         }]
                     });

--- a/plugins/crashes/api/api.js
+++ b/plugins/crashes/api/api.js
@@ -1030,11 +1030,11 @@ plugins.setConfigs("crashes", {
                                 let obj = {};
                                 let sortByField = columns[params.qstring.iSortCol_0];
 
-                                if (sortByField === 'latest_version' && crashgroupMeta.appVersionSorterAdded) {
+                                if (sortByField === 'latest_version' && crashgroupMeta.latest_version_sorter_added) {
                                     sortByField = 'latest_version_for_sort';
                                 }
 
-                                obj[columns[params.qstring.iSortCol_0]] = (params.qstring.sSortDir_0 === "asc") ? 1 : -1;
+                                obj[sortByField] = (params.qstring.sSortDir_0 === "asc") ? 1 : -1;
                                 cursor.sort(obj);
                             }
                             if (params.qstring.iDisplayStart && params.qstring.iDisplayStart !== 0) {

--- a/plugins/crashes/api/api.js
+++ b/plugins/crashes/api/api.js
@@ -99,23 +99,25 @@ function transformAppVersion(inpVersion) {
     for (let idx = prefixIdx; idx < buildIdx; idx += 1) {
         let item = execResult[idx];
 
-        if (idx >= majorIdx && idx <= patchIdx) {
-            item = 100000 + parseInt(item, 10);
-        }
+        if (item) {
+            if (idx >= majorIdx && idx <= patchIdx) {
+                item = 100000 + parseInt(item, 10);
+            }
 
-        if (idx >= minorIdx && idx <= patchIdx) {
-            item = '.' + item;
-        }
+            if (idx >= minorIdx && idx <= patchIdx) {
+                item = '.' + item;
+            }
 
-        if (idx === preReleaseIdx) {
-            item = '-' + item;
-        }
+            if (idx === preReleaseIdx) {
+                item = '-' + item;
+            }
 
-        if (idx === buildIdx) {
-            item = '+' + item;
-        }
+            if (idx === buildIdx) {
+                item = '+' + item;
+            }
 
-        transformed += item;
+            transformed += item;
+        }
     }
 
     return transformed;

--- a/plugins/crashes/api/api.js
+++ b/plugins/crashes/api/api.js
@@ -1646,6 +1646,7 @@ plugins.setConfigs("crashes", {
         common.db.collection('app_crashgroups' + appId).ensureIndex({"users": 1}, {background: true}, function() {});
         common.db.collection('app_crashgroups' + appId).ensureIndex({"lastTs": 1}, {background: true}, function() {});
         common.db.collection('app_crashgroups' + appId).ensureIndex({"latest_version": 1}, {background: true}, function() {});
+        common.db.collection('app_crashgroups' + appId).ensureIndex({"latest_version_for_sort": 1}, {background: true}, function() {});
         common.db.collection('app_crashgroups' + appId).ensureIndex({"groups": 1}, {background: true}, function() {});
         common.db.collection('app_crashgroups' + appId).ensureIndex({"is_hidden": 1}, {background: true}, function() {});
         common.db.collection('app_crashusers' + appId).ensureIndex({"group": 1, "uid": 1}, {background: true}, function() {});
@@ -1698,6 +1699,7 @@ plugins.setConfigs("crashes", {
             common.db.collection('app_crashgroups' + appId).ensureIndex({"users": 1}, {background: true}, function() {});
             common.db.collection('app_crashgroups' + appId).ensureIndex({"lastTs": 1}, {background: true}, function() {});
             common.db.collection('app_crashgroups' + appId).ensureIndex({"latest_version": 1}, {background: true}, function() {});
+            common.db.collection('app_crashgroups' + appId).ensureIndex({"latest_version_for_sort": 1}, {background: true}, function() {});
             common.db.collection('app_crashgroups' + appId).ensureIndex({"groups": 1}, {background: true}, function() {});
             common.db.collection('app_crashgroups' + appId).ensureIndex({"is_hidden": 1}, {background: true}, function() {});
         });
@@ -1728,6 +1730,7 @@ plugins.setConfigs("crashes", {
             common.db.collection('app_crashgroups' + appId).ensureIndex({"users": 1}, {background: true}, function() {});
             common.db.collection('app_crashgroups' + appId).ensureIndex({"lastTs": 1}, {background: true}, function() {});
             common.db.collection('app_crashgroups' + appId).ensureIndex({"latest_version": 1}, {background: true}, function() {});
+            common.db.collection('app_crashgroups' + appId).ensureIndex({"latest_version_for_sort": 1}, {background: true}, function() {});
             common.db.collection('app_crashgroups' + appId).ensureIndex({"groups": 1}, {background: true}, function() {});
             common.db.collection('app_crashgroups' + appId).ensureIndex({"is_hidden": 1}, {background: true}, function() {});
         });

--- a/plugins/crashes/api/api.js
+++ b/plugins/crashes/api/api.js
@@ -41,6 +41,87 @@ plugins.setConfigs("crashes", {
 * crru - crash resolved user (users who upgraded and got crashes resolved from upgraded vesion)
 */
 
+/**
+ *  Check if an app version string follows some kind of scheme (there is only semantic versioning for now)
+ *  @param {string} inpVersion - an app version string
+ *  @return {array} [regex.exec result, version scheme name]
+ */
+function checkAppVersion(inpVersion) {
+    // Regex is from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+    const semverRgx = /(^v?)(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
+    // Half semver is similar to semver but with only one dot
+    const halfSemverRgx = /(^v?)(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
+
+    let execResult = semverRgx.exec(inpVersion);
+
+    if (execResult) {
+        return [execResult, 'semver'];
+    }
+
+    execResult = halfSemverRgx.exec(inpVersion);
+
+    if (execResult) {
+        return [execResult, 'halfSemver'];
+    }
+
+    return [null, null];
+}
+
+/**
+ *  Transform app version so it will be numerically correct when sorted as a string
+ *  For example '1.10.2' will be transformed to '100001.100010.100002'
+ *  So when sorted ascending it will come after '1.2.0' ('100001.100002.100000')
+ *  @param {string} inpVersion - an app version string
+ *  @return {string} the transformed app version
+ */
+function transformAppVersion(inpVersion) {
+    const [execResult, versionScheme] = checkAppVersion(inpVersion);
+
+    if (execResult === null) {
+        // Version string does not follow any scheme, just return it
+        return inpVersion;
+    }
+
+    let transformed = '';
+    let prefixIdx = 1;
+    let majorIdx = 2;
+    let minorIdx = 3;
+    let patchIdx = 4;
+    let preReleaseIdx = 5;
+    let buildIdx = 6;
+
+    if (versionScheme === 'halfSemver') {
+        patchIdx -= 1;
+        preReleaseIdx -= 1;
+        buildIdx -= 1;
+    }
+
+    for (let idx = prefixIdx; idx < buildIdx; idx += 1) {
+        let item = execResult[idx];
+
+        if (idx >= majorIdx && idx <= patchIdx) {
+            item = 100000 + parseInt(item, 10);
+        }
+
+        if (idx >= minorIdx && idx <= patchIdx) {
+            item = '.' + item;
+        }
+
+        if (idx === preReleaseIdx) {
+            item = '-' + item;
+        }
+
+        if (idx === buildIdx) {
+            item = '+' + item;
+        }
+
+        transformed += item;
+    }
+
+    return transformed;
+}
+
+
 (function() {
     plugins.register("/permissions/features", function(ob) {
         ob.features.push(FEATURE_NAME);
@@ -553,6 +634,7 @@ plugins.setConfigs("crashes", {
                                     groupInsert.is_resolved = false;
                                     groupInsert.startTs = report.ts;
                                     groupInsert.latest_version = report.app_version;
+                                    groupInsert.latest_version_for_sort = transformAppVersion(report.app_version);
                                     groupInsert.error = report.error;
                                     groupInsert.lrid = report._id + "";
 
@@ -671,6 +753,7 @@ plugins.setConfigs("crashes", {
                                         if (!isNew) {
                                             if (crashGroup.latest_version && common.versionCompare(report.app_version.replace(/\./g, ":"), crashGroup.latest_version.replace(/\./g, ":")) > 0) {
                                                 group.latest_version = report.app_version;
+                                                group.latest_version_for_sort = transformAppVersion(report.app_version);
                                                 group.error = report.error;
                                                 group.lrid = report._id + "";
                                             }

--- a/plugins/crashes/api/parts/version.js
+++ b/plugins/crashes/api/parts/version.js
@@ -1,0 +1,90 @@
+/**
+* Module for dealing with versions
+* @module plugins/crashes/api/parts/version
+*/
+
+/**
+ *  Check if a version string follows some kind of scheme (there is only semantic versioning (semver) for now)
+ *  @param {string} inpVersion - an app version string
+ *  @return {array} [regex.exec result, version scheme name]
+ */
+function checkAppVersion(inpVersion) {
+    // Regex is from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+    const semverRgx = /(^v?)(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
+    // Half semver is similar to semver but with only one dot
+    const halfSemverRgx = /(^v?)(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$/;
+
+    let execResult = semverRgx.exec(inpVersion);
+
+    if (execResult) {
+        return [execResult, 'semver'];
+    }
+
+    execResult = halfSemverRgx.exec(inpVersion);
+
+    if (execResult) {
+        return [execResult, 'halfSemver'];
+    }
+
+    return [null, null];
+}
+
+module.exports = {
+    /**
+     *  Transform a version string so it will be numerically correct when sorted
+     *  For example '1.10.2' will be transformed to '100001.100010.100002'
+     *  So when sorted ascending it will come after '1.2.0' ('100001.100002.100000')
+     *  @param {string} inpVersion - an app version string
+     *  @return {string} the transformed app version
+     */
+    transformAppVersion: function(inpVersion) {
+        const [execResult, versionScheme] = checkAppVersion(inpVersion);
+
+        if (execResult === null) {
+            // Version string does not follow any scheme, just return it
+            return inpVersion;
+        }
+
+        // Mark version parts based on semver scheme
+        let prefixIdx = 1;
+        let majorIdx = 2;
+        let minorIdx = 3;
+        let patchIdx = 4;
+        let preReleaseIdx = 5;
+        let buildIdx = 6;
+
+        if (versionScheme === 'halfSemver') {
+            patchIdx -= 1;
+            preReleaseIdx -= 1;
+            buildIdx -= 1;
+        }
+
+        let transformed = '';
+        // Rejoin version parts to a new string
+        for (let idx = prefixIdx; idx < buildIdx; idx += 1) {
+            let part = execResult[idx];
+
+            if (part) {
+                if (idx >= majorIdx && idx <= patchIdx) {
+                    part = 100000 + parseInt(part, 10);
+                }
+
+                if (idx >= minorIdx && idx <= patchIdx) {
+                    part = '.' + part;
+                }
+
+                if (idx === preReleaseIdx) {
+                    part = '-' + part;
+                }
+
+                if (idx === buildIdx) {
+                    part = '+' + part;
+                }
+
+                transformed += part;
+            }
+        }
+
+        return transformed;
+    }
+};

--- a/plugins/crashes/frontend/public/javascripts/countly.models.js
+++ b/plugins/crashes/frontend/public/javascripts/countly.models.js
@@ -58,23 +58,25 @@ function transformAppVersion(inpVersion) {
     for (var idx = prefixIdx; idx < buildIdx; idx += 1) {
         var item = execResult[idx];
 
-        if (idx >= majorIdx && idx <= patchIdx) {
-            item = 100000 + parseInt(item, 10);
-        }
+        if (item) {
+            if (idx >= majorIdx && idx <= patchIdx) {
+                item = 100000 + parseInt(item, 10);
+            }
 
-        if (idx >= minorIdx && idx <= patchIdx) {
-            item = '.' + item;
-        }
+            if (idx >= minorIdx && idx <= patchIdx) {
+                item = '.' + item;
+            }
 
-        if (idx === preReleaseIdx) {
-            item = '-' + item;
-        }
+            if (idx === preReleaseIdx) {
+                item = '-' + item;
+            }
 
-        if (idx === buildIdx) {
-            item = '+' + item;
-        }
+            if (idx === buildIdx) {
+                item = '+' + item;
+            }
 
-        transformed += item;
+            transformed += item;
+        }
     }
 
     return transformed;

--- a/plugins/crashes/frontend/public/javascripts/countly.models.js
+++ b/plugins/crashes/frontend/public/javascripts/countly.models.js
@@ -1,7 +1,7 @@
 /* globals app, countlyCrashSymbols, jQuery, countlyCommon, countlyAuth, countlyGlobal, countlyVue, countlyCrashesEventLogs, countlySession, CV, $ */
 
 /**
- *  Check if an app version string follows some kind of scheme (there is only semantic versioning for now)
+ *  Check if a version string follows some kind of scheme (there is only semantic versioning (semver) for now)
  *  @param {string} inpVersion - an app version string
  *  @return {array} [regex.exec result, version scheme name]
  */
@@ -27,7 +27,7 @@ function checkAppVersion(inpVersion) {
 }
 
 /**
- *  Transform app version so it will be numerically correct when sorted as a string
+ *  Transform a version string so it will be numerically correct when sorted
  *  For example '1.10.2' will be transformed to '100001.100010.100002'
  *  So when sorted ascending it will come after '1.2.0' ('100001.100002.100000')
  *  @param {string} inpVersion - an app version string
@@ -41,7 +41,7 @@ function transformAppVersion(inpVersion) {
         return inpVersion;
     }
 
-    var transformed = '';
+    // Mark version parts based on semver scheme
     var prefixIdx = 1;
     var majorIdx = 2;
     var minorIdx = 3;
@@ -55,27 +55,29 @@ function transformAppVersion(inpVersion) {
         buildIdx -= 1;
     }
 
+    var transformed = '';
+    // Rejoin version parts to a new string
     for (var idx = prefixIdx; idx < buildIdx; idx += 1) {
-        var item = execResult[idx];
+        var part = execResult[idx];
 
-        if (item) {
+        if (part) {
             if (idx >= majorIdx && idx <= patchIdx) {
-                item = 100000 + parseInt(item, 10);
+                part = 100000 + parseInt(part, 10);
             }
 
             if (idx >= minorIdx && idx <= patchIdx) {
-                item = '.' + item;
+                part = '.' + part;
             }
 
             if (idx === preReleaseIdx) {
-                item = '-' + item;
+                part = '-' + part;
             }
 
             if (idx === buildIdx) {
-                item = '+' + item;
+                part = '+' + part;
             }
 
-            transformed += item;
+            transformed += part;
         }
     }
 

--- a/plugins/crashes/frontend/public/javascripts/countly.views.js
+++ b/plugins/crashes/frontend/public/javascripts/countly.views.js
@@ -587,6 +587,13 @@
                         }
                     });
                 }
+            },
+            appVersionSort: function(item1, item2) {
+                if (item1.latest_version_for_sort && item2.latest_version_for_sort) {
+                    return item1.latest_version_for_sort.localeCompare(item2.latest_version_for_sort);
+                }
+
+                return item1.latest_version.localeCompare(item2.latest_version);
             }
         },
         beforeCreate: function() {

--- a/plugins/crashes/frontend/public/templates/crashgroup.html
+++ b/plugins/crashes/frontend/public/templates/crashgroup.html
@@ -389,7 +389,7 @@
                             </template>
                         </el-table-column>
                         <el-table-column prop="device" :label="i18n('crashes.device')" sortable></el-table-column>
-                        <el-table-column prop="app_version" :label="i18n('crashes.app_version')" sortable>
+                        <el-table-column prop="app_version" :label="i18n('crashes.app_version')" sortable sort-by="app_version_for_sort">
                         </el-table-column>
                         <el-table-column v-if="hasUserPermission" :label="i18n('crashes.user')">
                             <template slot-scope="col">

--- a/plugins/crashes/frontend/public/templates/overview.html
+++ b/plugins/crashes/frontend/public/templates/overview.html
@@ -34,7 +34,7 @@
                             <el-table-column v-if="col.value === 'reports'" :key="idx" prop="reports" :label="i18n('crashes.reports')" width="150" sortable></el-table-column>
                             <el-table-column v-if="col.value === 'lastTs'" :key="idx" prop="lastTs" :label="i18n('crashes.last_time')" :formatter="formatDate" width="180" sortable></el-table-column>
                             <el-table-column v-if="col.value === 'users'" :key="idx" prop="users" :label="i18n('crashes.affected-users')" width="170" sortable></el-table-column>
-                            <el-table-column v-if="col.value === 'latest_version'" :key="idx" prop="latest_version" :label="i18n('crashes.latest_app')" width="190" sortable></el-table-column>
+                            <el-table-column v-if="col.value === 'latest_version'" :key="idx" prop="latest_version" :label="i18n('crashes.latest_app')" width="190" sortable :sort-method="appVersionSort"></el-table-column>
                         </template>
                     </template>
                     <template v-slot:bottomline="scope">


### PR DESCRIPTION
This pr adds a new field to `crashgroup` collection based on `crashgroup.latest_version`. This new field can be used to sort crashgroup in a numerically correct way.

The same sorting method is also used for `crashes` but only on the front-end side.