### PR TITLE
[SER-631] [crashes] Update latest crash id in crashgroup even if new crash app version is the same as the last

### DIFF
--- a/plugins/crashes/api/api.js
+++ b/plugins/crashes/api/api.js
@@ -18,7 +18,8 @@ plugins.setConfigs("crashes", {
     report_limit: 100,
     grouping_strategy: "error_and_file",
     smart_preprocessing: true,
-    smart_regexes: "{.*?}\n/.*?/"
+    smart_regexes: "{.*?}\n/.*?/",
+    same_app_version_crash_update: false
 });
 
 /**
@@ -677,8 +678,18 @@ plugins.setConfigs("crashes", {
                                             if (crashGroup.latest_version && common.versionCompare(report.app_version.replace(/\./g, ":"), crashGroup.latest_version.replace(/\./g, ":")) > 0) {
                                                 group.latest_version = report.app_version;
                                                 group.latest_version_for_sort = versionUtils.transformAppVersion(report.app_version);
-                                                group.error = report.error;
-                                                group.lrid = report._id + "";
+                                            }
+                                            if (plugins.getConfig('crashes').same_app_version_crash_update) {
+                                                if (crashGroup.latest_version && common.versionCompare(report.app_version.replace(/\./g, ":"), crashGroup.latest_version.replace(/\./g, ":")) >= 0) {
+                                                    group.error = report.error;
+                                                    group.lrid = report._id + "";
+                                                }
+                                            }
+                                            else {
+                                                if (crashGroup.latest_version && common.versionCompare(report.app_version.replace(/\./g, ":"), crashGroup.latest_version.replace(/\./g, ":")) > 0) {
+                                                    group.error = report.error;
+                                                    group.lrid = report._id + "";
+                                                }
                                             }
                                             if (crashGroup.resolved_version && crashGroup.is_resolved && common.versionCompare(report.app_version.replace(/\./g, ":"), crashGroup.resolved_version.replace(/\./g, ":")) > 0) {
                                                 group.is_resolved = false;

--- a/plugins/crashes/frontend/public/localization/crashes.properties
+++ b/plugins/crashes/frontend/public/localization/crashes.properties
@@ -198,6 +198,9 @@ configs.help.crashes-smart_preprocessing = Merges together more groups by removi
 crashes.smart_regexes = Smart regexes to remove information from stacktrace
 configs.help.crashes-smart_regexes = JavaScript regex as string without needed options, one regex per new line, (example removing contents between {} brackets: {.*?}), test: stack.replace(new RegExp(reg, "gim"), "");
 
+crashes.same_app_version_crash_update = Latest crash update
+configs.help.crashes-same_app_version_crash_update = Update latest crash in crashgroup even when incoming crash has the same app version as latest crash
+
 crashes.home.total = Total number of crashes or crash groups occurrences for the applied filter, in the selected time period. 
 crashes.home.unique = Number of crashes (fatal or non-fatal) that occurred uniquely, in the selected time period. Only the first occurrence of the crash is recorded.
 crashes.home.per-session=Number of crashes for the applied filter occurring per session, expressed as a percentage, in the selected time period.


### PR DESCRIPTION
Crashgroup keeps latest crash id as lrid in document. Currently when receiving new crash with same app version as the latest crash, lrid is not updated to the incoming crash id. This pr adds a setting that enables updating latest crash id even if incoming crash app version is the same as the latest crash app version.