### PR TITLE
[SER-809]

### DIFF
--- a/plugins/compliance-hub/frontend/public/javascripts/countly.views.js
+++ b/plugins/compliance-hub/frontend/public/javascripts/countly.views.js
@@ -616,7 +616,7 @@
                     return this.$store.getters["countlyConsentManager/isLoading"];
                 }
             },
-            mounted: function() {
+            beforeCreate: function() {
                 var userDetails = this.$store.getters["countlyUsers/userDetailsResource/userDetails"];
                 if (userDetails.uid) {
                     this.$store.dispatch("countlyConsentManager/uid", userDetails.uid);


### PR DESCRIPTION
### Issue
Currently initial consent fetch request is made without uid (this fetches consent records of all users),
and when component is mounted we get uid and make another request with uid (now we get only the required user data) which overwrites the previous fetched data.


[[fix] initial fetch call has uid now](https://github.com/Countly/countly-server/commit/8fd070a0c491ffbf8a993b6e127384b899883404)