### PR TITLE
Add form-data package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "express": "4.18.2",
         "express-rate-limit": "6.7.0",
         "express-session": "1.17.3",
+        "form-data": "^4.0.0",
         "formidable": "1.2.2",
         "fs-extra": "10.1.0",
         "geoip-lite": "1.4.7",
@@ -1964,7 +1965,6 @@
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/balanced-match": {
@@ -2612,7 +2612,6 @@
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -3042,7 +3041,6 @@
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -4199,8 +4197,8 @@
     },
     "node_modules/form-data": {
       "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -11125,8 +11123,7 @@
       "version": "3.2.4"
     },
     "asynckit": {
-      "version": "0.4.0",
-      "dev": true
+      "version": "0.4.0"
     },
     "balanced-match": {
       "version": "1.0.2"
@@ -11547,7 +11544,6 @@
     },
     "combined-stream": {
       "version": "1.0.8",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -11831,8 +11827,7 @@
       "version": "2.0.1"
     },
     "delayed-stream": {
-      "version": "1.0.0",
-      "dev": true
+      "version": "1.0.0"
     },
     "delegates": {
       "version": "1.0.0"
@@ -12584,7 +12579,8 @@
     },
     "form-data": {
       "version": "4.0.0",
-      "dev": true,
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "express": "4.18.2",
     "express-rate-limit": "6.7.0",
     "express-session": "1.17.3",
+    "form-data": "^4.0.0",
     "formidable": "1.2.2",
     "fs-extra": "10.1.0",
     "geoip-lite": "1.4.7",


### PR DESCRIPTION
Since `request` is replaced by `got` in next branch [`request.form()`](https://www.npmjs.com/package/request#multipartform-data-multipart-form-uploads) is no longer available. We now have to use `form-data` to modify POST request body for `got`, so `form-data` has to be explicitly set as a dependency.