### PR TITLE
Handle partial permission object in depCheck

### DIFF
--- a/api/parts/mgmt/users.js
+++ b/api/parts/mgmt/users.js
@@ -385,7 +385,7 @@ async function depCheck(params) {
         //check permission dependency for each app
         const crudTypes = ["c", "r", "u", "d"];
         crudTypes.forEach(function(crudType) {
-            let apps = params.qstring.args.permission[crudType];
+            let apps = params.qstring.args.permission[crudType] || {};
             Object.keys(apps).forEach(function(app) {
                 let feats = apps[app].allowed;
                 Object.keys(feats).forEach(function(feat) {


### PR DESCRIPTION
handle permission object with missing _CRUD_, ex: `{ _: { a: [], u: [] } }`

![image](https://github.com/Countly/countly-server/assets/18065510/90237741-68a1-4e7b-ac8f-6703dd5058b1)
