### PR TITLE
Update logging level in Countly configuration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -927,6 +927,7 @@ jobs:
             -e COUNTLY_CONFIG__KAFKA_CONSUMER_INVALIDJSONBEHAVIOR=skip \
             -e COUNTLY_CONFIG__KAFKA_CONSUMER_INVALIDJSONMETRICS=true \
             -e COUNTLY_SETTINGS__LOGS__DEBUG='' \
+            -e COUNTLY_SETTINGS__LOGS__DEFAULT='error' \
             countly/countly-core:pipelines-${{ inputs.custom_tag || github.base_ref || github.ref_name }} \
             sleep infinity
 


### PR DESCRIPTION
Set default Countly log level to "error" for UI tests