### PR TITLE
[SER-2235] - Save button naming in survey drawer

### DIFF
--- a/frontend/express/public/javascripts/countly/vue/templates/drawer.html
+++ b/frontend/express/public/javascripts/countly/vue/templates/drawer.html
@@ -89,8 +89,8 @@
                     <div class="cly-vue-drawer__buttons is-multi-step is-single-step bu-is-justify-content-flex-end bu-is-flex" v-if="isMultiStep">
                         <el-button :data-test-id="testId + '-cancel-button'" type="secondary" @click="doClose" size="small" v-if="currentStepIndex === 0 && hasCancelButton" :disabled="isSubmitPending">{{cancelButtonLabel}}</el-button>
                         <el-button :data-test-id="testId + '-previous-step-button'" type="secondary" @click="prevStep" size="small" v-if="currentStepIndex > 0" :disabled="isSubmitPending">{{i18n('common.drawer.previous-step')}}</el-button>
-                        <el-button :data-test-id="testId + '-next-step-button'" type="success" @click="nextStep" size="small" v-if="!isLastStep" :class="{'is-disabled':!isCurrentStepValid}" :disabled="isSubmitPending">{{i18n('common.drawer.next-step')}}</el-button>
-                        <el-button :data-test-id="testId + '-save-button'" type="success" @click="submit" :loading="isSubmitPending" size="small" v-if="isLastStep" :class="{'is-disabled':!isSubmissionAllowed}" :disabled="isSubmitPending">{{saveButtonLabel}}</el-button>
+                        <el-button :data-test-id="testId + '-next-step-button'" type="success" :key="isLastStep" @click="nextStep" size="small" v-if="!isLastStep" :class="{'is-disabled':!isCurrentStepValid}" :disabled="isSubmitPending">{{i18n('common.drawer.next-step')}}</el-button>
+                        <el-button :data-test-id="testId + '-save-button'" type="success" :key="isLastStep" @click="submit" :loading="isSubmitPending" size="small" v-if="isLastStep" :class="{'is-disabled':!isSubmissionAllowed}" :disabled="isSubmitPending">{{saveButtonLabel}}</el-button>
                     </div>
                     <div class="cly-vue-drawer__buttons is-single-step is-single-step bu-is-justify-content-flex-end bu-is-flex" v-if="!isMultiStep">
                         <el-button :data-test-id="testId + '-cancel-button'" type="secondary" @click="doClose" size="small" v-if="hasCancelButton" :disabled="isSubmitPending">{{cancelButtonLabel}}</el-button>


### PR DESCRIPTION
While creating the survey, if the user clicks on the "+Add Condition" button to add User Behavior Segmentation, the "Complete" button on the Review page changes to "Next step".