### PR TITLE
[plugins] Update internal-events endpoint access right

### DIFF
--- a/plugins/plugins/api/api.js
+++ b/plugins/plugins/api/api.js
@@ -5,7 +5,7 @@ var plugin = {},
     parser = require('properties-parser'),
     mail = require('../../../api/parts/mgmt/mail.js'),
     plugins = require('../../pluginManager.js'),
-    { validateUser, validateGlobalAdmin, validateAppAdmin } = require('../../../api/utils/rights.js');
+    { validateUser, validateGlobalAdmin, validateAppAdmin, validateRead } = require('../../../api/utils/rights.js');
 
 (function() {
     plugins.register('/i/plugins', function(ob) {
@@ -185,7 +185,7 @@ var plugin = {},
     plugins.register("/o/internal-events", function(ob) {
         var params = ob.params;
 
-        validateGlobalAdmin(params, function() {
+        validateRead(params, 'core', function() {
             var events = [];
             common.arrayAddUniq(events, plugins.internalEvents.concat(plugins.internalDrillEvents));
             common.returnOutput(params, events);


### PR DESCRIPTION
`internal-events` endpoint is used somewhere that is not only for global admin. So the access right has to be adjusted.