### PR TITLE
[SER-959] Fix localization for systemlogs.preventIPTracking

### DIFF
--- a/plugins/systemlogs/frontend/public/localization/systemlogs.properties
+++ b/plugins/systemlogs/frontend/public/localization/systemlogs.properties
@@ -25,6 +25,7 @@ systemlogs.for-crash = For Crash
 systemlogs.for-id = For ID
 systemlogs.data = Data
 configs.systemlogs-preventIPTracking = Disable IP Tracking
+systemlogs.preventIPTracking = Disable IP Tracking
 configs.help.systemlogs-preventIPTracking = Do not record IP address of actions taken by the users
 
 systemlogs.action.logout = Logout


### PR DESCRIPTION
in <countly>/plugins/plugins/frontend/public/templates/configuration.html at line 50, getLabelName(key) looks up systemlogs.preventIPTracking as the key is preventIPTracking. 