### PR TITLE
[component-ui-fix] Width of cly-event-select component is fixed

### DIFF
--- a/frontend/express/public/javascripts/countly/vue/components/helpers.js
+++ b/frontend/express/public/javascripts/countly/vue/components/helpers.js
@@ -544,7 +544,7 @@
                     :single-option-settings="singleOptionSettings"\
                     :adaptive-length="adaptiveLength"\
                     :arrow="arrow"\
-                    :width="computedWidth"\
+                    :width="width"\
                     v-bind="$attrs"\
                     v-on="$listeners">\
                     <template v-slot:header="selectScope">\
@@ -564,7 +564,7 @@
                     return [];
                 }
             },
-            width: { type: [Number, Object, String]},
+            width: { type: [Number, Object, String], default: 'fit-content'},
             adaptiveLength: {type: Boolean, default: true},
             arrow: {type: Boolean, default: false},
             title: { type: String, require: false},
@@ -581,9 +581,6 @@
             };
         },
         computed: {
-            computedWidth: function() {
-                return this.width || 400;
-            },
             hasTitle: function() {
                 return !!this.title;
             },
@@ -686,11 +683,6 @@
                 return availableEvents;
             }
         },
-        created: function() {
-            if (this.adaptiveLength && this.width === 400 && this.availableEvents.length > 0) {
-                this.width = this.availableEvents * 80;
-            }
-        }
     }));
 
     Vue.component("cly-paginate", countlyBaseComponent.extend({


### PR DESCRIPTION
In next branch, cly-event-select component works broken in some places such as funnels drawer and cohorts drawers.
There is a default 400px from cly-select-x. In most places, content does not fit into the component because width value is not given when calling component. Therefore, I added 'fit-content' as a default value in prop. 

The calculation, for this [task](https://countly.atlassian.net/browse/SER-777),  in created() has been removed as unnecessary. And I also checked if it affected place where it was used in this task.
Also I removed computedWidth field as unnecessary again(https://github.com/Countly/countly-server/commit/cb71ac2e1b3eba4320a9fdc2ef966e6c7a7efc1f) It won't give error anymore as we removed the assignment width prop in created()

please contact me if you have any concerns @Cookiezaurs 