### PR TITLE
fixed mongo7 and 2412 upgrade scripts

### DIFF
--- a/bin/upgrade/24.12/upgrade.mongo.70.sh
+++ b/bin/upgrade/24.12/upgrade.mongo.70.sh
@@ -117,6 +117,15 @@ if [ -f /etc/redhat-release ]; then
     systemctl daemon-reload
 fi
 
+# check and comment out journal: enabled: true in mongod.conf
+CONF_FILE="/etc/mongod.conf"
+if grep -qP '^\s*journal\s*:\s*$' "$CONF_FILE" && grep -qP '^\s*enabled\s*:\s*true\s*$' "$CONF_FILE"; then
+    echo "Commenting out journal: enabled: true in $CONF_FILE"
+    sed -i '/^\s*journal\s*:/ { N; s/\(.*\n\s*\)\(enabled\s*:\s*true\s*$\)/# \1# \2/ }' "$CONF_FILE"
+else
+    echo "Could not find 'journal: enabled: true' in $CONF_FILE or it's already commented."
+fi
+
 #mongodb might need to be started
 systemctl restart mongod || echo "mongodb systemctl job does not exist"
 

--- a/bin/upgrade/24.12/upgrade_db.sh
+++ b/bin/upgrade/24.12/upgrade_db.sh
@@ -22,8 +22,8 @@ then
 
     if [ "$1" != "combined" ]; then
         #upgrade plugins
-        countly plugin enable journey_engine;
         countly plugin enable content;
+        countly plugin enable journey_engine;        
         nodejs "$DIR/scripts/install_plugins.js"
     fi
     

--- a/bin/upgrade/24.12/upgrade_db.sh
+++ b/bin/upgrade/24.12/upgrade_db.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-VER="24.10"
+VER="24.12"
 
 CONTINUE="$(countly check before upgrade db "$VER")"
 

--- a/bin/upgrade/24.12/upgrade_fs.sh
+++ b/bin/upgrade/24.12/upgrade_fs.sh
@@ -2,7 +2,7 @@
 
 echo "Running filesystem modifications"
 
-VER="24.10"
+VER="24.12"
 
 CONTINUE="$(countly check before upgrade fs "$VER")"
 
@@ -23,8 +23,8 @@ then
     #enable command line
     bash "$DIR/scripts/detect.init.sh"
     
-    countly plugin enable journey_engine;
     countly plugin enable content;
+    countly plugin enable journey_engine;
 
     #upgrade plugins
     nodejs "$DIR/scripts/install_plugins.js"


### PR DESCRIPTION
- Added step to disable/comment out journal: enabled: true in mongod.conf as its deprecated post mongo 6
- Fixed version info in both fs & db script
- As journey_engine plugin is dependent on content plugin, ammended the steps to install content plugins first.