### PR TITLE
Optimisation suggestions for nginx 

### DIFF
--- a/bin/config/nginx.conf
+++ b/bin/config/nginx.conf
@@ -1,11 +1,14 @@
 user www-data;
-worker_processes 4;
+worker_processes auto;  # Changed to auto to match CPU cores
+worker_cpu_affinity auto;
 worker_rlimit_nofile 40000;
 pid /var/run/nginx.pid;
 
 events {
         worker_connections 20000;
-        # multi_accept on;
+        use epoll;
+        multi_accept on; # Added multi_accept with accept_mutex off and epoll
+        accept_mutex off;
 }
 
 http {
@@ -23,6 +26,21 @@ http {
         server_tokens off;
         proxy_pass_header Server;
 
+        # Proxy buffering settings
+        proxy_request_buffering off; # Optimization for large buffers`
+        proxy_buffering on;  # Enable buffering for responses for throughput optimization
+        proxy_buffer_size 16k;
+        proxy_buffers 4 32k;
+        proxy_busy_buffers_size 64k;
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+
+
+        # Sets the HTTP protocol version for proxying. By default, version 1.0 is used. Version 1.1 is recommended for use with keepalive connections
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+
         # server_names_hash_bucket_size 64;
         # server_name_in_redirect off;
 
@@ -34,7 +52,36 @@ http {
         ##
 
         access_log off;
-        error_log /var/log/nginx/error.log;
+        error_log /var/log/nginx/error.log error; # Added log level
+
+        ##
+        # Brotli Settings
+        ##
+
+        brotli on;
+        brotli_comp_level 6;
+        brotli_static on;
+        brotli_min_length 256;
+        brotli_types
+            application/javascript
+            application/json
+            application/vnd.ms-fontobject
+            application/x-font-opentype
+            application/x-font-truetype
+            application/x-font-ttf
+            application/x-javascript
+            font/eot
+            font/opentype
+            font/otf
+            font/truetype
+            image/svg+xml
+            image/vnd.microsoft.icon
+            image/x-icon
+            image/x-win-bitmap
+            text/css
+            text/javascript
+            text/plain
+            text/xml;
 
         ##
         # Gzip Settings
@@ -46,9 +93,34 @@ http {
         gzip_vary on;
         gzip_proxied any;
         gzip_comp_level 6;
-        # gzip_buffers 16 8k;
-        # gzip_http_version 1.1;
-        gzip_types text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript;
+        gzip_min_length 256;  # Added minimum length
+        gzip_types
+            application/atom+xml
+            application/javascript
+            application/json
+            application/vnd.ms-fontobject
+            application/x-font-opentype
+            application/x-font-truetype
+            application/x-font-ttf
+            application/x-javascript
+            application/xml
+            font/eot
+            font/opentype
+            font/otf
+            font/truetype
+            image/svg+xml
+            image/vnd.microsoft.icon
+            image/x-icon
+            image/x-win-bitmap
+            text/css
+            text/javascript
+            text/plain
+            text/xml;
+
+       # Request body settings
+       client_body_buffer_size 16k;
+       client_body_timeout 30s;
+       client_max_body_size 100m;
 
         ##
         # Virtual Host Configs


### PR DESCRIPTION
## Changed as these perform better on modern kernels for higher throughput and concurrency
```
use epoll;
multi_accept on; # Added multi_accept with accept_mutex off and epoll
accept_mutex off;
```

## Added brotli 

## Sets the HTTP protocol version for proxying. By default, version 1.0 is used. Version 1.1 is recommended for use with  keepalive

Enables keep-alive by default, can consider making it `upgrade`?
```
       keepalive connections
        proxy_http_version 1.1;
        proxy_set_header Connection "";
```
        

## Post request buffers
```       # Request body settings
       client_body_buffer_size 16k;
       client_body_timeout 30s;
       client_max_body_size 100m;
```