### PR TITLE
[SER-760] request form bugfix

### DIFF
--- a/api/utils/countly-request/index.js
+++ b/api/utils/countly-request/index.js
@@ -171,7 +171,7 @@ async function uploadFormFile(url, fileData, callback) {
 module.exports.post = function(uri, options, callback) {
     var params = initParams(uri, options, callback);
     if (params.options && (params.options.url || params.options.uri)) {
-        if (params.options.form) {
+        if (params.options.form && params.options.form.fileStream && params.options.form.fileField) {
             // If options include a form, use uploadFormFile
             const { url, form } = params.options;
             uploadFormFile(url || params.options.uri, form, params.callback);


### PR DESCRIPTION
fileFormUpload was called when request.form exists. This was not correct. form can exists but it may not be file upload. This was breaking AD Plugin