### PR TITLE
[SER-2207] User can create journey with past time.

### DIFF
--- a/frontend/express/public/javascripts/countly/vue/components/date.js
+++ b/frontend/express/public/javascripts/countly/vue/components/date.js
@@ -1660,9 +1660,48 @@
                 type: Boolean,
                 default: true,
                 required: false
+            },
+            minDateValue: {
+                type: Date
+            },
+            isFuture: {
+                type: Boolean,
+                default: false
             }
         },
-        template: '<el-time-picker :append-to-body="appendToBody" :style="{\'width\': width + \'px\'}" class="cly-vue-time-picker" v-bind="$attrs" v-on="$listeners" :format="format" :clearable="clearable"></el-time-picker>'
+        computed: {
+            pickerOptions() {
+                const defaultRange = { selectableRange: '00:00:00 - 23:59:00' };
+
+                if (!this.minDateValue) {
+                    return defaultRange;
+                }
+
+                const now = moment();
+                const minDateMoment = moment(this.minDateValue);
+                const isToday = minDateMoment.isSame(now, 'day');
+
+                if (this.isFuture && isToday) {
+                    return {
+                        selectableRange: `${now.format('HH:mm:ss')} - 23:59:00`
+                    };
+                }
+
+                return defaultRange;
+            }
+        },
+        template: `
+                <el-time-picker
+                    :append-to-body="appendToBody"
+                    :clearable="clearable"
+                    :format="format"
+                    :picker-options="pickerOptions"
+                    :style="{\'width\': width + \'px\'}"
+                    class="cly-vue-time-picker"
+                    v-bind="$attrs"
+                    v-on="$listeners"
+                >
+                </el-time-picker>`
     });
 
 

--- a/frontend/express/public/javascripts/countly/vue/templates/datepicker.html
+++ b/frontend/express/public/javascripts/countly/vue/templates/datepicker.html
@@ -207,7 +207,7 @@
                         <span class="text-medium">{{i18n('common.time')}}</span>
                     </div>
                     <div>
-                        <cly-time-picker align="right" :width="100" v-model="minTime"></cly-time-picker>
+                        <cly-time-picker align="right" :width="100" v-model="minTime" :min-date-value="minDate" :is-future="isFuture"></cly-time-picker>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
If "isFuture" prop is true, disable past time slots when the date is selected is today. 
for [reference](https://element.eleme.io/#/en-US/component/time-picker#timepicker)