### PR TITLE
[SER-581] Data Manager ---> Changing the visibility of an unplanned event

### DIFF
--- a/plugins/data-manager/frontend/public/javascripts/countly.views.js
+++ b/plugins/data-manager/frontend/public/javascripts/countly.views.js
@@ -246,6 +246,12 @@
             },
             onSubmit: function(doc) {
                 if (doc.isEditMode) {
+                    if (!doc.status || doc.status === 'unplanned') {
+                        if (!doc.is_visible) {
+                            CountlyHelpers.notify({message: CV.i18n('data-manager.error.event-visibility-error'), sticky: false, type: 'error'});
+                        }
+                        doc.is_visible = true;
+                    }
                     this.$store.dispatch('countlyDataManager/editEvent', doc);
                 }
                 else {


### PR DESCRIPTION
[fix] show error and prevent visibility hidden,when status = 'unplanned'.