### PR TITLE
feat: speed up visual tests with blazediff

### DIFF
--- a/ui-tests/cypress.config.sample.js
+++ b/ui-tests/cypress.config.sample.js
@@ -32,12 +32,12 @@ module.exports = defineConfig({
                     const data = new Uint8Array(fs.readFileSync(filePath));
                     const pdfDoc = await pdfjsLib.getDocument({ data }).promise;
 
-                    // Import pixelmatch only if logo check is needed
-                    let pixelmatch;
+                    // Import blazediff only if logo check is needed
+                    let blazediff;
                     const doLogoCheck = !!options.referenceLogoPath;
                     if (doLogoCheck) {
-                        const pm = await import("pixelmatch");
-                        pixelmatch = pm.default;
+                        const { diff } = await import("@blazediff/core");
+                        blazediff = diff;
                     }
 
                     let hasImage = false;
@@ -88,7 +88,7 @@ module.exports = defineConfig({
                                     const resizedPdfImg = PNG.sync.read(resizedPdfBuffer);
 
                                     const diff = new PNG({ width: refLogo.width, height: refLogo.height });
-                                    const mismatched = pixelmatch(
+                                    const mismatched = blazediff(
                                         refLogo.data,
                                         resizedPdfImg.data,
                                         diff.data,

--- a/ui-tests/package-lock.json
+++ b/ui-tests/package-lock.json
@@ -16,12 +16,19 @@
         "moment": "^2.29.4"
       },
       "devDependencies": {
+        "@blazediff/core": "^1.9.0",
         "cypress": "^13.4.0",
         "pdfjs-dist": "^3.11.174",
-        "pixelmatch": "^7.1.0",
         "pngjs": "^7.0.0",
         "sharp": "^0.34.4"
       }
+    },
+    "node_modules/@blazediff/core": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@blazediff/core/-/core-1.9.0.tgz",
+      "integrity": "sha512-4W6TNzvD5KyUWiAHT+MyAg79FWe8rv493nfvWKeWox67lbUHTiTy40n7rmg6cQjhu5hflCDw73FExgmv22IgNQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@cypress/request": {
       "version": "3.0.9",
@@ -1161,6 +1168,7 @@
       "integrity": "sha512-KeWNC9xSHG/ewZURVbaQsBQg2mOKw4XhjJZFKjWbEjgZCdxpPXLpJnfq5Jns1Gvnjp6AlnIfpZfWFlDgVKXdWQ==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cypress/request": "^3.0.0",
         "@cypress/xvfb": "^1.2.4",
@@ -1339,6 +1347,7 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
       "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+      "peer": true,
       "dependencies": {
         "ansi-colors": "^4.1.1"
       },
@@ -2475,19 +2484,6 @@
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pixelmatch": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-7.1.0.tgz",
-      "integrity": "sha512-1wrVzJ2STrpmONHKBy228LM1b84msXDUoAzVEl0R8Mz4Ce6EPr+IVtxm8+yvrqLYMHswREkjYFaMxnyGnaY3Ng==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "pngjs": "^7.0.0"
-      },
-      "bin": {
-        "pixelmatch": "bin/pixelmatch"
       }
     },
     "node_modules/pngjs": {

--- a/ui-tests/package.json
+++ b/ui-tests/package.json
@@ -16,9 +16,9 @@
     "moment": "^2.29.4"
   },
   "devDependencies": {
+    "@blazediff/core": "^1.9.0",
     "cypress": "^13.4.0",
     "pdfjs-dist": "^3.11.174",
-    "pixelmatch": "^7.1.0",
     "pngjs": "^7.0.0",
     "sharp": "^0.34.4"
   }


### PR DESCRIPTION
# Description

Replace pixelmatch with [BlazeDiff](https://github.com/teimurjan/blazediff). BlazeDiff is the fastest image diff tool. `@blazediff/core` (pure JavaScript approach) is ~50%  faster than `pixelmatch`, using the same API and producing the same results. It weighs twice as much, is actively supported, and is type-safe out of the box.

It's already running visuals for:

- https://github.com/ant-design/ant-design
- https://github.com/ant-design/x
- https://github.com/antvis/G
- https://github.com/antvis/GPT-Vis
- https://github.com/Shopify/react-native-skia
- https://github.com/vega/vega
- https://github.com/apexcharts/apexcharts.js

You can check the benchmarks here: https://github.com/teimurjan/blazediff/blob/main/BENCHMARKS.md.