### PR TITLE
[SER-1088] Flutter stacktrace

### DIFF
--- a/plugins/crashes/api/parts/stacktrace.js
+++ b/plugins/crashes/api/parts/stacktrace.js
@@ -417,7 +417,8 @@ var trace = {
         }
         else {
             parts = crash.error.replace(/^\s*\n/gim, "\n").split("\n\n");
-            if (parts.length > 1) {
+            const isFlutter = /flutter|\.dart/i.test(crash.error);
+            if (parts.length > 1 && !isFlutter) {
                 crash.error = null;
                 threads = [];
                 for (let i = 0; i < parts.length; i++) {

--- a/plugins/crashes/tests.js
+++ b/plugins/crashes/tests.js
@@ -3095,13 +3095,39 @@ describe('Testing Crashes', function() {
     describe('Flutter stacktrace', async() => {
         it('should return flutter stacktrace correctly', async() => {
             const crashData = {
+                // this is a malformed stacktrace from sdk with two newlines after the first line
                 '_error': 'java.lang.Exception: IntegerDivisionByOneException\n\n%230      int (dart:core-patch/integers.dart:30:7)\n%231      CrashReportingPage.dividedByZero (package:countly_flutter_example/page_crash_reporting.dart:49:31)\n%232      _InkResponseState.handleTap (package:flutter/src/material/ink_well.dart:1183:21)',
                 '_os_version': '8.2',
                 '_os': 'Android',
                 '_app_version': '78.0.0',
             };
 
-            await request.get(`/i?app_key=${APP_KEY}&device_id=${DEVICE_ID}&crash=${JSON.stringify(crashData)}`);
+            await request.get(`/i?app_key=${APP_KEY}&device_id=${DEVICE_ID}&crash=${JSON.stringify(crashData)}`).expect(200);
+            const crashGroupQuery = JSON.stringify({
+                os: crashData._os,
+                latest_version: crashData._app_version,
+            });
+
+            let crashGroupResponse = await request
+                .get(`/o?method=crashes&api_key=${API_KEY_ADMIN}&app_id=${APP_ID}&query=${crashGroupQuery}`);
+            const crashGroup = crashGroupResponse.body.aaData[0];
+
+            should(crashGroup.error).equal(common.escape_html(crashData._error.replaceAll('%23', '#')));
+
+            await request
+                .get('/i/crashes/delete?args=' + JSON.stringify({ crash_id: crashGroup._id }) + '&app_id=' + APP_ID + '&api_key=' + API_KEY_ADMIN);
+        });
+
+        it('should return flutter stacktrace correctly', async() => {
+            const crashData = {
+                // this is how a normal stacktrace should look like with just one newline after the first line
+                '_error': 'java.lang.Exception: IntegerDivisionByOneException\n%230      int (dart:core-patch/integers.dart:30:7)\n%231      CrashReportingPage.dividedByZero (package:countly_flutter_example/page_crash_reporting.dart:49:31)\n%232      _InkResponseState.handleTap (package:flutter/src/material/ink_well.dart:1183:21)',
+                '_os_version': '8.2',
+                '_os': 'Android',
+                '_app_version': '78.0.0',
+            };
+
+            await request.get(`/i?app_key=${APP_KEY}&device_id=${DEVICE_ID}&crash=${JSON.stringify(crashData)}`).expect(200);
             const crashGroupQuery = JSON.stringify({
                 os: crashData._os,
                 latest_version: crashData._app_version,

--- a/plugins/crashes/tests.js
+++ b/plugins/crashes/tests.js
@@ -3093,7 +3093,7 @@ describe('Testing Crashes', function() {
     });
 
     describe('Flutter stacktrace', async() => {
-        it('should return flutter stacktrace correctly', async() => {
+        it('should return double newline flutter stacktrace correctly', async() => {
             const crashData = {
                 // this is a malformed stacktrace from sdk with two newlines after the first line
                 '_error': 'java.lang.Exception: IntegerDivisionByOneException\n\n%230      int (dart:core-patch/integers.dart:30:7)\n%231      CrashReportingPage.dividedByZero (package:countly_flutter_example/page_crash_reporting.dart:49:31)\n%232      _InkResponseState.handleTap (package:flutter/src/material/ink_well.dart:1183:21)',
@@ -3118,7 +3118,7 @@ describe('Testing Crashes', function() {
                 .get('/i/crashes/delete?args=' + JSON.stringify({ crash_id: crashGroup._id }) + '&app_id=' + APP_ID + '&api_key=' + API_KEY_ADMIN);
         });
 
-        it('should return flutter stacktrace correctly', async() => {
+        it('should return normal flutter stacktrace correctly', async() => {
             const crashData = {
                 // this is how a normal stacktrace should look like with just one newline after the first line
                 '_error': 'java.lang.Exception: IntegerDivisionByOneException\n%230      int (dart:core-patch/integers.dart:30:7)\n%231      CrashReportingPage.dividedByZero (package:countly_flutter_example/page_crash_reporting.dart:49:31)\n%232      _InkResponseState.handleTap (package:flutter/src/material/ink_well.dart:1183:21)',

--- a/plugins/crashes/tests.js
+++ b/plugins/crashes/tests.js
@@ -1,6 +1,7 @@
 var request = require('supertest');
 var should = require('should');
 var testUtils = require("../../test/testUtils");
+const common = require('../../api/utils/common');
 request = request(testUtils.url);
 
 var APP_KEY = "";
@@ -3088,6 +3089,32 @@ describe('Testing Crashes', function() {
             const crash = crashGroupResponse.body.data[0];
 
             crash.binary_images.should.equal(JSON.stringify(crashData._binary_images));
+        });
+    });
+
+    describe('Flutter stacktrace', async() => {
+        it('should return flutter stacktrace correctly', async() => {
+            const crashData = {
+                '_error': 'java.lang.Exception: IntegerDivisionByOneException\n\n%230      int (dart:core-patch/integers.dart:30:7)\n%231      CrashReportingPage.dividedByZero (package:countly_flutter_example/page_crash_reporting.dart:49:31)\n%232      _InkResponseState.handleTap (package:flutter/src/material/ink_well.dart:1183:21)',
+                '_os_version': '8.2',
+                '_os': 'Android',
+                '_app_version': '78.0.0',
+            };
+
+            await request.get(`/i?app_key=${APP_KEY}&device_id=${DEVICE_ID}&crash=${JSON.stringify(crashData)}`);
+            const crashGroupQuery = JSON.stringify({
+                os: crashData._os,
+                latest_version: crashData._app_version,
+            });
+
+            let crashGroupResponse = await request
+                .get(`/o?method=crashes&api_key=${API_KEY_ADMIN}&app_id=${APP_ID}&query=${crashGroupQuery}`);
+            const crashGroup = crashGroupResponse.body.aaData[0];
+
+            should(crashGroup.error).equal(common.escape_html(crashData._error.replaceAll('%23', '#')));
+
+            await request
+                .get('/i/crashes/delete?args=' + JSON.stringify({ crash_id: crashGroup._id }) + '&app_id=' + APP_ID + '&api_key=' + API_KEY_ADMIN);
         });
     });
 


### PR DESCRIPTION
Flutter stacktrace is formatted like

```
java.lang.Exception: IntegerDivisionByZeroException
--> there's an extra newline here
#0      int.~/ (dart:core-patch/integers.dart:30:7)
#1      etc...
--> another extra newline here
at ly.count.dart.countly_flutter.CountlyFlutterPlugin.onMethodCall(CountlyFlutterPlugin.java:394)
```

Because of the extra newline it's being treated as multithread. But it's not actually multithreaded so it's not processed correctly by the backend and hence it's not showing up in the frontend.

This pr adds detection for flutter stacktrace so that it can be processed correctly and be shown in the frontend. 


Note: The extra newline is actually coming from sdk, so in the future the sdk should be updated to  remove the extra newline.