### PR TITLE
made node GPG key install idempotent to avoid re-download errors

### DIFF
--- a/bin/countly.install_ubuntu.sh
+++ b/bin/countly.install_ubuntu.sh
@@ -57,7 +57,9 @@ sudo apt-get install -y nginx
 sudo apt-get update
 sudo apt-get install -y ca-certificates curl gnupg
 sudo mkdir -p /etc/apt/keyrings
-curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+if [ ! -f /etc/apt/keyrings/nodesource.gpg ]; then
+    curl -fsSL "https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key" | sudo gpg --batch --yes --dearmor -o /etc/apt/keyrings/nodesource.gpg
+fi
 NODE_MAJOR=20
 echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list
 sudo apt-get update


### PR DESCRIPTION
Changes prevents the "gpg: cannot open '/dev/tty'" error that occurred during reinstallation, fix makes the script check for existing security keys first and added flags to run non-interactively. Tested the changes with both fresh install and reinstall.