### PR TITLE
[SER-719] [crashes] Get build uuid from other in crashes list if latest crash is not in crashes list

### DIFF
--- a/plugins/crashes/frontend/public/javascripts/countly.models.js
+++ b/plugins/crashes/frontend/public/javascripts/countly.models.js
@@ -820,12 +820,22 @@ function transformAppVersion(inpVersion) {
 
                                 crashgroupJson.binary_images = latestCrash && latestCrash.binary_images;
 
+                                let buildUuid = latestCrash && latestCrash.build_uuid;
+
+                                if (!buildUuid) {
+                                    crashgroupJson.data.every(function(item) {
+                                        buildUuid = item.build_uuid;
+
+                                        return !buildUuid;
+                                    });
+                                }
+
                                 var crashes = [{
                                     _id: crashgroupJson.lrid,
                                     os: crashgroupJson.os,
                                     native_cpp: crashgroupJson.native_cpp,
                                     app_version: crashgroupJson.latest_version,
-                                    build_uuid: latestCrash && latestCrash.build_uuid,
+                                    build_uuid: buildUuid,
                                     javascript: crashgroupJson.javascript
                                 }];
 


### PR DESCRIPTION
For iOS crashes and crashgroup, build uuid is needed for symbolication. This build uuid is saved in crash document. Crashgroup will get its build uuid from the latest crash that is saved in crashgroup document.

When opening crashgroup page, crashgroup detail will be displayed along with a list of crashes. In this page crashgroup will try to get build uuid from the list of crashes. The amount of crashes on the list is limited (default is 100), so if there are more crashes than the limit those crashes data will not be available on the page. This causes a problem when the latest crash in crashgroup is not available on the page. Crashgroup cannot get build uuid because the crash is not available so crashgroup cannot be symbolicated.