### PR TITLE
Added service,deployment & ingress files for ingestion traffic routing

### DIFF
--- a/bin/docker/k8s/countly-api.yaml
+++ b/bin/docker/k8s/countly-api.yaml
@@ -38,8 +38,8 @@ spec:
             topologyKey: "kubernetes.io/hostname"
       containers:
       - name: countly-api
-        image: countly/api:20.11.2
-#        image: gcr.io/countly-01/api:20.11.2     # Enterprise Edition
+        image: countly/api:23.03
+#        image: gcr.io/countly-01/api:23.03     # Enterprise Edition
         imagePullPolicy: Always
         ports:
         - containerPort: 3001
@@ -47,13 +47,13 @@ spec:
           httpGet:
             path: /o/ping
             port: 3001
-          initialDelaySeconds: 120
-          periodSeconds: 10
-          timeoutSeconds: 3
+          initialDelaySeconds: 300
+          periodSeconds: 30
+          timeoutSeconds: 30
         env:
           - name: COUNTLY_PLUGINS
-            value: "mobile,web,desktop,plugins,density,locale,browser,sources,views,enterpriseinfo,logger,systemlogs,populator,reports,crashes,push,star-rating,slipping-away-users,compare,server-stats,dbviewer,assistant,times-of-day,compliance-hub,alerts,onboarding,consolidate,remote-config,hooks,dashboards"
-            # Enterprise Edition: value: "mobile,web,desktop,plugins,density,locale,browser,sources,views,drill,funnels,retention_segments,flows,cohorts,surveys,remote-config,ab-testing,formulas,activity-map,concurrent_users,revenue,logger,systemlogs,populator,reports,crashes,push,geo,block,users,star-rating,slipping-away-users,compare,server-stats,assistant,dbviewer,crash_symbolication,groups,white-labeling,alerts,times-of-day,compliance-hub,onboarding,active_users,performance-monitoring,config-transfer,consolidate,data-manager,hooks,dashboards,heatmaps"
+            value: "mobile,web,desktop,plugins,density,locale,browser,sources,views,enterpriseinfo,logger,systemlogs,errorlogs,populator,reports,crashes,push,star-rating,slipping-away-users,compare,server-stats,dbviewer,assistant,times-of-day,compliance-hub,alerts,onboarding,consolidate,remote-config,hooks,dashboards"
+            # Enterprise Edition: value: "mobile,web,desktop,plugins,density,locale,browser,sources,views,license,drill,funnels,retention_segments,flows,cohorts,surveys,remote-config,ab-testing,formulas,activity-map,concurrent_users,revenue,logger,systemlogs,errorlogs,populator,reports,crashes,push,geo,block,restrict,users,star-rating,slipping-away-users,compare,server-stats,assistant,dbviewer,crash_symbolication,groups,white-labeling,alerts,times-of-day,compliance-hub,onboarding,active_users,performance-monitoring,config-transfer,consolidate,data-manager,hooks,dashboards,heatmaps"
           - name: COUNTLY_CONFIG_API_FILESTORAGE
             value: "gridfs"
           - name: COUNTLY_CONFIG__MONGODB

--- a/bin/docker/k8s/countly-ingestion-ingress-baremetal_setup.yaml
+++ b/bin/docker/k8s/countly-ingestion-ingress-baremetal_setup.yaml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: countly-tls
+data:
+  tls.crt: YOUR_SSL_CERT_IN_BASE64      # cat cert.crt | base64
+  tls.key: YOUR_SSL_KEY_IN_BASE64       # cat cert.key | base64
+type: kubernetes.io/tls
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: countly-ingress
+  namespace: countly
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+spec:
+  tls:
+  - hosts:
+    - YOUR_HOSTNAME                     # example.count.ly
+    secretName: tls-secret
+  rules:
+  - http:
+      paths:
+      - backend:
+          serviceName: countly-ingestion
+          servicePort: 3001
+        path: /(i.*)
+      - backend:
+          serviceName: countly-ingestion
+          servicePort: 3001
+        path: /(i/bulk.*)
+      - backend:
+          serviceName: countly-api
+          servicePort: 3001
+        path: /(i/.*)
+      - backend:
+          serviceName: countly-api
+          servicePort: 3001
+        path: /(o.*)
+      - backend:
+          serviceName: countly-api
+          servicePort: 3001
+        path: /(o/.*)
+      - backend:
+          serviceName: countly-frontend
+          servicePort: 6001
+        path: /(images/.*)
+      - backend:
+          serviceName: countly-frontend
+          servicePort: 6001
+        path: /(.*)

--- a/bin/docker/k8s/countly-ingestion-ingress-gce.yaml
+++ b/bin/docker/k8s/countly-ingestion-ingress-gce.yaml
@@ -1,0 +1,67 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: countly-tls
+data:
+  tls.crt: YOUR_SSL_CERT_IN_BASE64      # cat cert.crt | base64
+  tls.key: YOUR_SSL_KEY_IN_BASE64       # cat cert.key | base64
+type: kubernetes.io/tls
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: countly-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    kubernetes.io/ingress.global-static-ip-name: "countly-static-ip"
+spec:
+  tls:
+  - hosts:
+    - YOUR_HOSTNAME                     # example.count.ly
+    secretName: countly-tls
+  rules:
+  - host: example.count.ly
+    http:
+      paths:
+      - path: /i
+        pathType: Exact
+        backend:
+          service:
+            name: countly-ingestion
+            port:
+              number: 3001
+      - path: /i/bulk
+        pathType: Exact
+        backend:
+          service:
+            name: countly-ingestion
+            port:
+              number: 3001
+      - path: /i/*
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: countly-api
+            port:
+              number: 3001
+      - path: /o
+        pathType: Prefix
+        backend:
+          service:
+            name: countly-api
+            port:
+              number: 3001
+      - path: /o/*
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: countly-api
+            port:
+              number: 3001
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: countly-frontend
+            port:
+              number: 6001

--- a/bin/docker/k8s/countly-ingestion-ingress.yaml
+++ b/bin/docker/k8s/countly-ingestion-ingress.yaml
@@ -1,0 +1,67 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: countly-tls
+data:
+  tls.crt: YOUR_SSL_CERT_IN_BASE64      # cat cert.crt | base64
+  tls.key: YOUR_SSL_KEY_IN_BASE64       # cat cert.key | base64
+type: kubernetes.io/tls
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: countly-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    kubernetes.io/ingress.global-static-ip-name: "countly-static-ip"
+spec:
+  tls:
+  - hosts:
+    - YOUR_HOSTNAME                     # example.count.ly
+    secretName: countly-tls
+  rules:
+  - host: example.count.ly
+    http:
+      paths:
+      - path: /i
+        pathType: Exact
+        backend:
+          service:
+            name: countly-ingestion
+            port:
+              number: 3001
+      - path: /i/bulk
+        pathType: Exact
+        backend:
+          service:
+            name: countly-ingestion
+            port:
+              number: 3001
+      - path: /i/*
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: countly-api
+            port:
+              number: 3001
+      - path: /o
+        pathType: Prefix
+        backend:
+          service:
+            name: countly-api
+            port:
+              number: 3001
+      - path: /o/*
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: countly-api
+            port:
+              number: 3001
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: countly-frontend
+            port:
+              number: 6001

--- a/bin/docker/k8s/countly-ingestion-ingress.yaml
+++ b/bin/docker/k8s/countly-ingestion-ingress.yaml
@@ -13,7 +13,6 @@ metadata:
   name: countly-ingress
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
-    kubernetes.io/ingress.global-static-ip-name: "countly-static-ip"
 spec:
   tls:
   - hosts:

--- a/bin/docker/k8s/countly-ingestion.yaml
+++ b/bin/docker/k8s/countly-ingestion.yaml
@@ -1,52 +1,41 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: countly-frontend
+  name: countly-ingestion
 spec:
   ports:
-  - port: 6001
+  - port: 3001
     protocol: TCP
-    targetPort: 6001
+    targetPort: 3001
   selector:
-    app: countly-frontend
+    app: countly-ingestion
   type: NodePort
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: countly-frontend-deployment
+  name: countly-ingestion-deployment
 spec:
   selector:
     matchLabels:
-      app: countly-frontend
+      app: countly-ingestion
   replicas: 1
   template:
     metadata:
       labels:
-        app: countly-frontend
+        app: countly-ingestion
     spec:
-      affinity:
-        podAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - mongo
-                - mongodb-replicaset
-            topologyKey: "kubernetes.io/hostname"
       containers:
-      - name: countly-frontend
-        image: countly/frontend:23.03
-#        image: gcr.io/countly-01/frontend:23.03     # Enterprise Edition
+      - name: countly-ingestion
+        image: countly/api:23.03
+#        image: gcr.io/countly-01/api:23.03     # Enterprise Edition
         imagePullPolicy: Always
         ports:
-        - containerPort: 6001
+        - containerPort: 3001
         readinessProbe:
           httpGet:
-            path: /ping
-            port: 6001
+            path: /o/ping
+            port: 3001
           initialDelaySeconds: 300
           periodSeconds: 30
           timeoutSeconds: 30

--- a/bin/docker/k8s/mongo/mongo-single.yaml
+++ b/bin/docker/k8s/mongo/mongo-single.yaml
@@ -40,7 +40,7 @@ spec:
       terminationGracePeriodSeconds: 10
       containers:
         - name: mongo
-          image: mongo:4.4.6
+          image: mongo:6.0.5
           command:
             - mongod
             - "--bind_ip"

--- a/bin/docker/k8s/mongo/values.yaml
+++ b/bin/docker/k8s/mongo/values.yaml
@@ -40,7 +40,7 @@ copyConfigImage:
 # Specs for the MongoDB image
 image:
   repository: mongo
-  tag: 3.6.12
+  tag: 6.0.5
   pullPolicy: IfNotPresent
 
 # Additional environment variables to be set in the container


### PR DESCRIPTION
- Service & Deployment file added for Ingestion based routing
- Ingress file created for GCE,Cloud & Baremetal to match ingestion based routing
- upgraded Mongodb versions for standalone & replicaset setup of k8's
- upgraded countly Image version in api, frontend & ingestion deployment files
- updated delay & timeout period for Readiness probe in all deployment
- updated Plugins to match current list of supported plugins.