### PR TITLE
[SER-708] Issue while deleting event

### DIFF
--- a/plugins/data-manager/frontend/public/javascripts/countly.views.js
+++ b/plugins/data-manager/frontend/public/javascripts/countly.views.js
@@ -767,9 +767,11 @@
                 var rows = this.deleteQueue;
                 var events = [];
                 rows.forEach(function(row) {
-                    events.push(row.key);
+                    var delKey = row.key || row.e || row.name;
+                    events.push(delKey);
                 });
                 this.$store.dispatch('countlyDataManager/deleteEvents', events);
+                this.deleteQueue = null;
                 this.showDeleteDialog = false;
             },
             statusClassObject: statusClassObject,

--- a/plugins/data-manager/frontend/public/templates/events-default.html
+++ b/plugins/data-manager/frontend/public/templates/events-default.html
@@ -6,7 +6,7 @@
         ref="eventsDefaultTable"
         :searchPlaceholder="i18n('data-manager.event-search-placeholder')"
         :rows="events"
-        :keyFn="function(row) {return row.key}"
+        :keyFn="function(row) {return row.key ||row.e || row.name}"
         :indent=0
         :force-loading="isLoading"
         :tracked-fields="trackedFields"
@@ -174,7 +174,7 @@
             {{i18n('data-manager.delete-event-permanently')}}<br/> 
             <small class="color-red-100">{{ i18n('data-manager.delete-event-warning') }}</small>
             <ul>
-             <li v-for="ev in deleteQueue"> {{ev.key}}</li>
+             <li v-for="ev in deleteQueue"> {{ev.key || ev.e || ev.name}}</li>
             </ul>
         </template>
     </cly-confirm-dialog>


### PR DESCRIPTION
- Delete drill_meta of an event by passing `key || e || name` , so it no longer appears in data manager->events.
- blank list of selected events in delete popup fixed:
<img width="403" alt="image" src="https://github.com/Countly/countly-server/assets/18065510/e3eb2541-2de5-4a13-ae56-f89434d471c5">
