### PR TITLE
[SER-750] Set member permission when editing

### DIFF
--- a/api/parts/mgmt/users.js
+++ b/api/parts/mgmt/users.js
@@ -503,6 +503,10 @@ usersApi.updateUser = async function(params) {
     if (updatedMember.admin_of) {
         if (Array.isArray(updatedMember.admin_of) && updatedMember.admin_of.length) {
             updatedMember.permission = updatedMember.permission || {};
+            if (!updatedMember.permission._) {
+                updatedMember.permission._ = {};
+            }
+            updatedMember.permission._.a = updatedMember.admin_of;
             updatedMember.permission.c = updatedMember.permission.c || {};
             updatedMember.permission.r = updatedMember.permission.r || {};
             updatedMember.permission.u = updatedMember.permission.u || {};
@@ -520,6 +524,10 @@ usersApi.updateUser = async function(params) {
     if (updatedMember.user_of) {
         if (Array.isArray(updatedMember.user_of) && updatedMember.user_of.length) {
             updatedMember.permission = updatedMember.permission || {};
+            if (!updatedMember.permission._) {
+                updatedMember.permission._ = {};
+            }
+            updatedMember.permission._.u = [updatedMember.user_of];
             updatedMember.permission.r = updatedMember.permission.r || {};
             for (let i = 0; i < updatedMember.user_of.length; i++) {
                 updatedMember.permission.r[updatedMember.user_of[i]] = updatedMember.permission.r[updatedMember.user_of[i]] || {all: true, allowed: {}};

--- a/test/2.api/05.update.user.js
+++ b/test/2.api/05.update.user.js
@@ -59,6 +59,50 @@ describe('Updating user', function() {
                 });
         });
     });
+    describe('User permission when user is updated', async() => {
+        it('Should set correct permission when user is updated', async() => {
+            API_KEY_ADMIN = testUtils.get("API_KEY_ADMIN");
+            // Create new user
+            const params = JSON.stringify({
+                full_name: 'testedit1',
+                username: 'testedit1',
+                password: 'p4ssw0rD!',
+                email: 'testedit1@mail.co',
+            });
+
+            let sp = new URLSearchParams();
+            sp.append('api_key', API_KEY_ADMIN);
+            sp.append('args', params);
+
+            const response = await request.get(`/i/users/create?${sp.toString()}`);
+            const userId = response.body._id;
+
+            const editParams = JSON.stringify({user_id: userId, admin_of: ['appId']});
+
+            sp = new URLSearchParams();
+            sp.append('api_key', API_KEY_ADMIN);
+            sp.append('args', editParams);
+
+            const editResponse = await request.get(`/i/users/update?${sp.toString()}`);
+
+            should(editResponse.status).equal(200);
+
+            sp = new URLSearchParams();
+            sp.append('api_key', API_KEY_ADMIN);
+
+            const allUserResponse = await request.get(`/o/users/all?${sp.toString()}`);
+            const user = allUserResponse.body[userId];
+
+            should(user.permission._.a).deepEqual(['appId']);
+
+            // Delete user
+            sp = new URLSearchParams();
+            sp.append('api_key', API_KEY_ADMIN);
+            sp.append('args', JSON.stringify({ user_ids: [userId] }));
+
+            await request.get(`/i/users/delete?${sp.toString()}`);
+        });
+    });
     describe('Update user permission when app is deleted', async() => {
         it('Should update user permission when app is deleted', async() => {
             API_KEY_ADMIN = testUtils.get("API_KEY_ADMIN");


### PR DESCRIPTION
When a member is edited through API, the member permission is broken.
This is because the API can still receive old permission parameters but it does not generate the correct permission object from those parameters (related doc [/i/users/update](https://api.count.ly/reference/iusersupdate) ).
This pr updates the API so that it can generate correct permission based on the old permission parameters.