### PR TITLE
[emails][puppeteer][fix] allow chrome to launch multiple instances

### DIFF
--- a/api/utils/render.js
+++ b/api/utils/render.js
@@ -25,6 +25,7 @@ var chromePath = "";
 var countlyFs = require('./countlyFs');
 var log = require('./log.js')('core:render');
 var countlyConfig = require('./../config', 'dont-enclose');
+var fs = require('fs');
 
 
 /**
@@ -69,7 +70,7 @@ exports.renderView = function(options, cb) {
                 },
                 args: ['--no-sandbox', '--disable-setuid-sandbox', '--ignore-certificate-errors'],
                 ignoreHTTPSErrors: true,
-                userDataDir: pathModule.resolve(__dirname, "../../dump/chrome")
+                userDataDir: pathModule.resolve(__dirname, "../../dump/chrome/" + Date.now())
             };
 
             if (chromePath) {
@@ -251,6 +252,9 @@ exports.renderView = function(options, cb) {
                 await bodyHandle.dispose();
                 await browser.close();
 
+                // Remove user data directory after use
+                fs.rmSync(settings.userDataDir, { recursive: true, force: true });
+
                 var imageData = {
                     image: image,
                     path: path
@@ -261,6 +265,8 @@ exports.renderView = function(options, cb) {
             catch (e) {
                 log.e("Headless chrome browser error", e);
                 await browser.close();
+                // Remove user data directory after use
+                fs.rmSync(settings.userDataDir, { recursive: true, force: true });
                 return cb(e);
             }
         }


### PR DESCRIPTION
Bypasses the following error by creating new user dir on every launch and then cleaning up afterwards.

`Failed to create a ProcessSingleton for your profile directory. This means that running multiple instances would start multiple browser processes rather than opening a new window in the existing process. Aborting now to avoid profile corruption.`