### PR TITLE
[fix] Hooks: Added null check for incoming data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Enterprise Features:
 
 Fixes:
 - [core] Unifying alphabetical order for dropdowns with dashboard apps
+- [hooks] Added null check for incoming data
 
 Enterprise Fixes:
 - [content] Asset URL was wrongly constructed when user switches between apps

--- a/plugins/hooks/api/parts/triggers/incoming_data.js
+++ b/plugins/hooks/api/parts/triggers/incoming_data.js
@@ -189,6 +189,9 @@ class IncomingDataTrigger {
          */
         function assertOperation(value, filterObj) {
             var matched = true;
+            if (typeof value === 'undefined' || value === null) {
+                return false;
+            }
             if (filterObj.$in && filterObj.$in.indexOf(value) === -1) {
                 matched = false;
             }


### PR DESCRIPTION
Problem:
- If a filter (custom user property) defined inside the hooks does not exist in the incoming data getting an error.

Solution:
- Added null check