### PR TITLE
[SER-1444] update on the alert data type options for CE

### DIFF
--- a/plugins/alerts/frontend/public/javascripts/countly.views.js
+++ b/plugins/alerts/frontend/public/javascripts/countly.views.js
@@ -350,6 +350,12 @@
                 if (!countlyGlobal.plugins.includes("revenue")) {
                     alertDataTypeOptions = alertDataTypeOptions.filter(({ value }) => value !== "revenue");
                 }
+                if (!countlyGlobal.plugins.includes("cohorts")) {
+                    alertDataTypeOptions = alertDataTypeOptions.filter(({ value }) => value !== "cohorts" && value !== "profile_groups");
+                }
+                if (!countlyGlobal.plugins.includes("users")) {
+                    alertDataTypeOptions = alertDataTypeOptions.filter(({ value }) => value !== "users");
+                }
                 return alertDataTypeOptions;
             },
             alertDefine: function() {


### PR DESCRIPTION
data types which is the plugins that belong to the enterprise version are not listed on the community edition version anymore