### PR TITLE
fix: Add z-index to sidebar menu container

### DIFF
--- a/frontend/express/public/stylesheets/styles/blocks/_sidebar.scss
+++ b/frontend/express/public/stylesheets/styles/blocks/_sidebar.scss
@@ -141,6 +141,7 @@ $bg-color: #24292e;
         box-sizing: border-box;
         height: 100%;
         overflow: hidden;
+        z-index: 2004;
         position: relative;
 
         /* .cly-vue-sidebar__menu--with-banner */


### PR DESCRIPTION
Custom dashboards are rendered above the menu, causing visibility issue during menu transition