### PR TITLE
Fixed TypeError currEvent.key.indexOf is not a function

### DIFF
--- a/api/parts/data/events.js
+++ b/api/parts/data/events.js
@@ -56,7 +56,12 @@ countlyEvents.processEvents = function(params) {
             for (let i = 0; i < params.qstring.events.length; i++) {
 
                 if (typeof params.qstring.events[i].key !== 'string') {
-                    params.qstring.events[i].key = stringifyEventKey(params.qstring.events[i].key);
+                    try {
+                        params.qstring.events[i].key = JSON.stringify(params.qstring.events[i].key);
+                    }
+                    catch (error) {
+                        params.qstring.events[i].key += "";
+                    }
                 }
 
                 var currEvent = params.qstring.events[i],
@@ -89,7 +94,6 @@ countlyEvents.processEvents = function(params) {
                     continue;
                 }
                 eventCollectionName = "events" + crypto.createHash('sha1').update(shortEventName + params.app_id).digest('hex');
-
                 if (currEvent.segmentation) {
 
                     for (var segKey in currEvent.segmentation) {
@@ -183,20 +187,6 @@ countlyEvents.processEvents = function(params) {
 
                     callback(null, retObj);
                 });
-            }
-
-            /**
-             * Stringify an event key
-             * @param {object} obj - Object to be stringified
-             * @returns {object} returns obj stringified
-             **/
-            function stringifyEventKey(obj) {
-                try {
-                    return JSON.stringify(obj);
-                }
-                catch (error) {
-                    return obj + "";
-                }
             }
         });
     });

--- a/api/parts/data/events.js
+++ b/api/parts/data/events.js
@@ -54,9 +54,11 @@ countlyEvents.processEvents = function(params) {
             }
 
             for (let i = 0; i < params.qstring.events.length; i++) {
-                if (params.qstring.events[i]) {
-                    params.qstring.events[i] += "";
+
+                if (typeof params.qstring.events[i].key !== 'string') {
+                    params.qstring.events[i].key = stringifyEventKey(params.qstring.events[i].key);
                 }
+
                 var currEvent = params.qstring.events[i],
                     shortEventName = "",
                     eventCollectionName = "";
@@ -181,6 +183,20 @@ countlyEvents.processEvents = function(params) {
 
                     callback(null, retObj);
                 });
+            }
+
+            /**
+             * Stringify an event key
+             * @param {object} obj - Object to be stringified
+             * @returns {object} returns obj stringified
+             **/
+            function stringifyEventKey(obj) {
+                try {
+                    return JSON.stringify(obj);
+                }
+                catch (error) {
+                    return obj + "";
+                }
             }
         });
     });

--- a/api/parts/data/events.js
+++ b/api/parts/data/events.js
@@ -54,9 +54,13 @@ countlyEvents.processEvents = function(params) {
             }
 
             for (let i = 0; i < params.qstring.events.length; i++) {
+                if (params.qstring.events[i]) {
+                    params.qstring.events[i] += "";
+                }
                 var currEvent = params.qstring.events[i],
                     shortEventName = "",
                     eventCollectionName = "";
+
                 if (!currEvent.segmentation) {
                     continue;
                 }


### PR DESCRIPTION
Changes for this bug report,
https://countly.slack.com/archives/C0469N7GX24/p1710826591407139

Tested for requests with events keys,
- events=[{"key":"1"}]
- events=[{"key":1}]
- events=[{"key":null}]
- &events=[{"key":{"object":"ob"}}]