### PR TITLE
[bugfix][data points]

### DIFF
--- a/plugins/server-stats/api/api.js
+++ b/plugins/server-stats/api/api.js
@@ -32,7 +32,7 @@ const FEATURE_NAME = 'server-stats';
     function eventCountMapper(events) {
         const eventCountMap = {};
         for (let i = 0; i < events.length; i++) {
-            const eventKeyCount = events[i].count || 1;
+            const eventKeyCount = 1;
 
             if (stats.internalEventsEnum[events[i].key]) {
                 eventCountMap[stats.internalEventsEnum[events[i].key]] = eventKeyCount + (eventCountMap[stats.internalEventsEnum[events[i].key]] || 0);


### PR DESCRIPTION
When counting data points . If in request event segment count =2, it still has to count as single data point