### PR TITLE
Events are not listed in the cly-event-select component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Features:
 - [system-utility] New endpoint: /take-heap-snapshot.
 - [system-utility] Using nodejs fs to write profiler files instead of gridfs.
 
+Enterprise fixes:
+- [drill] Fixed empty events list in drill section
+ 
 ## Version 24.05.22
 Features:
 - [core] Add self tracking capability

--- a/frontend/express/public/javascripts/countly/vue/components/helpers.js
+++ b/frontend/express/public/javascripts/countly/vue/components/helpers.js
@@ -1,4 +1,4 @@
-/* global Vue, CV, app, countlyEvent, countlyGlobal, countlyAuth, VueJsonPretty, ElementTiptapPlugin, countlyCommon CountlyHelpers*/
+/* global Vue, CV, $, app, countlyEvent, countlyGlobal, countlyAuth, VueJsonPretty, ElementTiptapPlugin, countlyCommon CountlyHelpers*/
 
 (function(countlyVue) {
 

--- a/frontend/express/public/stylesheets/vue/clyvue.scss
+++ b/frontend/express/public/stylesheets/vue/clyvue.scss
@@ -4181,3 +4181,12 @@
         }
     }		
 }
+
+.cly-event-select {
+    &__loading {
+        display: flex;
+        margin-top:0;
+        position: unset;
+        top:0;
+    }
+}


### PR DESCRIPTION
Problem:
The events selected in the cly-event-select component are not listed again after the page is refreshed

Solution: Fetched available events asynchronously to ensure data is loaded before rendering the component and added a loading panel for waiting time