### PR TITLE
fix: clickhouse adapter should be enabled by default

### DIFF
--- a/api/config.sample.js
+++ b/api/config.sample.js
@@ -33,7 +33,7 @@ var countlyConfig = {
                 enabled: true
             },
             clickhouse: {
-                enabled: false
+                enabled: true
             }
         },
         comparisonLogs: {


### PR DESCRIPTION
For the new architecture having the `clickhouse` plugin enabled is mandatory. 

Enabling by default through `config.sample.js`