### PR TITLE
[SER-1072] Email reports timing out

### DIFF
--- a/api/utils/pdf.js
+++ b/api/utils/pdf.js
@@ -40,7 +40,6 @@ exports.renderPDF = async function(html, callback, options = null, puppeteerArgs
         else {
             browser = await puppeteer.launch();
         }
-        //TODO:TEST
         const updatedTimeout = 240000;
         const page = await browser.newPage();
 

--- a/api/utils/render.js
+++ b/api/utils/render.js
@@ -153,6 +153,9 @@ exports.renderView = function(options, cb) {
                                 log.d("BLOCK 1:  miss me with this 304");
                                 return true; //TODO:TEST
                             }
+                            else {
+                                return false;
+                            }
 
                         },
                         { timeout: updatedTimeout }
@@ -176,6 +179,9 @@ exports.renderView = function(options, cb) {
                                 else if (response.status() === 304) {
                                     log.d("BLOCK 2:  miss me with this 304");
                                     return true; //TODO:TEST
+                                }
+                                else {
+                                    return false;
                                 }
 
                             },

--- a/api/utils/render.js
+++ b/api/utils/render.js
@@ -62,10 +62,7 @@ exports.renderView = function(options, cb) {
 
             var settings = {
                 headless: true,
-                args: ['--no-sandbox', '--disable-setuid-sandbox',
-                    //'--disable-dev-shm-usage',    //TODO:TEST
-                    //'--enable-features=NetworkService'
-                ],
+                args: ['--no-sandbox', '--disable-setuid-sandbox'],
                 ignoreHTTPSErrors: true,
                 userDataDir: pathModule.resolve(__dirname, "../../dump/chrome")
             };
@@ -79,18 +76,6 @@ exports.renderView = function(options, cb) {
             try {
                 log.d('Started rendering images');
                 var page = await browser.newPage();
-
-                //TODO:TEST
-                //await page.setRequestInterception(true);
-                // page.on('request', (request) => {
-                //     if (request.url().includes('session_check')) {
-                //         request.abort();
-                //         console.log("------------------------- aborted the session_check call");
-                //     }
-                //     else {
-                //         request.continue();
-                //     }
-                // });
 
                 page.on('console', (msg) => {
                     log.d("Headless chrome page log", msg.text());
@@ -163,8 +148,6 @@ exports.renderView = function(options, cb) {
                     );
                 }
 
-                //TODO:TEST
-                //await timeout(1500);
                 await timeout(500);
 
                 await page.evaluate(cbFn, options);
@@ -192,7 +175,6 @@ exports.renderView = function(options, cb) {
                     }
                 }
 
-                //await timeout(2500); //TODO:TEST
                 await timeout(1500);
 
                 await page.setViewport({
@@ -217,12 +199,6 @@ exports.renderView = function(options, cb) {
                 await page.evaluate(beforeScrnCbFn, options);
 
                 await timeout(1500);
-
-                //TODO:TEST
-                // await page.waitForNetworkIdle({
-                //     idleTime: 5000, // Consider the network idle after 5 seconds of no activity
-                //     timeout: 100000, // Timeout after 100 seconds
-                // });
 
                 var image = "";
                 var screenshotOptions = {

--- a/api/utils/render.js
+++ b/api/utils/render.js
@@ -131,7 +131,7 @@ exports.renderView = function(options, cb) {
                     await page.waitForResponse(
                         function(response) {
                             var url = response.url();
-                            log.d("BLOCK 1 STATUS, URL", response.status(), url);
+                            log.d("waitForRegex - Response Status: " + response.status() + ", URL: " + url);
                             if (waitForRegex.test(url) && response.status() === 200) {
                                 return true;
                             }
@@ -153,7 +153,7 @@ exports.renderView = function(options, cb) {
                         await page.waitForResponse(
                             function(response) {
                                 var url = response.url();
-                                log.d("BLOCK 2 STATUS, URL", response.status(), url);
+                                log.d("waitForRegexAfterCbfn - Response Status: " + response.status() + ", URL: " + url);
                                 if (waitForRegex.test(url) && response.status() === 200) {
                                     return true;
                                 }

--- a/api/utils/render.js
+++ b/api/utils/render.js
@@ -77,6 +77,7 @@ exports.renderView = function(options, cb) {
             var browser = await puppeteer.launch(settings);
 
             try {
+                log.d('Started rendering images');
                 var page = await browser.newPage();
 
                 //TODO:TEST
@@ -145,7 +146,7 @@ exports.renderView = function(options, cb) {
                     await page.waitForResponse(
                         function(response) {
                             var url = response.url();
-                            log.d("BLOCK 1 STATUS, URL", response.status(), url());
+                            log.d("BLOCK 1 STATUS, URL", response.status(), url);
                             if (waitForRegex.test(url) && response.status() === 200) {
                                 return true;
                             }
@@ -173,6 +174,7 @@ exports.renderView = function(options, cb) {
                         await page.waitForResponse(
                             function(response) {
                                 var url = response.url();
+                                log.d("BLOCK 2 STATUS, URL", response.status(), url);
                                 if (waitForRegex.test(url) && response.status() === 200) {
                                     return true;
                                 }
@@ -277,7 +279,7 @@ exports.renderView = function(options, cb) {
                     image: image,
                     path: path
                 };
-                log.d('render.js Finished rendering images');
+                log.d('Finished rendering images');
                 return cb(null, imageData);
             }
             catch (e) {

--- a/api/utils/render.js
+++ b/api/utils/render.js
@@ -135,10 +135,6 @@ exports.renderView = function(options, cb) {
                             if (waitForRegex.test(url) && response.status() === 200) {
                                 return true;
                             }
-                            else if (response.status() === 304) {
-                                log.d("BLOCK 1:  miss me with this 304");
-                                return true; //TODO:TEST
-                            }
                             else {
                                 return false;
                             }
@@ -160,10 +156,6 @@ exports.renderView = function(options, cb) {
                                 log.d("BLOCK 2 STATUS, URL", response.status(), url);
                                 if (waitForRegex.test(url) && response.status() === 200) {
                                     return true;
-                                }
-                                else if (response.status() === 304) {
-                                    log.d("BLOCK 2:  miss me with this 304");
-                                    return true; //TODO:TEST
                                 }
                                 else {
                                     return false;

--- a/api/utils/render.js
+++ b/api/utils/render.js
@@ -277,7 +277,7 @@ exports.renderView = function(options, cb) {
                     image: image,
                     path: path
                 };
-
+                log.d('render.js Finished rendering images');
                 return cb(null, imageData);
             }
             catch (e) {

--- a/plugins/dashboards/api/api.js
+++ b/plugins/dashboards/api/api.js
@@ -1375,7 +1375,7 @@ plugins.setConfigs("dashboards", {
                                 //$(".funnels table colgroup col:last-child").width("80px");
                                 //};
 
-                                options.waitForRegex = new RegExp(/o\/dashboards?/gi);
+                                options.waitForRegex = new RegExp(/o\/dashboards?/i);
 
                                 options.id = "#content";
 

--- a/plugins/dashboards/frontend/public/templates/email.html
+++ b/plugins/dashboards/frontend/public/templates/email.html
@@ -80,7 +80,7 @@
                     <td style="padding: 30px 0px 30px 0px;" class="logo" align="center">
                         <table border="0" cellpadding="0" cellspacing="0" width="100%" >
                             <tr>
-                                <td bgcolor="#ffffff" width="100" align="left"><a href="<%= version.page %>" target="_blank"><img alt="Logo" src="<%= host %>/images/pre-login/countly-logo-dark.png" width="150" style="display: block; font-family: Helvetica, Arial, sans-serif; color: #666666; font-size: 16px;" border="0"></a></td>
+                                <td bgcolor="#ffffff" width="100" align="left"><a href="<%= version.page %>" target="_blank"><img alt="Logo" src="<%= typeof localhost !== 'undefined' ? localhost : host %>/images/pre-login/countly-logo-dark.png" width="150" style="display: block; font-family: Helvetica, Arial, sans-serif; color: #666666; font-size: 16px;" border="0"></a></td>
                             </tr>
                         </table>
                     </td>
@@ -99,7 +99,7 @@
                     <td>
                         <table width="100%" align="center" border="0" cellspacing="0" cellpadding="0">
                             <tr>
-                                <td align="center" style="padding-top: 0px;" ><img alt="Dashboard" src="<%= host %>/dashboards/images/screenshots/<%= image.name %>" width="750" style="display: block;" border="0"></img></td>
+                                <td align="center" style="padding-top: 0px;" ><img alt="Dashboard" src="<%= typeof localhost !== 'undefined' ? localhost : host %>/dashboards/images/screenshots/<%= image.name %>" width="750" style="display: block;" border="0"></img></td>
                             </tr>
                         </table>
                     </td>

--- a/plugins/reports/api/reports.js
+++ b/plugins/reports/api/reports.js
@@ -673,7 +673,7 @@ var metricProps = {
                 if (report.sendPdf === true) {
                     //use localhost for pdf generation instead of domain
                     //it prevents the issue when one server has local files and loadbalancer sends the request to another server
-                    let emailFiller = message.data;
+                    let emailFiller = Object.assign({}, message.data);
                     emailFiller.localhost = (process.env.COUNTLY_CONFIG_PROTOCOL || "http") + "://" + countlyConfig.web.host + ':' + countlyConfig.web.port + countlyConfig.path;
                     const htmlForPdf = ejs.render(message.template, emailFiller);
                     pdf.renderPDF(htmlForPdf, function() {

--- a/plugins/reports/api/reports.js
+++ b/plugins/reports/api/reports.js
@@ -649,7 +649,9 @@ var metricProps = {
                 if (!html && message.data && message.template) { // report from dashboard
                     const msg = reports.genUnsubscribeCode(report, report.emails[i]);
                     message.data.unsubscribe_link = message.data.host + "/unsubscribe_report?data=" + encodeURIComponent(msg);
-                    html = ejs.render(message.template, message.data);
+                    let emailFiller = message.data;
+                    emailFiller.host = 'http://localhost';
+                    html = ejs.render(message.template, emailFiller);
                 }
                 const msg = {
                     to: report.emails[i],


### PR DESCRIPTION
 - use `localhost` for pdf generation instead of domain because it prevents the issue when one server has local files and loadbalancer sends the request to another server
 - added try/catch, proper logs & default navigation timeout for pdf generation.
 - explicit return for `page.waitForResponse`