### PR TITLE
feat: [deletion-manager] defer deletions under CH load pressure

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -157,6 +157,24 @@ plugins.connectToAllDatabases().then(function() {
         }
     );
 
+    if (common.queryRunner && typeof common.queryRunner.isAdapterAvailable === 'function' && common.queryRunner.isAdapterAvailable('clickhouse')) {
+        common.db.collection('plugins').updateOne(
+            {
+                _id: 'plugins',
+                'deletion_manager.ch_max_parts_per_partition': { $exists: false },
+                'deletion_manager.ch_max_total_mergetree_parts': { $exists: false }
+            },
+            {
+                $set: {
+                    'deletion_manager.ch_max_parts_per_partition': 1000,
+                    'deletion_manager.ch_max_total_mergetree_parts': 100000
+                }
+            }).catch(e => {
+            const message = `Failed to add deletion_manager defaults: ${e}`;
+            log && log.e ? log.e(message) : console.log(message);
+        });
+    }
+
     /**
      * Initialize Plugins
      */


### PR DESCRIPTION
Adds pre-checks in DeletionManagerJob to fetch ClickHouse health metrics and defer deletion tasks if system load exceeds defined thresholds. This helps prevent overloading ClickHouse by pausing deletions when the number of parts per partition or total parts is too high.