### PR TITLE
[SER-617] [crashes] Fix stacktrace section condition check

### DIFF
--- a/plugins/crashes/frontend/public/templates/crashgroup.html
+++ b/plugins/crashes/frontend/public/templates/crashgroup.html
@@ -76,7 +76,7 @@
                     </cly-crashes-dashboard-tile>
                 </div>
             </cly-section>
-            <cly-section id="crash-tabs" v-if="!!(crashgroup && crashgroup.error)">
+            <cly-section id="crash-tabs" v-if="!!(crashgroup && (crashgroup.error || crashgroupUnsymbolicatedStacktrace))">
                 <el-tabs class="crashgroup-detail-tabs" v-model="currentTab" type="card" style="border-radius: 4px;">
                     <el-tab-pane :label="i18n('crashes.stacktrace')" name="stacktrace">
                         <crash-stacktrace :code="(!showSymbolicated && crashgroupUnsymbolicatedStacktrace) ? crashgroupUnsymbolicatedStacktrace : crashgroup.error">


### PR DESCRIPTION
When symbolicated stacktrace is empty, stacktrace section is not shown in crashgroup detail page. This pr fix the condition check for stacktrace section so that it will still be shown when symbolicated stacktrace is empty.