### PR TITLE
[SER-528] Move sortBy method into AppsMixin

### DIFF
--- a/frontend/express/public/javascripts/countly/vue/components/sidebar.js
+++ b/frontend/express/public/javascripts/countly/vue/components/sidebar.js
@@ -33,6 +33,38 @@
                     }
                     return active || {};
                 },
+            },
+            methods: {
+                sortBy: function(arrayToSort, sortList) {
+                    if (!sortList.length) {
+                        return arrayToSort;
+                    }
+
+                    var tmpArr = [],
+                        retArr = [];
+
+                    var i;
+                    for (i = 0; i < arrayToSort.length; i++) {
+                        var objId = arrayToSort[i]._id + "";
+                        if (sortList.indexOf(objId) !== -1) {
+                            tmpArr[sortList.indexOf(objId)] = arrayToSort[i];
+                        }
+                    }
+
+                    for (i = 0; i < tmpArr.length; i++) {
+                        if (tmpArr[i]) {
+                            retArr[retArr.length] = tmpArr[i];
+                        }
+                    }
+
+                    for (i = 0; i < arrayToSort.length; i++) {
+                        if (retArr.indexOf(arrayToSort[i]) === -1) {
+                            retArr[retArr.length] = arrayToSort[i];
+                        }
+                    }
+
+                    return retArr;
+                }
             }
         };
 
@@ -282,36 +314,6 @@
                 },
                 onMenuItemClick: function(item) {
                     this.$store.dispatch("countlySidebar/updateSelectedMenuItem", {menu: "analytics", item: item});
-                },
-                sortBy: function(arrayToSort, sortList) {
-                    if (!sortList.length) {
-                        return arrayToSort;
-                    }
-
-                    var tmpArr = [],
-                        retArr = [];
-
-                    var i;
-                    for (i = 0; i < arrayToSort.length; i++) {
-                        var objId = arrayToSort[i]._id + "";
-                        if (sortList.indexOf(objId) !== -1) {
-                            tmpArr[sortList.indexOf(objId)] = arrayToSort[i];
-                        }
-                    }
-
-                    for (i = 0; i < tmpArr.length; i++) {
-                        if (tmpArr[i]) {
-                            retArr[retArr.length] = tmpArr[i];
-                        }
-                    }
-
-                    for (i = 0; i < arrayToSort.length; i++) {
-                        if (retArr.indexOf(arrayToSort[i]) === -1) {
-                            retArr[retArr.length] = arrayToSort[i];
-                        }
-                    }
-
-                    return retArr;
                 },
                 identifySelected: function() {
                     var currLink = Backbone.history.fragment;


### PR DESCRIPTION
The call to `sortBy` method causes error when `AppsMixin` is included into a component that does not have `sortBy` method. So move `sortBy` method into `AppsMixin`.