### PR TITLE
[SER-718] [crashes] Cleanup crashgroup custom field

### DIFF
--- a/bin/upgrade/23.03/scripts/cleanup_crashgroup_custom_field.js
+++ b/bin/upgrade/23.03/scripts/cleanup_crashgroup_custom_field.js
@@ -1,10 +1,10 @@
 const pluginManager = require('../../../../plugins/pluginManager.js');
+const { generateUpdates } = require('../../../../plugins/crashes/api/parts/custom_field.js');
 
 console.log('Cleaning up crashgroup custom fields');
 
 pluginManager.dbConnection().then(async(countlyDb) => {
     const BATCH_SIZE = 200;
-    const MAX_CUSTOM_FIELD_KEYS = 100;
     const apps = await countlyDb.collection('apps').find({}).project({_id: 1}).toArray();
 
     for (let idx = 0; idx < apps.length; idx += 1) {
@@ -17,30 +17,7 @@ pluginManager.dbConnection().then(async(countlyDb) => {
         let updates = [];
 
         for (let idy = 0; idy < crashgroups.length; idy += 1) {
-            const crashgroup = crashgroups[idy];
-            const keysToRemove = {};
-
-            for (const key in crashgroup.custom) {
-                const excessFields = Object.keys(crashgroup.custom[key]).length - MAX_CUSTOM_FIELD_KEYS;
-
-                if (excessFields > 0) {
-                    Object.entries(crashgroup.custom[key])
-                        .sort((a, b) => a[1] - b[1])
-                        .slice(0, excessFields)
-                        .forEach(([k, _]) => keysToRemove[`custom.${key}.${k}`] = '');
-                }
-            }
-
-            if (Object.keys(keysToRemove).length > 0) {
-                updates.push({
-                    updateOne: {
-                        filter: { _id: crashgroups[idy]._id },
-                        update: {
-                            $unset: keysToRemove,
-                        },
-                    },
-                });
-            }
+            updates = updates.concat(generateUpdates(crashgroups[idy]));
 
             if (updates.length === BATCH_SIZE || idy === crashgroups.length - 1) {
                 try {

--- a/bin/upgrade/23.03/scripts/cleanup_crashgroup_custom_field.js
+++ b/bin/upgrade/23.03/scripts/cleanup_crashgroup_custom_field.js
@@ -1,37 +1,10 @@
 const pluginManager = require('../../../../plugins/pluginManager.js');
-const { generateUpdates } = require('../../../../plugins/crashes/api/parts/custom_field.js');
+const { cleanupCustomField } = require('../../../../plugins/crashes/api/parts/custom_field.js');
 
 console.log('Cleaning up crashgroup custom fields');
 
 pluginManager.dbConnection().then(async(countlyDb) => {
-    const BATCH_SIZE = 200;
-    const apps = await countlyDb.collection('apps').find({}).project({_id: 1}).toArray();
-
-    for (let idx = 0; idx < apps.length; idx += 1) {
-        const crashgroupCollection = `app_crashgroups${apps[idx]._id}`;
-        const crashgroups = await countlyDb.collection(crashgroupCollection)
-            .find({ _id: { $ne: 'meta' }, 'custom': { $exists: true } })
-            .project({ custom: 1 })
-            .toArray();
-
-        let updates = [];
-
-        for (let idy = 0; idy < crashgroups.length; idy += 1) {
-            updates = updates.concat(generateUpdates(crashgroups[idy]));
-
-            if (updates.length === BATCH_SIZE || idy === crashgroups.length - 1) {
-                try {
-                    await countlyDb.collection(crashgroupCollection).bulkWrite(updates, { ordered: false });
-                }
-                catch (err) {
-                    console.error(`Failed updating collection ${crashgroupCollection}`, err);
-                }
-                finally {
-                    updates = [];
-                }
-            }
-        }
-    }
+    await cleanupCustomField(countlyDb);
 
     countlyDb.close();
     console.log('Crashgroup cleanup done');

--- a/bin/upgrade/23.03/scripts/cleanup_crashgroup_custom_field.js
+++ b/bin/upgrade/23.03/scripts/cleanup_crashgroup_custom_field.js
@@ -1,0 +1,61 @@
+const pluginManager = require('../../../../plugins/pluginManager.js');
+
+console.log('Cleaning up crashgroup custom fields');
+
+pluginManager.dbConnection().then(async(countlyDb) => {
+    const BATCH_SIZE = 200;
+    const MAX_CUSTOM_FIELD_KEYS = 100;
+    const apps = await countlyDb.collection('apps').find({}).project({_id: 1}).toArray();
+
+    for (let idx = 0; idx < apps.length; idx += 1) {
+        const crashgroupCollection = `app_crashgroups${apps[idx]._id}`;
+        const crashgroups = await countlyDb.collection(crashgroupCollection)
+            .find({ _id: { $ne: 'meta' }, 'custom': { $exists: true } })
+            .project({ custom: 1 })
+            .toArray();
+
+        let updates = [];
+
+        for (let idy = 0; idy < crashgroups.length; idy += 1) {
+            const crashgroup = crashgroups[idy];
+            const keysToRemove = {};
+
+            for (const key in crashgroup.custom) {
+                const excessFields = Object.keys(crashgroup.custom[key]).length - MAX_CUSTOM_FIELD_KEYS;
+
+                if (excessFields > 0) {
+                    Object.entries(crashgroup.custom[key])
+                        .sort((a, b) => a[1] - b[1])
+                        .slice(0, excessFields)
+                        .forEach(([k, _]) => keysToRemove[`custom.${key}.${k}`] = '');
+                }
+            }
+
+            if (Object.keys(keysToRemove).length > 0) {
+                updates.push({
+                    updateOne: {
+                        filter: { _id: crashgroups[idy]._id },
+                        update: {
+                            $unset: keysToRemove,
+                        },
+                    },
+                });
+            }
+
+            if (updates.length === BATCH_SIZE || idy === crashgroups.length - 1) {
+                try {
+                    await countlyDb.collection(crashgroupCollection).bulkWrite(updates, { ordered: false });
+                }
+                catch (err) {
+                    console.error(`Failed updating collection ${crashgroupCollection}`, err);
+                }
+                finally {
+                    updates = [];
+                }
+            }
+        }
+    }
+
+    countlyDb.close();
+    console.log('Crashgroup cleanup done');
+});

--- a/plugins/crashes/api/api.js
+++ b/plugins/crashes/api/api.js
@@ -55,6 +55,10 @@ plugins.setConfigs("crashes", {
                 console.log(err);
             }
         });
+
+        setTimeout(() => {
+            require('../../../api/parts/jobs').job('crashes:cleanup_custom_field').replace().schedule("every 10 minutes");
+        }, 10000);
     });
     var ranges = ["ram", "bat", "disk", "run", "session"];
     var segments = ["os_version", "os_name", "manufacture", "device", "resolution", "app_version", "cpu", "opengl", "orientation", "view", "browser"];

--- a/plugins/crashes/api/jobs/cleanup_custom_field.js
+++ b/plugins/crashes/api/jobs/cleanup_custom_field.js
@@ -1,0 +1,51 @@
+const job = require('../../../../api/parts/jobs/job.js');
+const log = require('../../../../api/utils/log.js')('job:crashes:cleanup_custom_field');
+const pluginManager = require('../../../pluginManager.js');
+
+const { cleanupCustomField } = require('../parts/custom_field.js');
+
+/** class CleanupCustomFieldJob */
+class CleanupCustomFieldJob extends job.Job {
+    /** function run
+     * @param {object} countlyDb - db connection object
+     * @param {function} doneJob - function to call when finishing Job
+     * @param {function} progressJob - fnction to call while running job
+    */
+    run(countlyDb, doneJob, progressJob) {
+        var total = 0;
+        var current = 0;
+        var bookmark = '';
+        log.d('Starting cleanup custom field job');
+
+        /**
+         * check job status periodically
+         */
+        function ping() {
+            log.d('Pinging cleanup custom field job');
+            if (pingTimeout) {
+                progressJob(total, current, bookmark);
+                pingTimeout = setTimeout(ping, 10000);
+            }
+        }
+        var pingTimeout = setTimeout(ping, 10000);
+
+        /**
+         * end job
+         * @returns {varies} job done
+         */
+        function endJob() {
+            log.d('Ending cleanup custom field job');
+            clearTimeout(pingTimeout);
+            pingTimeout = 0;
+            return doneJob();
+        }
+
+        pluginManager.loadConfigs(countlyDb, async() => {
+            await cleanupCustomField(countlyDb);
+
+            return endJob();
+        });
+    }
+}
+
+module.exports = CleanupCustomFieldJob;

--- a/plugins/crashes/api/parts/custom_field.js
+++ b/plugins/crashes/api/parts/custom_field.js
@@ -35,7 +35,43 @@ function generateUpdates(crashgroup) {
     return updates;
 }
 
+/**
+* Cleanup custom field from crashgroup documents
+* @param {Object} countlyDb - db connection object
+* @param {number} BATCH_SIZE - bulk write batch size
+*/
+async function cleanupCustomField(countlyDb, BATCH_SIZE = 200) {
+    const apps = await countlyDb.collection('apps').find({}).project({_id: 1}).toArray();
+
+    for (let idx = 0; idx < apps.length; idx += 1) {
+        const crashgroupCollection = `app_crashgroups${apps[idx]._id}`;
+        const crashgroups = await countlyDb.collection(crashgroupCollection)
+            .find({ _id: { $ne: 'meta' }, 'custom': { $exists: true } })
+            .project({ custom: 1 })
+            .toArray();
+
+        let updates = [];
+
+        for (let idy = 0; idy < crashgroups.length; idy += 1) {
+            updates = updates.concat(generateUpdates(crashgroups[idy]));
+
+            if (updates.length && (updates.length === BATCH_SIZE || idy === crashgroups.length - 1)) {
+                try {
+                    await countlyDb.collection(crashgroupCollection).bulkWrite(updates, { ordered: false });
+                }
+                catch (err) {
+                    console.error(`Failed updating collection ${crashgroupCollection}`, err);
+                }
+                finally {
+                    updates = [];
+                }
+            }
+        }
+    }
+}
+
 module.exports = {
     generateUpdates,
+    cleanupCustomField,
     MAX_CUSTOM_FIELD_KEYS,
 };

--- a/plugins/crashes/api/parts/custom_field.js
+++ b/plugins/crashes/api/parts/custom_field.js
@@ -1,0 +1,41 @@
+const MAX_CUSTOM_FIELD_KEYS = 100;
+
+/**
+* Generate updates for cleaning up custom field from a crashgroup document
+* @param {Object} crashgroup - crashgroup document, it has to contain '_id' and `custom` fields
+* @returns {Object} update queries for mongo bulk update
+*/
+function generateUpdates(crashgroup) {
+    const updates = [];
+    const keysToRemove = {};
+    const customField = crashgroup.custom;
+
+    for (const key in customField) {
+        const excessFields = Object.keys(customField[key]).length - MAX_CUSTOM_FIELD_KEYS;
+
+        if (excessFields > 0) {
+            Object.entries(customField[key])
+                .sort((a, b) => a[1] - b[1])
+                .slice(0, excessFields)
+                .forEach(([k]) => keysToRemove[`custom.${key}.${k}`] = '');
+        }
+    }
+
+    if (Object.keys(keysToRemove).length > 0) {
+        updates.push({
+            updateOne: {
+                filter: { _id: crashgroup._id },
+                update: {
+                    $unset: keysToRemove,
+                },
+            },
+        });
+    }
+
+    return updates;
+}
+
+module.exports = {
+    generateUpdates,
+    MAX_CUSTOM_FIELD_KEYS,
+};


### PR DESCRIPTION
Crashgroup is saving custom field sent by client. When there are too many unique custom fields saved, crashgroup document size gets too big and problems start coming.

To mitigate the problem this pr adds a script that can be run to cleanup custom fields from crashgroup documents. The script will keep 100 custom field key with the most count for each crashgroup document (something like `{ custom: { key1: { id1: 100, id2: 200, …, id100: 20} }, { key2: { id1: 40, id2: 10, …, id100: 5 }}}`).

This pr also adds a background job that runs the script operation every 10 minutes.