### PR TITLE
[SER-544] [event] Remove dot at the end of event name

### DIFF
--- a/api/parts/data/events.js
+++ b/api/parts/data/events.js
@@ -86,6 +86,8 @@ countlyEvents.processEvents = function(params) {
                     continue;
                 }
 
+                shortEventName = shortEventName.replace(/\.+$/, '');
+
                 eventCollectionName = "events" + crypto.createHash('sha1').update(shortEventName + params.app_id).digest('hex');
 
                 if (currEvent.segmentation) {
@@ -242,6 +244,8 @@ function processEvents(appEvents, appSegments, appSgValues, params, omitted_segm
         if (!shortEventName) {
             continue;
         }
+
+        shortEventName = shortEventName.replace(/\.+$/, '');
 
         // Create new collection name for the event
         eventCollectionName = "events" + crypto.createHash('sha1').update(shortEventName + params.app_id).digest('hex');


### PR DESCRIPTION
Event keys are being used as subdocument key. If event key ends with `.` the subdocument would be impossible to query since a query like `eventKey..subdocument` will be read as there is an empty field between `eventKey` and `subdocument`