### PR TITLE
Migrate shellcheck rules from rc file to args

### DIFF
--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,8 +1,0 @@
-disable=SC2230
-disable=SC2236
-disable=SC2164
-disable=SC2237
-disable=SC2002
-disable=SC2012
-disable=SC2001
-disable=SC2116

--- a/bin/commands/scripts/shellcheck.sh
+++ b/bin/commands/scripts/shellcheck.sh
@@ -9,6 +9,6 @@ do
           STATUS=1
       fi
   fi
-done < <(find "$DIR/../" -type f  -name "*.sh" -print)
+done < <(find "$DIR/../../../" -type f  -name "*.sh" -print)
 
  exit $STATUS

--- a/bin/commands/scripts/shellcheck.sh
+++ b/bin/commands/scripts/shellcheck.sh
@@ -4,11 +4,11 @@ STATUS=0
 while IFS="" read -r file
 do
   if [[ $file != *"/node_modules/"* ]] && [[ $file != *"/core/"* ]] && [[ $file != *"/bin/scripts/nghttp2/"* ]]; then
-      if ! shellcheck "$file"
+      if ! shellcheck -e SC2230 -e SC2236 -e SC2164 -e SC2237 -e SC2002 -e SC2012 -e SC2001 -e SC2116 "$file"
       then
           STATUS=1
       fi
   fi
-done < <(find "$DIR/../../../" -type f  -name "*.sh" -print)
-  
+done < <(find "$DIR/../" -type f  -name "*.sh" -print)
+
  exit $STATUS


### PR DESCRIPTION
There is inconsistency about reading excludes from rc file between versions, using arguments for excludes as workaround.
ref: https://github.com/koalaman/shellcheck/issues/2534