### PR TITLE
fix: compliance-hub tests

### DIFF
--- a/plugins/compliance-hub/api/api.js
+++ b/plugins/compliance-hub/api/api.js
@@ -61,7 +61,7 @@ const FEATURE_NAME = 'compliance_hub';
             }
             validateRead(params, FEATURE_NAME, function() {
                 try {
-                    var columns = ["device_id", "device_id", "uid", "type", "after", "ts"];
+                    var columns = ["device_id", "device_id", "uid", "type", "ts", "ts"];
                     var checkOb;
                     if (params.qstring.iSortCol_0 && params.qstring.sSortDir_0 && columns[params.qstring.iSortCol_0]) {
                         checkOb = {};

--- a/plugins/compliance-hub/api/queries/consents.js
+++ b/plugins/compliance-hub/api/queries/consents.js
@@ -177,6 +177,9 @@ function transformConsentRows(rows) {
         if (out.did) {
             out.device_id = out.did;
         }
+        if (out.a) {
+            out.app_id = out.a;
+        }
         if (out.up) {
             Object.assign(out, out.up);
             delete out.up;

--- a/plugins/compliance-hub/tests.js
+++ b/plugins/compliance-hub/tests.js
@@ -130,7 +130,7 @@ describe('Testing Compliance Hub', function() {
                 user = user || {};
                 user.should.have.property('consent');
 
-                user.consent.should.have.property('session', true);
+                user.consent.should.have.property('sessions', true);
                 done();
 
             });
@@ -268,7 +268,6 @@ describe('Testing Compliance Hub', function() {
                         record.should.have.property('device_id');
                         record.should.have.property('ts');
                         record.should.have.property('type');
-                        record.should.have.property('after');
                         record.should.have.property('change');
                     }
                     setTimeout(done, 100);
@@ -527,7 +526,6 @@ describe('Testing Compliance Hub', function() {
                             item.should.have.property('app_id');
                             item.should.have.property('ts');
                             item.should.have.property('type');
-                            item.should.have.property('after');
                             item.should.have.property('change');
                             item.should.have.property('cd');
                             if (item.uid) {
@@ -668,7 +666,7 @@ describe('Testing Compliance Hub', function() {
                 user.should.have.property('consent');
 
                 user.consent.should.have.property('events', true);
-                user.consent.should.have.property('session', true);
+                user.consent.should.have.property('sessions', true);
                 done();
 
             });
@@ -689,6 +687,9 @@ describe('Testing Compliance Hub', function() {
                     ob.should.have.property('result', 'Success');
                     setTimeout(done, 100 * testUtils.testScalingFactor);
                 });
+        });
+        it('Trigger deletion job to run', function(done) {
+            testUtils.triggerJobToRun("api:deletionManagerJob", done);
         });
     });
 


### PR DESCRIPTION
Removed `after` field as it has no reference anywhere