### PR TITLE
Fix/docker python vulnerabilities

### DIFF
--- a/Dockerfile-api
+++ b/Dockerfile-api
@@ -30,14 +30,14 @@ RUN apt-get update && \
 RUN apt-get update && \
 	apt-get upgrade -y && \
 	cd /usr/src && \
-	wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-	tar -xf Python-3.8.12.tar.xz && \
+	wget https://www.python.org/ftp/python/3.8.20/Python-3.8.20.tar.xz && \
+	tar -xf Python-3.8.20.tar.xz && \
 	apt-get install -y build-essential sudo zlib1g-dev libssl3 libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libsqlite3-dev libreadline-dev libffi-dev curl libbz2-dev && \
-	cd Python-3.8.12 && \
+	cd Python-3.8.20 && \
 	./configure --enable-optimizations --enable-shared && \
 	make && \
 	make altinstall && \
-	ldconfig /usr/src/Python-3.8.12 && \
+	ldconfig /usr/src/Python-3.8.20 && \
 	ln -s /usr/local/bin/python3.8 /usr/bin/python3
 
 RUN curl -s -L -o /tmp/tini.deb "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini_${TINI_VERSION}.deb" && \
@@ -55,6 +55,7 @@ RUN curl -s -L -o /tmp/tini.deb "https://github.com/krallin/tini/releases/downlo
 	HOME=/tmp npm install argon2 --build-from-source --unsafe-perm=true --allow-root && \
 	./bin/docker/preinstall.sh && \
 	bash /opt/countly/bin/scripts/detect.init.sh && \
+	python3.8 -m pip install --upgrade pip setuptools && \
 	\
 	# cleanup & chown
 	npm remove -y --no-save mocha nyc should supertest && \

--- a/Dockerfile-api
+++ b/Dockerfile-api
@@ -38,7 +38,7 @@ RUN apt-get update && \
 	make && \
 	make altinstall && \
 	ldconfig /usr/src/Python-3.8.20 && \
-	ln -s /usr/local/bin/python3.8 /usr/bin/python3
+	ln -sf /usr/local/bin/python3.8 /usr/bin/python3
 
 RUN curl -s -L -o /tmp/tini.deb "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini_${TINI_VERSION}.deb" && \
 	dpkg -i /tmp/tini.deb && \
@@ -59,11 +59,12 @@ RUN curl -s -L -o /tmp/tini.deb "https://github.com/krallin/tini/releases/downlo
 	\
 	# cleanup & chown
 	npm remove -y --no-save mocha nyc should supertest && \
+        apt-get purge -y python3 python3-pip python3-distutils python3-setuptools && \
 	apt-get remove -y git gcc g++ make automake autoconf libtool pkg-config unzip sqlite3 wget && \
 	apt-get install -y libgbm-dev libgbm1 gconf-service libasound2 libatk1.0-0 libatk-bridge2.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils && \
 	apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
-	rm -rf test /tmp/* /tmp/.??* /var/tmp/* /var/tmp/.??* /var/log/* /root/.npm && \
-        rm -f /usr/local/lib/python3.8/ensurepip/_bundled/*.whl && rm -rf /usr/src/Python* && \
+        apt-get autoremove -y && \
+	rm -rf test /tmp/* /tmp/.??* /var/tmp/* /var/tmp/.??* /var/log/* /root/.npm /usr/local/lib/python3.8/ensurepip/_bundled/*.whl /usr/src/Python* /var/lib/dpkg/info/python3* && \
 	\
 	# temporary to remove npm bug message
 	mkdir /.npm && chown -R 1001:0 /.npm && \

--- a/Dockerfile-api
+++ b/Dockerfile-api
@@ -62,6 +62,7 @@ RUN curl -s -L -o /tmp/tini.deb "https://github.com/krallin/tini/releases/downlo
 	apt-get install -y libgbm-dev libgbm1 gconf-service libasound2 libatk1.0-0 libatk-bridge2.0-0 libc6 libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgcc1 libgconf-2-4 libgdk-pixbuf2.0-0 libglib2.0-0 libgtk-3-0 libnspr4 libpango-1.0-0 libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils && \
 	apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
 	rm -rf test /tmp/* /tmp/.??* /var/tmp/* /var/tmp/.??* /var/log/* /root/.npm && \
+        rm -f /usr/local/lib/python3.8/ensurepip/_bundled/*.whl && rm -rf /usr/src/Python* && \
 	\
 	# temporary to remove npm bug message
 	mkdir /.npm && chown -R 1001:0 /.npm && \

--- a/Dockerfile-api
+++ b/Dockerfile-api
@@ -55,6 +55,7 @@ RUN curl -s -L -o /tmp/tini.deb "https://github.com/krallin/tini/releases/downlo
 	HOME=/tmp npm install argon2 --build-from-source --unsafe-perm=true --allow-root && \
 	./bin/docker/preinstall.sh && \
 	bash /opt/countly/bin/scripts/detect.init.sh && \
+        python3.8 -m pip install --upgrade pip setuptools && \
 	\
 	# cleanup & chown
 	npm remove -y --no-save mocha nyc should supertest && \

--- a/Dockerfile-api
+++ b/Dockerfile-api
@@ -55,7 +55,6 @@ RUN curl -s -L -o /tmp/tini.deb "https://github.com/krallin/tini/releases/downlo
 	HOME=/tmp npm install argon2 --build-from-source --unsafe-perm=true --allow-root && \
 	./bin/docker/preinstall.sh && \
 	bash /opt/countly/bin/scripts/detect.init.sh && \
-	python3.8 -m pip install --upgrade pip setuptools && \
 	\
 	# cleanup & chown
 	npm remove -y --no-save mocha nyc should supertest && \

--- a/Dockerfile-frontend
+++ b/Dockerfile-frontend
@@ -60,6 +60,7 @@ RUN curl -s -L -o /tmp/tini.deb "https://github.com/krallin/tini/releases/downlo
 	apt-get autoremove -y && \
 	apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
 	rm -rf test /tmp/* /tmp/.??* /var/tmp/* /var/tmp/.??* /var/log/* /root/.npm && \
+        rm -f /usr/local/lib/python3.8/ensurepip/_bundled/*.whl && rm -rf /usr/src/Python* && \
 	\
 	# temporary to remove npm bug message
 	mkdir /.npm && chown -R 1001:0 /.npm && \

--- a/Dockerfile-frontend
+++ b/Dockerfile-frontend
@@ -26,14 +26,14 @@ RUN apt-get update && \
 RUN apt-get update && \
 	apt-get upgrade -y && \
 	cd /usr/src && \
-	wget https://www.python.org/ftp/python/3.8.12/Python-3.8.12.tar.xz && \
-	tar -xf Python-3.8.12.tar.xz && \
+	wget https://www.python.org/ftp/python/3.8.20/Python-3.8.20.tar.xz && \
+	tar -xf Python-3.8.20.tar.xz && \
 	apt-get install -y build-essential sudo zlib1g-dev libssl3 libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libsqlite3-dev libreadline-dev libffi-dev curl libbz2-dev && \
-	cd Python-3.8.12 && \
+	cd Python-3.8.20 && \
 	./configure --enable-optimizations --enable-shared && \
 	make && \
 	make altinstall && \
-	ldconfig /usr/src/Python-3.8.12 && \
+	ldconfig /usr/src/Python-3.8.20 && \
 	ln -s /usr/local/bin/python3.8 /usr/bin/python3
 
 RUN curl -s -L -o /tmp/tini.deb "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini_${TINI_VERSION}.deb" && \
@@ -52,6 +52,7 @@ RUN curl -s -L -o /tmp/tini.deb "https://github.com/krallin/tini/releases/downlo
 	HOME=/tmp npm install argon2 --build-from-source --unsafe-perm=true --allow-root && \
 	./bin/docker/preinstall.sh && \
 	bash /opt/countly/bin/scripts/detect.init.sh && \
+	python3.8 -m pip install --upgrade pip setuptools && \
 	countly update sdk-web && \
 	\
 	# cleanup & chown

--- a/Dockerfile-frontend
+++ b/Dockerfile-frontend
@@ -52,7 +52,6 @@ RUN curl -s -L -o /tmp/tini.deb "https://github.com/krallin/tini/releases/downlo
 	HOME=/tmp npm install argon2 --build-from-source --unsafe-perm=true --allow-root && \
 	./bin/docker/preinstall.sh && \
 	bash /opt/countly/bin/scripts/detect.init.sh && \
-	python3.8 -m pip install --upgrade pip setuptools && \
 	countly update sdk-web && \
 	\
 	# cleanup & chown

--- a/Dockerfile-frontend
+++ b/Dockerfile-frontend
@@ -52,7 +52,8 @@ RUN curl -s -L -o /tmp/tini.deb "https://github.com/krallin/tini/releases/downlo
 	HOME=/tmp npm install argon2 --build-from-source --unsafe-perm=true --allow-root && \
 	./bin/docker/preinstall.sh && \
 	bash /opt/countly/bin/scripts/detect.init.sh && \
-	countly update sdk-web && \
+	python3.8 -m pip install --upgrade pip setuptools && \
+        countly update sdk-web && \
 	\
 	# cleanup & chown
 	npm remove -y --no-save mocha nyc should supertest puppeteer && \

--- a/Dockerfile-frontend
+++ b/Dockerfile-frontend
@@ -34,7 +34,7 @@ RUN apt-get update && \
 	make && \
 	make altinstall && \
 	ldconfig /usr/src/Python-3.8.20 && \
-	ln -s /usr/local/bin/python3.8 /usr/bin/python3
+	ln -sf /usr/local/bin/python3.8 /usr/bin/python3
 
 RUN curl -s -L -o /tmp/tini.deb "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini_${TINI_VERSION}.deb" && \
 	dpkg -i /tmp/tini.deb && \
@@ -57,11 +57,12 @@ RUN curl -s -L -o /tmp/tini.deb "https://github.com/krallin/tini/releases/downlo
 	\
 	# cleanup & chown
 	npm remove -y --no-save mocha nyc should supertest puppeteer && \
-	apt-get remove -y git gcc g++ make automake autoconf libtool pkg-config unzip sqlite3 wget && \
+	apt-get purge -y python3 python3-pip python3-distutils python3-setuptools && \
+        apt-get remove -y git gcc g++ make automake autoconf libtool pkg-config unzip sqlite3 wget && \
 	apt-get autoremove -y && \
 	apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
-	rm -rf test /tmp/* /tmp/.??* /var/tmp/* /var/tmp/.??* /var/log/* /root/.npm && \
-        rm -f /usr/local/lib/python3.8/ensurepip/_bundled/*.whl && rm -rf /usr/src/Python* && \
+        apt-get autoremove -y && \
+        rm -rf test /tmp/* /tmp/.??* /var/tmp/* /var/tmp/.??* /var/log/* /root/.npm /usr/local/lib/python3.8/ensurepip/_bundled/*.whl /usr/src/Python* /var/lib/dpkg/info/python3* && \
 	\
 	# temporary to remove npm bug message
 	mkdir /.npm && chown -R 1001:0 /.npm && \

--- a/bin/docker/modify.sh
+++ b/bin/docker/modify.sh
@@ -22,7 +22,6 @@ if [ "${COUNTLY_CONTAINER}" != "frontend" ]; then
 			yum install -y python36 python36-libs python36-devel python36-pip
 		fi
 		# shellcheck disable=SC1091
-                python3.8 -m pip install --upgrade pip setuptools
 		python3.8 -m pip install -r /opt/countly/plugins/ab-testing/api/bayesian/requirements.txt
 		cd /opt/countly/plugins/ab-testing/api/bayesian && python3.8 model.py
 	fi

--- a/bin/docker/modify.sh
+++ b/bin/docker/modify.sh
@@ -22,6 +22,7 @@ if [ "${COUNTLY_CONTAINER}" != "frontend" ]; then
 			yum install -y python36 python36-libs python36-devel python36-pip
 		fi
 		# shellcheck disable=SC1091
+                python3.8 -m pip install --upgrade pip setuptools
 		python3.8 -m pip install -r /opt/countly/plugins/ab-testing/api/bayesian/requirements.txt
 		cd /opt/countly/plugins/ab-testing/api/bayesian && python3.8 model.py
 	fi


### PR DESCRIPTION
Upgraded Python from 3.8.12 to 3.8.20
Fixed symlink forcing it to Python3.8
Upgraded Pip and setuptools packages to latest available
Removed Python3.11 as we are compiling python3.8 which is base requirement for ab-testing
Autoremove package which are no longer required.