### PR TITLE
[SER-1600] [crashes] Process app version as string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 Fixes:
 - [script] Fixing bug with "delete_old_members" script that led to malformed requests
 - [core] Fixed bug where changing passwords results in the loss of the "Global Admin" role
+- [crash] Fixed bug in crash ingestion for scenarios where the "app version" is not a string.
 
 ## Version 24.05.17
 Fixes:

--- a/plugins/crashes/api/api.js
+++ b/plugins/crashes/api/api.js
@@ -464,6 +464,9 @@ plugins.setConfigs("crashes", {
                         }
                         updateUser.hadAnyNonfatalCrash = report.ts;
                     }
+                    if ('app_version' in report && typeof report.app_version !== 'string') {
+                        report.app_version += '';
+                    }
                     let updateData = {$inc: {}};
                     updateData.$inc["data.crashes"] = 1;
                     if (Object.keys(updateUser).length) {

--- a/plugins/crashes/tests.js
+++ b/plugins/crashes/tests.js
@@ -3091,6 +3091,35 @@ describe('Testing Crashes', function() {
         });
     });
 
+    describe('Crash app version', async() => {
+        it('should process crash app version as string', async() => {
+            const crashData = {
+                "_error": "error",
+                "_app_version": 123, // app version is number
+                "_os": "android",
+            };
+
+            await request.get('/i')
+                .query({ app_key: APP_KEY, device_id: DEVICE_ID, crash: JSON.stringify(crashData) })
+                .expect(200);
+
+            const crashGroupQuery = JSON.stringify({
+                latest_version: { $in: [`${crashData._app_version}`] },
+            });
+            let crashGroupResponse = await request
+                .get('/o')
+                .query({ method: 'crashes', api_key: API_KEY_ADMIN, app_id: APP_ID, query: crashGroupQuery });
+            const crashGroup = crashGroupResponse.body.aaData[0];
+            crashGroupResponse = await request
+                .get(`/o?`)
+                .query({ method: 'crashes', api_key: API_KEY_ADMIN, app_id: APP_ID, group: crashGroup._id });
+
+            const crash = crashGroupResponse.body.data[0];
+
+            crash.app_version.should.equal(`${crashData._app_version}`);
+        });
+    });
+
     describe('Reset app', function() {
         it('should reset data', function(done) {
             var params = {app_id: APP_ID, period: "reset"};


### PR DESCRIPTION
Crash app version is being processed everywhere as a string. But the dashboard can receive the app version as a number which will cause an error somewhere. To prevent that error, turn all incoming crash app version into a string.