### PR TITLE
fix(start-ratings): typo in translation label

### DIFF
--- a/plugins/star-rating/frontend/public/javascripts/countly.views.js
+++ b/plugins/star-rating/frontend/public/javascripts/countly.views.js
@@ -1336,7 +1336,7 @@
 
                             CountlyHelpers.notify({
                                 type: 'error',
-                                message: CV.i18n('star-rating.widget.delete.fai'),
+                                message: CV.i18n('star-rating.widget.delete.fail'),
                                 width: 'large',
                             });
                         });


### PR DESCRIPTION
This fixes a typo in a translation label for the `star-rating` widget.