### PR TITLE
feat(api): add v2 health endpoints and CORS support for new dashboard

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -277,6 +277,13 @@ function handleRequest(req, res) {
     res.setHeader('Connection', 'keep-alive');
     res.setHeader('Keep-Alive', 'timeout=5, max=1000');
 
+    // CORS headers for all responses (GET, POST, OPTIONS)
+    const requestOrigin = req.headers.origin;
+    if (requestOrigin) {
+        res.setHeader('Access-Control-Allow-Origin', requestOrigin);
+        res.setHeader('Access-Control-Allow-Credentials', 'true');
+    }
+
     if (req.method.toLowerCase() === 'post') {
         const formidableOptions = { multiples: true };
         if (countlyConfig.api.maxUploadFileSize) {
@@ -352,9 +359,12 @@ function handleRequest(req, res) {
     }
     else if (req.method.toLowerCase() === 'options') {
         const headers = {};
-        headers["Access-Control-Allow-Origin"] = "*";
+        headers["Access-Control-Allow-Origin"] = requestOrigin || "*";
         headers["Access-Control-Allow-Methods"] = "POST, GET, OPTIONS";
-        headers["Access-Control-Allow-Headers"] = "countly-token, Content-Type";
+        headers["Access-Control-Allow-Headers"] = "countly-token, Content-Type, Authorization";
+        if (requestOrigin) {
+            headers["Access-Control-Allow-Credentials"] = "true";
+        }
         res.writeHead(200, headers);
         res.end();
     }

--- a/api/services/systemHealth.ts
+++ b/api/services/systemHealth.ts
@@ -1,0 +1,406 @@
+/**
+ * Shared service for system health data (used by both legacy /o/system/* and v2 /health/*).
+ *
+ * Each function accepts explicit dependencies (db, plugins, config) rather than
+ * importing singletons so the module stays testable and free of circular requires.
+ */
+
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const plugins = require('../../plugins/pluginManager.ts');
+const common = require('../utils/common.js');
+const log = require('../utils/log.js')('service:system-health');
+
+// ---------------------------------------------------------------------------
+// Kafka events/meta cache (30 s TTL with in-flight dedup)
+// ---------------------------------------------------------------------------
+const KAFKA_META_CACHE_TTL = 30_000;
+let _kafkaMetaCache: any = null;
+let _kafkaMetaCacheTs = 0;
+let _kafkaMetaCachePromise: Promise<any> | null = null;
+
+// ---------------------------------------------------------------------------
+// 1. Observability (mutation + clickhouse)
+// ---------------------------------------------------------------------------
+
+/**
+ * Dispatches `/system/observability/collect` and returns the fulfilled provider
+ * results as an array.
+ */
+export async function collectObservability(params: any): Promise<any[]> {
+    const results = await plugins.dispatchAsPromise('/system/observability/collect', { params });
+    return (results || [])
+        .filter((r: any) => r && r.status === 'fulfilled' && r.value)
+        .map((r: any) => r.value);
+}
+
+// ---------------------------------------------------------------------------
+// 2. Aggregator status (change-stream resume tokens)
+// ---------------------------------------------------------------------------
+
+export async function getAggregatorStatus(): Promise<any[]> {
+    const [pluginsData, drillData] = await Promise.all([
+        common.db.collection('plugins').findOne({ _id: '_changeStreams' }),
+        common.drillDb
+            .collection('drill_events')
+            .find({}, { projection: { cd: 1 } })
+            .sort({ cd: -1 })
+            .limit(1)
+            .toArray(),
+    ]);
+
+    const data: any[] = [];
+    const now = Date.now();
+    const nowDrill = drillData?.length ? new Date(drillData[0].cd).valueOf() : now;
+
+    if (pluginsData) {
+        for (const key in pluginsData) {
+            if (key !== '_id') {
+                const lastAccepted = new Date(pluginsData[key].cd).valueOf();
+                data.push({
+                    name: key,
+                    last_cd: pluginsData[key].cd,
+                    drill: drillData?.[0]?.cd,
+                    last_id: pluginsData[key]._id,
+                    diff: (now - lastAccepted) / 1000,
+                    diffDrill: (nowDrill - lastAccepted) / 1000,
+                });
+            }
+        }
+    }
+    return data;
+}
+
+// ---------------------------------------------------------------------------
+// 3. Kafka status overview
+// ---------------------------------------------------------------------------
+
+export async function getKafkaStatus(): Promise<any> {
+    const KAFKA_QUERY_LIMIT = 500;
+
+    const [consumerState, consumerHealth, lagHistory, connectStatus, stateSummary, healthSummary] =
+        await Promise.all([
+            common.db
+                .collection('kafka_consumer_state')
+                .find(
+                    {},
+                    {
+                        projection: {
+                            consumerGroup: 1,
+                            topic: 1,
+                            partitions: 1,
+                            lastProcessedAt: 1,
+                            batchCount: 1,
+                            duplicatesSkipped: 1,
+                            lastDuplicateAt: 1,
+                            lastBatchSize: 1,
+                            avgBatchSize: 1,
+                        },
+                    },
+                )
+                .sort({ lastProcessedAt: -1 })
+                .limit(KAFKA_QUERY_LIMIT)
+                .toArray(),
+
+            common.db
+                .collection('kafka_consumer_health')
+                .find(
+                    {},
+                    {
+                        projection: {
+                            groupId: 1,
+                            rebalanceCount: 1,
+                            lastRebalanceAt: 1,
+                            lastJoinAt: 1,
+                            lastMemberId: 1,
+                            lastGenerationId: 1,
+                            commitCount: 1,
+                            lastCommitAt: 1,
+                            errorCount: 1,
+                            lastErrorAt: 1,
+                            lastErrorMessage: 1,
+                            recentErrors: 1,
+                            totalLag: 1,
+                            partitionLag: 1,
+                            lagUpdatedAt: 1,
+                            updatedAt: 1,
+                        },
+                    },
+                )
+                .sort({ updatedAt: -1 })
+                .limit(KAFKA_QUERY_LIMIT)
+                .toArray(),
+
+            common.db
+                .collection('kafka_lag_history')
+                .find({}, { projection: { ts: 1, groups: 1, connectLag: 1 } })
+                .sort({ ts: -1 })
+                .limit(100)
+                .toArray(),
+
+            common.db
+                .collection('kafka_connect_status')
+                .find(
+                    {},
+                    {
+                        projection: {
+                            connectorName: 1,
+                            connectorState: 1,
+                            connectorType: 1,
+                            workerId: 1,
+                            tasks: 1,
+                            updatedAt: 1,
+                        },
+                    },
+                )
+                .sort({ updatedAt: -1 })
+                .limit(KAFKA_QUERY_LIMIT)
+                .toArray(),
+
+            common.db
+                .collection('kafka_consumer_state')
+                .aggregate([
+                    {
+                        $group: {
+                            _id: null,
+                            totalBatchesProcessed: { $sum: { $ifNull: ['$batchCount', 0] } },
+                            totalDuplicatesSkipped: { $sum: { $ifNull: ['$duplicatesSkipped', 0] } },
+                            avgBatchSizeSum: { $sum: { $ifNull: ['$avgBatchSize', 0] } },
+                            groupsWithData: { $sum: { $cond: [{ $gt: ['$avgBatchSize', 0] }, 1, 0] } },
+                        },
+                    },
+                ])
+                .toArray(),
+
+            common.db
+                .collection('kafka_consumer_health')
+                .aggregate([
+                    {
+                        $group: {
+                            _id: null,
+                            totalRebalances: { $sum: { $ifNull: ['$rebalanceCount', 0] } },
+                            totalErrors: { $sum: { $ifNull: ['$errorCount', 0] } },
+                            totalLag: { $sum: { $ifNull: ['$totalLag', 0] } },
+                        },
+                    },
+                ])
+                .toArray(),
+        ]);
+
+    // Summaries
+    const stSummary = stateSummary[0] || {};
+    const totalBatchesProcessed = stSummary.totalBatchesProcessed || 0;
+    const totalDuplicatesSkipped = stSummary.totalDuplicatesSkipped || 0;
+    const avgBatchSizeOverall =
+        stSummary.groupsWithData > 0 ? stSummary.avgBatchSizeSum / stSummary.groupsWithData : 0;
+
+    const htSummary = healthSummary[0] || {};
+    const totalRebalances = htSummary.totalRebalances || 0;
+    const totalErrors = htSummary.totalErrors || 0;
+    const totalLagAll = htSummary.totalLag || 0;
+
+    // Transform consumer state rows
+    const partitionStats = consumerState.map((state: any) => {
+        const partitions = state.partitions || {};
+        const partitionCount = Object.keys(partitions).length;
+        const activePartitions = Object.values(partitions).filter((p: any) => p.lastProcessedAt).length;
+
+        return {
+            id: state._id,
+            consumerGroup: state.consumerGroup,
+            topic: state.topic,
+            partitionCount,
+            activePartitions,
+            lastProcessedAt: state.lastProcessedAt,
+            batchCount: state.batchCount || 0,
+            duplicatesSkipped: state.duplicatesSkipped || 0,
+            lastDuplicateAt: state.lastDuplicateAt,
+            lastBatchSize: state.lastBatchSize,
+            avgBatchSize: state.avgBatchSize ? Math.round(state.avgBatchSize) : null,
+        };
+    });
+
+    // Transform consumer health rows
+    const consumerStats = consumerHealth.map((health: any) => ({
+        id: health._id,
+        groupId: health.groupId,
+        rebalanceCount: health.rebalanceCount || 0,
+        lastRebalanceAt: health.lastRebalanceAt,
+        lastJoinAt: health.lastJoinAt,
+        lastMemberId: health.lastMemberId,
+        lastGenerationId: health.lastGenerationId,
+        commitCount: health.commitCount || 0,
+        lastCommitAt: health.lastCommitAt,
+        errorCount: health.errorCount || 0,
+        lastErrorAt: health.lastErrorAt,
+        lastErrorMessage: health.lastErrorMessage,
+        recentErrors: health.recentErrors || [],
+        totalLag: health.totalLag || 0,
+        partitionLag: health.partitionLag || {},
+        lagUpdatedAt: health.lagUpdatedAt,
+        updatedAt: health.updatedAt,
+    }));
+
+    // Connector stats
+    const connectorStats = connectStatus.map((conn: any) => ({
+        id: conn._id,
+        connectorName: conn.connectorName,
+        connectorState: conn.connectorState,
+        connectorType: conn.connectorType,
+        workerId: conn.workerId,
+        tasks: conn.tasks || [],
+        tasksRunning: (conn.tasks || []).filter((t: any) => t.state === 'RUNNING').length,
+        tasksTotal: (conn.tasks || []).length,
+        updatedAt: conn.updatedAt,
+    }));
+
+    // Connect consumer group lag
+    const connectConsumerGroupId = common.config?.kafka?.connectConsumerGroupId;
+    const connectGroupHealth = connectConsumerGroupId
+        ? consumerHealth.find((h: any) => h.groupId === connectConsumerGroupId)
+        : null;
+
+    return {
+        summary: {
+            totalBatchesProcessed,
+            totalDuplicatesSkipped,
+            avgBatchSizeOverall: Math.round(avgBatchSizeOverall * 100) / 100,
+            totalRebalances,
+            totalErrors,
+            totalLag: totalLagAll,
+            consumerGroupCount: consumerStats.length,
+            partitionCount: partitionStats.length,
+        },
+        partitions: partitionStats,
+        consumers: consumerStats,
+        lagHistory: lagHistory.reverse(), // oldest-first for charts
+        connectStatus: {
+            enabled: !!common.config?.kafka?.connectApiUrl,
+            connectors: connectorStats,
+            sinkLag: connectGroupHealth?.totalLag || 0,
+            sinkLagUpdatedAt: connectGroupHealth?.lagUpdatedAt,
+        },
+    };
+}
+
+// ---------------------------------------------------------------------------
+// 4. Kafka events (paginated, DataTables-compatible)
+// ---------------------------------------------------------------------------
+
+interface KafkaEventsQuery {
+    eventType?: string;
+    groupId?: string;
+    topic?: string;
+    clusterId?: string;
+    iSortCol_0?: string;
+    sSortDir_0?: string;
+    iDisplayStart?: string;
+    iDisplayLength?: string;
+    sEcho?: string;
+}
+
+export async function getKafkaEvents(qs: KafkaEventsQuery): Promise<any> {
+    const query: any = {};
+
+    if (qs.eventType && qs.eventType !== 'all') {
+        query.type = qs.eventType + '';
+    }
+    if (qs.groupId && qs.groupId !== 'all') {
+        query.groupId = qs.groupId + '';
+    }
+    if (qs.topic && qs.topic !== 'all') {
+        query.topic = qs.topic + '';
+    }
+    if (qs.clusterId && qs.clusterId !== 'all') {
+        query.clusterId = qs.clusterId + '';
+    }
+
+    const [total, filteredCount] = await Promise.all([
+        common.db.collection('kafka_consumer_events').countDocuments({}),
+        common.db.collection('kafka_consumer_events').countDocuments(query),
+    ]);
+
+    let cursor = common.db.collection('kafka_consumer_events').find(query);
+
+    // Sorting with validated column index
+    const columns = ['_id', 'ts', 'type', 'groupId', 'topic', 'partition', 'clusterId'];
+    const sortColIndex = parseInt(qs.iSortCol_0 || '', 10);
+    if (
+        qs.iSortCol_0 &&
+        qs.sSortDir_0 &&
+        Number.isInteger(sortColIndex) &&
+        sortColIndex >= 0 &&
+        sortColIndex < columns.length
+    ) {
+        const sortObj: any = {};
+        sortObj[columns[sortColIndex]] = qs.sSortDir_0 === 'asc' ? 1 : -1;
+        cursor = cursor.sort(sortObj);
+    }
+    else {
+        cursor = cursor.sort({ ts: -1 });
+    }
+
+    // Pagination with validated parameters
+    const MAX_DISPLAY_LENGTH = 1000;
+    let displayStart = parseInt(qs.iDisplayStart || '', 10);
+    if (Number.isNaN(displayStart) || displayStart < 0) {
+        displayStart = 0;
+    }
+    if (displayStart > 0) {
+        cursor = cursor.skip(displayStart);
+    }
+
+    let displayLength = parseInt(qs.iDisplayLength || '', 10);
+    if (Number.isNaN(displayLength) || displayLength < 1 || displayLength > MAX_DISPLAY_LENGTH) {
+        displayLength = 50;
+    }
+    cursor = cursor.limit(displayLength);
+
+    const events = await cursor.toArray();
+
+    return {
+        sEcho: qs.sEcho,
+        iTotalRecords: Math.max(total, 0),
+        iTotalDisplayRecords: filteredCount,
+        aaData: events,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// 5. Kafka events meta (distinct filter values, cached)
+// ---------------------------------------------------------------------------
+
+export async function getKafkaEventsMeta(): Promise<any> {
+    const now = Date.now();
+    if (_kafkaMetaCache && now - _kafkaMetaCacheTs < KAFKA_META_CACHE_TTL) {
+        return _kafkaMetaCache;
+    }
+
+    // Reuse in-flight fetch to prevent thundering herd on cache expiry
+    if (!_kafkaMetaCachePromise) {
+        _kafkaMetaCachePromise = Promise.all([
+            common.db.collection('kafka_consumer_events').distinct('type'),
+            common.db.collection('kafka_consumer_events').distinct('groupId'),
+            common.db.collection('kafka_consumer_events').distinct('topic'),
+            common.db.collection('kafka_consumer_events').distinct('clusterId'),
+        ])
+            .then(([eventTypes, groupIds, topics, clusterIds]: any[]) => {
+                _kafkaMetaCache = {
+                    eventTypes: eventTypes.filter(Boolean).sort(),
+                    groupIds: groupIds.filter(Boolean).sort(),
+                    topics: topics.filter(Boolean).sort(),
+                    clusterIds: clusterIds.filter(Boolean).sort(),
+                };
+                _kafkaMetaCacheTs = Date.now();
+                _kafkaMetaCachePromise = null;
+                return _kafkaMetaCache;
+            })
+            .catch((err: any) => {
+                _kafkaMetaCachePromise = null;
+                throw err;
+            });
+    }
+
+    return _kafkaMetaCachePromise;
+}

--- a/api/utils/requestProcessor.js
+++ b/api/utils/requestProcessor.js
@@ -37,11 +37,18 @@ const render = require('../../api/utils/render.js');
 
 var loaded_configs_time = 0;
 
-// Kafka events meta cache (30s TTL) with in-flight dedup
-var _kafkaMetaCache = null;
-var _kafkaMetaCacheTs = 0;
-var _kafkaMetaCachePromise = null;
-const KAFKA_META_CACHE_TTL = 30000;
+// Shared service for health endpoints (ESM, loaded lazily)
+var _systemHealthService = null;
+/**
+ * Lazily loads and returns the shared system health service module.
+ * @returns {Promise<object>} The systemHealth service exports
+ */
+async function getSystemHealthService() {
+    if (!_systemHealthService) {
+        _systemHealthService = await import('../services/systemHealth.ts');
+    }
+    return _systemHealthService;
+}
 
 const countlyApi = {
     data: {
@@ -1938,50 +1945,23 @@ const processRequest = (params) => {
                     }, params);
                     break;
                 case 'observability':
-                    validateUserForMgmtReadAPI(() => {
-                        plugins.dispatch('/system/observability/collect', {params: params}, function(err, results) {
-                            if (err) {
-                                common.returnMessage(params, 500, 'Error collecting observability data');
-                                return;
-                            }
-                            const data = (results || [])
-                                .filter(r => r && r.status === 'fulfilled' && r.value)
-                                .map(r => r.value);
+                    validateUserForMgmtReadAPI(async() => {
+                        try {
+                            const systemHealth = await getSystemHealthService();
+                            const data = await systemHealth.collectObservability(params);
                             common.returnOutput(params, data);
-                        });
+                        }
+                        catch (err) {
+                            log.e('Error collecting observability data:', err);
+                            common.returnMessage(params, 500, 'Error collecting observability data');
+                        }
                     }, params);
                     break;
                 case 'aggregator':
                     validateUserForMgmtReadAPI(async() => {
                         try {
-                            //fetch aggregator status and latest drill cd in parallel
-                            const [pluginsData, drillData] = await Promise.all([
-                                common.db.collection("plugins").findOne({_id: "_changeStreams"}),
-                                common.drillDb.collection("drill_events").find({}, {projection: {cd: 1}}).sort({cd: -1}).limit(1).toArray()
-                            ]);
-
-                            var data = [];
-                            var now = Date.now().valueOf();
-                            var nowDrill = now;
-                            if (drillData && drillData.length) {
-                                nowDrill = new Date(drillData[0].cd).valueOf();
-                            }
-
-                            if (pluginsData) {
-                                for (var key in pluginsData) {
-                                    if (key !== "_id") {
-                                        var lastAccepted = new Date(pluginsData[key].cd).valueOf();
-                                        data.push({
-                                            name: key,
-                                            last_cd: pluginsData[key].cd,
-                                            drill: drillData && drillData[0] && drillData[0].cd,
-                                            last_id: pluginsData[key]._id,
-                                            diff: (now - lastAccepted) / 1000,
-                                            diffDrill: (nowDrill - lastAccepted) / 1000
-                                        });
-                                    }
-                                }
-                            }
+                            const systemHealth = await getSystemHealthService();
+                            const data = await systemHealth.getAggregatorStatus();
                             common.returnOutput(params, data);
                         }
                         catch (err) {
@@ -1997,37 +1977,9 @@ const processRequest = (params) => {
                             // /o/system/kafka/events/meta - Get filter options (cached 30s, deduped)
                             validateUserForMgmtReadAPI(async() => {
                                 try {
-                                    var now = Date.now();
-                                    if (_kafkaMetaCache && (now - _kafkaMetaCacheTs) < KAFKA_META_CACHE_TTL) {
-                                        common.returnOutput(params, _kafkaMetaCache);
-                                        return;
-                                    }
-
-                                    // Reuse in-flight fetch to prevent thundering herd on cache expiry
-                                    if (!_kafkaMetaCachePromise) {
-                                        _kafkaMetaCachePromise = Promise.all([
-                                            common.db.collection('kafka_consumer_events').distinct('type'),
-                                            common.db.collection('kafka_consumer_events').distinct('groupId'),
-                                            common.db.collection('kafka_consumer_events').distinct('topic'),
-                                            common.db.collection('kafka_consumer_events').distinct('clusterId')
-                                        ]).then(function([eventTypes, groupIds, topics, clusterIds]) {
-                                            _kafkaMetaCache = {
-                                                eventTypes: eventTypes.filter(Boolean).sort(),
-                                                groupIds: groupIds.filter(Boolean).sort(),
-                                                topics: topics.filter(Boolean).sort(),
-                                                clusterIds: clusterIds.filter(Boolean).sort()
-                                            };
-                                            _kafkaMetaCacheTs = Date.now();
-                                            _kafkaMetaCachePromise = null;
-                                            return _kafkaMetaCache;
-                                        }).catch(function(err) {
-                                            _kafkaMetaCachePromise = null;
-                                            throw err;
-                                        });
-                                    }
-
-                                    var result = await _kafkaMetaCachePromise;
-                                    common.returnOutput(params, result);
+                                    const systemHealth = await getSystemHealthService();
+                                    const data = await systemHealth.getKafkaEventsMeta();
+                                    common.returnOutput(params, data);
                                 }
                                 catch (err) {
                                     log.e('Error fetching Kafka events meta:', err);
@@ -2039,69 +1991,9 @@ const processRequest = (params) => {
                             // /o/system/kafka/events - Get events list
                             validateUserForMgmtReadAPI(async() => {
                                 try {
-                                    // Build query from filters
-                                    const query = {};
-
-                                    if (params.qstring.eventType && params.qstring.eventType !== 'all') {
-                                        query.type = params.qstring.eventType + "";
-                                    }
-                                    if (params.qstring.groupId && params.qstring.groupId !== 'all') {
-                                        query.groupId = params.qstring.groupId + "";
-                                    }
-                                    if (params.qstring.topic && params.qstring.topic !== 'all') {
-                                        query.topic = params.qstring.topic + "";
-                                    }
-                                    if (params.qstring.clusterId && params.qstring.clusterId !== 'all') {
-                                        query.clusterId = params.qstring.clusterId + "";
-                                    }
-
-                                    // Get accurate counts
-                                    const [total, filteredCount] = await Promise.all([
-                                        common.db.collection('kafka_consumer_events').countDocuments({}),
-                                        common.db.collection('kafka_consumer_events').countDocuments(query)
-                                    ]);
-                                    let cursor = common.db.collection('kafka_consumer_events').find(query);
-
-                                    // Sorting with validated column index
-                                    const columns = ['_id', 'ts', 'type', 'groupId', 'topic', 'partition', 'clusterId'];
-                                    const sortColIndex = parseInt(params.qstring.iSortCol_0, 10);
-                                    if (params.qstring.iSortCol_0 &&
-                                        params.qstring.sSortDir_0 &&
-                                        Number.isInteger(sortColIndex) &&
-                                        sortColIndex >= 0 &&
-                                        sortColIndex < columns.length) {
-                                        const sortObj = {};
-                                        sortObj[columns[sortColIndex]] = params.qstring.sSortDir_0 === 'asc' ? 1 : -1;
-                                        cursor = cursor.sort(sortObj);
-                                    }
-                                    else {
-                                        cursor = cursor.sort({ ts: -1 });
-                                    }
-
-                                    // Pagination with validated parameters
-                                    const MAX_DISPLAY_LENGTH = 1000;
-                                    let displayStart = parseInt(params.qstring.iDisplayStart, 10);
-                                    if (Number.isNaN(displayStart) || displayStart < 0) {
-                                        displayStart = 0;
-                                    }
-                                    if (displayStart > 0) {
-                                        cursor = cursor.skip(displayStart);
-                                    }
-
-                                    let displayLength = parseInt(params.qstring.iDisplayLength, 10);
-                                    if (Number.isNaN(displayLength) || displayLength < 1 || displayLength > MAX_DISPLAY_LENGTH) {
-                                        displayLength = 50;
-                                    }
-                                    cursor = cursor.limit(displayLength);
-
-                                    const events = await cursor.toArray();
-
-                                    common.returnOutput(params, {
-                                        sEcho: params.qstring.sEcho,
-                                        iTotalRecords: Math.max(total, 0),
-                                        iTotalDisplayRecords: filteredCount,
-                                        aaData: events
-                                    });
+                                    const systemHealth = await getSystemHealthService();
+                                    const data = await systemHealth.getKafkaEvents(params.qstring);
+                                    common.returnOutput(params, data);
                                 }
                                 catch (err) {
                                     log.e('Error fetching Kafka consumer events:', err);
@@ -2115,192 +2007,9 @@ const processRequest = (params) => {
                     // Default: /o/system/kafka - Get Kafka status overview
                     validateUserForMgmtReadAPI(async() => {
                         try {
-                            const KAFKA_QUERY_LIMIT = 500;
-
-                            // Fetch all Kafka data and summaries in parallel (with projections)
-                            const [consumerState, consumerHealth, lagHistory, connectStatus, stateSummary, healthSummary] = await Promise.all([
-                                common.db.collection("kafka_consumer_state")
-                                    .find({}, {
-                                        projection: {
-                                            consumerGroup: 1,
-                                            topic: 1,
-                                            partitions: 1,
-                                            lastProcessedAt: 1,
-                                            batchCount: 1,
-                                            duplicatesSkipped: 1,
-                                            lastDuplicateAt: 1,
-                                            lastBatchSize: 1,
-                                            avgBatchSize: 1
-                                        }
-                                    })
-                                    .sort({ lastProcessedAt: -1 })
-                                    .limit(KAFKA_QUERY_LIMIT)
-                                    .toArray(),
-                                common.db.collection("kafka_consumer_health")
-                                    .find({}, {
-                                        projection: {
-                                            groupId: 1,
-                                            rebalanceCount: 1,
-                                            lastRebalanceAt: 1,
-                                            lastJoinAt: 1,
-                                            lastMemberId: 1,
-                                            lastGenerationId: 1,
-                                            commitCount: 1,
-                                            lastCommitAt: 1,
-                                            errorCount: 1,
-                                            lastErrorAt: 1,
-                                            lastErrorMessage: 1,
-                                            recentErrors: 1,
-                                            totalLag: 1,
-                                            partitionLag: 1,
-                                            lagUpdatedAt: 1,
-                                            updatedAt: 1
-                                        }
-                                    })
-                                    .sort({ updatedAt: -1 })
-                                    .limit(KAFKA_QUERY_LIMIT)
-                                    .toArray(),
-                                common.db.collection("kafka_lag_history")
-                                    .find({}, {projection: {ts: 1, groups: 1, connectLag: 1}})
-                                    .sort({ ts: -1 })
-                                    .limit(100)
-                                    .toArray(),
-                                common.db.collection("kafka_connect_status")
-                                    .find({}, {
-                                        projection: {
-                                            connectorName: 1,
-                                            connectorState: 1,
-                                            connectorType: 1,
-                                            workerId: 1,
-                                            tasks: 1,
-                                            updatedAt: 1
-                                        }
-                                    })
-                                    .sort({ updatedAt: -1 })
-                                    .limit(KAFKA_QUERY_LIMIT)
-                                    .toArray(),
-                                // Aggregate consumer state summary via MongoDB pipeline
-                                common.db.collection("kafka_consumer_state")
-                                    .aggregate([{
-                                        $group: {
-                                            _id: null,
-                                            totalBatchesProcessed: { $sum: { $ifNull: ["$batchCount", 0] } },
-                                            totalDuplicatesSkipped: { $sum: { $ifNull: ["$duplicatesSkipped", 0] } },
-                                            avgBatchSizeSum: { $sum: { $ifNull: ["$avgBatchSize", 0] } },
-                                            groupsWithData: { $sum: { $cond: [{ $gt: ["$avgBatchSize", 0] }, 1, 0] } }
-                                        }
-                                    }])
-                                    .toArray(),
-                                // Aggregate consumer health summary via MongoDB pipeline
-                                common.db.collection("kafka_consumer_health")
-                                    .aggregate([{
-                                        $group: {
-                                            _id: null,
-                                            totalRebalances: { $sum: { $ifNull: ["$rebalanceCount", 0] } },
-                                            totalErrors: { $sum: { $ifNull: ["$errorCount", 0] } },
-                                            totalLag: { $sum: { $ifNull: ["$totalLag", 0] } }
-                                        }
-                                    }])
-                                    .toArray()
-                            ]);
-
-                            // Extract summary from aggregation pipelines
-                            const stSummary = stateSummary[0] || {};
-                            const totalBatchesProcessed = stSummary.totalBatchesProcessed || 0;
-                            const totalDuplicatesSkipped = stSummary.totalDuplicatesSkipped || 0;
-                            const avgBatchSizeOverall = stSummary.groupsWithData > 0
-                                ? stSummary.avgBatchSizeSum / stSummary.groupsWithData
-                                : 0;
-
-                            const htSummary = healthSummary[0] || {};
-                            const totalRebalances = htSummary.totalRebalances || 0;
-                            const totalErrors = htSummary.totalErrors || 0;
-                            const totalLagAll = htSummary.totalLag || 0;
-
-                            // Transform consumer state rows
-                            const partitionStats = consumerState.map(state => {
-                                const partitions = state.partitions || {};
-                                const partitionCount = Object.keys(partitions).length;
-                                const activePartitions = Object.values(partitions).filter(p => p.lastProcessedAt).length;
-
-                                return {
-                                    id: state._id,
-                                    consumerGroup: state.consumerGroup,
-                                    topic: state.topic,
-                                    partitionCount,
-                                    activePartitions,
-                                    lastProcessedAt: state.lastProcessedAt,
-                                    batchCount: state.batchCount || 0,
-                                    duplicatesSkipped: state.duplicatesSkipped || 0,
-                                    lastDuplicateAt: state.lastDuplicateAt,
-                                    lastBatchSize: state.lastBatchSize,
-                                    avgBatchSize: state.avgBatchSize ? Math.round(state.avgBatchSize) : null
-                                };
-                            });
-
-                            // Transform consumer health rows
-                            const consumerStats = consumerHealth.map(health => ({
-                                id: health._id,
-                                groupId: health.groupId,
-                                rebalanceCount: health.rebalanceCount || 0,
-                                lastRebalanceAt: health.lastRebalanceAt,
-                                lastJoinAt: health.lastJoinAt,
-                                lastMemberId: health.lastMemberId,
-                                lastGenerationId: health.lastGenerationId,
-                                commitCount: health.commitCount || 0,
-                                lastCommitAt: health.lastCommitAt,
-                                errorCount: health.errorCount || 0,
-                                lastErrorAt: health.lastErrorAt,
-                                lastErrorMessage: health.lastErrorMessage,
-                                recentErrors: health.recentErrors || [],
-                                totalLag: health.totalLag || 0,
-                                partitionLag: health.partitionLag || {},
-                                lagUpdatedAt: health.lagUpdatedAt,
-                                updatedAt: health.updatedAt
-                            }));
-
-                            // Process Kafka Connect status
-                            const connectorStats = connectStatus.map(conn => ({
-                                id: conn._id,
-                                connectorName: conn.connectorName,
-                                connectorState: conn.connectorState,
-                                connectorType: conn.connectorType,
-                                workerId: conn.workerId,
-                                tasks: conn.tasks || [],
-                                tasksRunning: (conn.tasks || []).filter(t => t.state === 'RUNNING').length,
-                                tasksTotal: (conn.tasks || []).length,
-                                updatedAt: conn.updatedAt
-                            }));
-
-                            // Get connect consumer group lag for ClickHouse sink
-                            const connectConsumerGroupId = common.config?.kafka?.connectConsumerGroupId;
-                            const connectGroupHealth = connectConsumerGroupId
-                                ? consumerHealth.find(h => h.groupId === connectConsumerGroupId)
-                                : null;
-
-                            common.returnOutput(params, {
-                                summary: {
-                                    totalBatchesProcessed,
-                                    totalDuplicatesSkipped,
-                                    avgBatchSizeOverall: Math.round(avgBatchSizeOverall * 100) / 100,
-                                    totalRebalances,
-                                    totalErrors,
-                                    totalLag: totalLagAll,
-                                    consumerGroupCount: consumerStats.length,
-                                    partitionCount: partitionStats.length
-                                },
-                                partitions: partitionStats,
-                                consumers: consumerStats,
-                                lagHistory: lagHistory.reverse(), // Oldest first for charts
-
-                                // Kafka Connect status
-                                connectStatus: {
-                                    enabled: !!common.config?.kafka?.connectApiUrl,
-                                    connectors: connectorStats,
-                                    sinkLag: connectGroupHealth?.totalLag || 0,
-                                    sinkLagUpdatedAt: connectGroupHealth?.lagUpdatedAt
-                                }
-                            });
+                            const systemHealth = await getSystemHealthService();
+                            const data = await systemHealth.getKafkaStatus();
+                            common.returnOutput(params, data);
                         }
                         catch (err) {
                             log.e('Error fetching Kafka stats:', err);

--- a/api/v2/app.ts
+++ b/api/v2/app.ts
@@ -5,6 +5,7 @@ import type { Request, Response, NextFunction } from 'express';
 import authRouter from './routes/auth.ts';
 import usersRouter from './routes/users.ts';
 import appsRouter from './routes/apps.ts';
+import healthRouter from './routes/health.ts';
 import { pluginGuard } from './middleware/plugin-guard.ts';
 import { v2ErrorHandler } from './middleware/error-handler.ts';
 import { transformResponse } from './middleware/response-wrapper.ts';
@@ -37,9 +38,19 @@ app.use(function(_req: Request, res: Response, next: NextFunction) {
         if (add_headers[i] && add_headers[i].length > 0) {
             parts = add_headers[i].split(/:(.+)?/);
             if (parts.length === 3) {
-                res.setHeader(parts[0], parts[1]);
+                // Skip any configured Access-Control-Allow-Origin — we handle it dynamically below
+                if (parts[0].trim().toLowerCase() !== 'access-control-allow-origin') {
+                    res.setHeader(parts[0], parts[1]);
+                }
             }
         }
+    }
+
+    // Reflect the request Origin for credentialed requests (cookies)
+    const origin = _req.headers.origin;
+    if (origin) {
+        res.setHeader('Access-Control-Allow-Origin', origin);
+        res.setHeader('Access-Control-Allow-Credentials', 'true');
     }
 
     if (_req.method === 'OPTIONS') {
@@ -55,6 +66,7 @@ app.use(function(_req: Request, res: Response, next: NextFunction) {
 app.use('/v2/auth', authRouter);
 app.use('/v2/users', paramsAdapter, transformResponse, usersRouter);
 app.use('/v2/apps', paramsAdapter, transformResponse, appsRouter);
+app.use('/v2/health', paramsAdapter, transformResponse, healthRouter);
 
 // --- Plugin v2 routes (auto-discovered) ---
 // Scans plugins/<name>/api/v2/index.ts and registers as /v2/<name>

--- a/api/v2/routes/health.ts
+++ b/api/v2/routes/health.ts
@@ -1,0 +1,89 @@
+import { createRequire } from 'module';
+import express from 'express';
+import type { Request } from 'express';
+import {
+    collectObservability,
+    getAggregatorStatus,
+    getKafkaStatus,
+    getKafkaEvents,
+    getKafkaEventsMeta,
+} from '../../services/systemHealth.ts';
+
+const require = createRequire(import.meta.url);
+const common = require('../../utils/common.js');
+const { validateUser } = require('../../utils/rights.js');
+const log = require('../../utils/log.js')('v2:health');
+
+const router = express.Router();
+
+// GET /v2/health/observability
+router.get('/observability', async(req: Request, _res) => {
+    const params = (req as any).countlyParams;
+    try {
+        await validateUser(params);
+        const data = await collectObservability(params);
+        common.returnOutput(params, data);
+    }
+    catch (err) {
+        log.e('GET /v2/health/observability error: %j', err);
+        common.returnMessage(params, 500, 'Error collecting observability data');
+    }
+});
+
+// GET /v2/health/aggregator
+router.get('/aggregator', async(req: Request, _res) => {
+    const params = (req as any).countlyParams;
+    try {
+        await validateUser(params);
+        const data = await getAggregatorStatus();
+        common.returnOutput(params, data);
+    }
+    catch (err) {
+        log.e('GET /v2/health/aggregator error: %j', err);
+        common.returnMessage(params, 500, 'Error fetching aggregator status');
+    }
+});
+
+// GET /v2/health/kafka
+router.get('/kafka', async(req: Request, _res) => {
+    const params = (req as any).countlyParams;
+    try {
+        await validateUser(params);
+        const data = await getKafkaStatus();
+        common.returnOutput(params, data);
+    }
+    catch (err) {
+        log.e('GET /v2/health/kafka error: %j', err);
+        common.returnMessage(params, 500, 'Error fetching Kafka stats');
+    }
+});
+
+// GET /v2/health/kafka/events/meta  (must be before /kafka/events to avoid route clash)
+router.get('/kafka/events/meta', async(req: Request, _res) => {
+    const params = (req as any).countlyParams;
+    try {
+        await validateUser(params);
+        const data = await getKafkaEventsMeta();
+        common.returnOutput(params, data);
+    }
+    catch (err) {
+        log.e('GET /v2/health/kafka/events/meta error: %j', err);
+        common.returnMessage(params, 500, 'Error fetching Kafka events meta');
+    }
+});
+
+// GET /v2/health/kafka/events
+router.get('/kafka/events', async(req: Request, _res) => {
+    const params = (req as any).countlyParams;
+    try {
+        await validateUser(params);
+        const data = await getKafkaEvents(params.qstring);
+        common.returnOutput(params, data);
+    }
+    catch (err) {
+        log.e('GET /v2/health/kafka/events error: %j', err);
+        common.returnMessage(params, 500, 'Error fetching Kafka consumer events');
+    }
+});
+
+export default router;

--- a/frontend/express/public/core/health-manager/README.md
+++ b/frontend/express/public/core/health-manager/README.md
@@ -1,11 +1,18 @@
 # Health Manager
 
-Health Manager groups backend health views under one Management entry (`#/manage/health`). The set of tabs is dynamic: Mutation Status is available today, and additional metrics can be enabled here.
+Health Manager groups backend health views under one Management entry (`#/manage/health`). Four tabs are registered today: Mutation Status, Aggregator Status, Ingestion Status, and Kafka Events. The tab set is dynamic — additional metrics can be added here via `countlyVue.container.registerTab`.
 
 ## Access & Navigation
-- Visible to users with the `core` permission
+- Visible to users with the `core` permission.
 - Sidebar: Management → Health Manager.
-- Routes: `#/manage/health` and `#/manage/health/mutation-status`.
+- Routes:
+  - `#/manage/health` (redirects to the first tab)
+  - `#/manage/health/mutation-status`
+  - `#/manage/health/aggregator-status`
+  - `#/manage/health/ingestion-status`
+  - `#/manage/health/kafka-events`
+
+---
 
 ## Mutation Status (UI)
 Backed by `GET /o/system/observability` (providers: `mutation`, `clickhouse`). The screen is split into three parts:
@@ -16,19 +23,23 @@ Backed by `GET /o/system/observability` (providers: `mutation`, `clickhouse`). T
 ClickHouse optionality: when ClickHouse is not enabled, the system health section and `awaiting_ch_mutation_validation` status are hidden because they are ClickHouse-specific and do not block the Mongo-only flow.
 
 ## Mutation Status (Backend)
-The Mutation Manager service ensures granular deletes/updates reach all datastores that hold raw analytics. A single worker runs every minute (schedule is configurable in the `jobs` page) and reserves up to 10 oldest queued items per batch (batch limit is configurable in the `plugins` collection), marks them `running`, applies Mongo delete/update, optionally schedules ClickHouse mutations, then retries or completes. If ClickHouse pressure is high, reservation pauses and the yellow banner stays up until healthy. 
+The Mutation Manager service ensures granular deletes/updates reach all datastores that hold raw analytics. A single worker runs every minute (schedule is configurable in the `jobs` page) and reserves up to 10 oldest queued items per batch (batch limit is configurable in the `plugins` collection), marks them `running`, applies Mongo delete/update, optionally schedules ClickHouse mutations, then retries or completes. If ClickHouse pressure is high, reservation pauses and the yellow banner stays up until healthy.
 For more key points: `core/api/utils/mutationManager.README.md`
 - Accepts intents via `/core/delete_granular_data` and `/core/update_granular_data`; queues them in the `mutation_manager` collection with retry/backoff.
+- A third hook, `/core/execute_native_ch_mutation`, accepts raw ClickHouse ALTER TABLE DELETE/UPDATE statements. The SQL is validated by `isSafeNativeChMutation()` which only allows ALTER TABLE … DELETE/UPDATE … WHERE … syntax.
 - Runs a single-concurrency job (`core/api/jobs/mutationManagerJob.js`) every minute to reserve batches, process Mongo updates/deletes, and, when ClickHouse is enabled, schedule matching mutations.
 - Status lifecycle: `queued` → `running` → (optional) `awaiting_ch_mutation_validation` → `completed` or `failed` (after max retries).
+- Job defaults: `STALE_MS` 24 h, `RETRY_DELAY_MS` 30 min, `MAX_RETRIES` 3, `VALIDATION_INTERVAL_MS` 3 min, `BATCH_LIMIT` 10.
 - Fields: `ts`, `hb`, `retry_at`, `error`, `mutation_completion_ts` (used by the TTL index to purge old completed items).
 - Observability: registers `/system/observability/collect` with provider `mutation`, exposing queue summary and ClickHouse pressure so the UI and probes can react.
+
+---
 
 ## Aggregator Status (UI)
 Backed by `GET /o/system/kafka` and `GET /o/system/aggregator`. The screen displays:
 
 ### Kafka Consumer Stats
-When Kafka is enabled, displays comprehensive consumer health metrics:
+When Kafka is enabled, displays comprehensive consumer health metrics. Consumer groups whose ID contains `connect-clickhouse-sink` are filtered **out** — those are shown in the Ingestion Status tab instead.
 
 1. **Summary Cards** - Six metric cards showing:
    - Total Lag: Messages waiting to be processed (color-coded: green <1k, yellow <10k, red >10k)
@@ -54,13 +65,72 @@ For non-Kafka deployments, shows change stream resume token status:
 - Diff(drill): Lag behind drill events
 - Diff(now): Lag behind current time
 
-### Backend Collections
-- `kafka_consumer_state`: Per-partition deduplication and batch size stats (TTL: 7 days)
-- `kafka_consumer_health`: Per-consumer-group health stats (rebalances, errors, lag) (TTL: 7 days)
+---
 
-### Lag Monitoring Job
+## Ingestion Status (UI)
+Backed by `GET /o/system/kafka` (same endpoint as Aggregator Status, but filtered to only show consumer groups whose ID contains `connect-clickhouse-sink`). The screen monitors the Kafka Connect ClickHouse sink pipeline:
+
+1. **Summary Cards** - Four metric cards:
+   - Sink Lag: Total lag for sink consumer groups (color-coded: green <1k, yellow <10k, red >10k)
+   - Connectors Running: Running / total connectors
+   - Tasks Running: Running / total tasks across all connectors
+   - Throughput: Events-per-second from lag history
+
+2. **Throughput Chart** - Line chart of historical throughput derived from `kafka_lag_history` snapshots.
+
+3. **Connector Details Table** - Per-connector status from `kafka_connect_status`:
+   - Connector Name, State (RUNNING / PAUSED / FAILED), Type, Worker ID
+   - Tasks: each task's state, worker, and trace (if failed)
+
+## Ingestion Status (Backend)
+- The `kafkaLagMonitor.js` job (runs every 2 minutes) also fetches Kafka Connect connector status via the Connect REST API (`connectApiUrl` config) and writes to the `kafka_connect_status` collection.
+- Connector status documents include: connector name, state, type, worker ID, tasks array with per-task state/worker/trace.
+- The same `/o/system/kafka` endpoint serves both Aggregator and Ingestion tabs; the frontend applies the `connect-clickhouse-sink` filter.
+
+---
+
+## Kafka Events (UI)
+Backed by `GET /o/system/kafka/events` and `GET /o/system/kafka/events/meta`. The screen shows a server-side paginated table of consumer anomaly events recorded during batch deduplication:
+
+1. **Filters** - Filter by event type and consumer group (populated from the `/meta` endpoint).
+
+2. **Events Table** - Columns: Timestamp, Type, Severity, Group ID, Topic, Partition, Cluster ID, State Key. Each row is expandable to show full event details and metadata (hostname, process ID).
+
+3. **Event Types and Severity**:
+
+   | Type | Severity | Color | Meaning |
+   |------|----------|-------|---------|
+   | `CLUSTER_MISMATCH` | error | red | Stored cluster ID ≠ current cluster ID. Consumer state is reset. |
+   | `OFFSET_BACKWARD` | error | red | Committed offset went backward significantly. Partition state is reset. |
+   | `STATE_RESET` | warning | yellow | Full state reset triggered during a cluster mismatch. |
+   | `STATE_MIGRATED` | success | green | Legacy state document upgraded to cluster-versioned format. |
+
+4. **Pagination** - Server-side pagination via the `ServerDataTable` pattern; the API supports `page`, `limit`, `sort`, `query` (type/groupId filters).
+
+## Kafka Events (Backend)
+- Events are recorded by `KafkaEventSource.js` during batch deduplication when anomalies are detected (cluster mismatch, offset regression, state migration).
+- Each event document includes: `ts`, `type`, `groupId`, `topic`, `partition`, `clusterId`, `stateKey`, `details` (human-readable message), `metadata` (hostname, processId).
+- The `/o/system/kafka/events/meta` endpoint returns distinct event types and group IDs for filter dropdowns; the response is cached for 30 seconds with in-flight deduplication to prevent thundering-herd on page load.
+- Query index: `{ type: 1, groupId: 1, ts: -1 }` (created in `aggregator.ts`).
+
+---
+
+## Backend Collections
+
+| Collection | Purpose | TTL | Created In |
+|------------|---------|-----|------------|
+| `mutation_manager` | Granular mutation request queue | 30 days on `mutation_completion_ts` | `mutationManager.ts` |
+| `kafka_consumer_state` | Per-partition dedup and batch size stats | 7 days | `aggregator.ts` |
+| `kafka_consumer_health` | Per-group health (lag, rebalances, errors) | 7 days | `aggregator.ts` |
+| `kafka_lag_history` | Lag snapshots for throughput charts | Capped: 1000 docs / 5 MB | `aggregator.ts` |
+| `kafka_connect_status` | Kafka Connect connector status | 7 days on `updatedAt` | `ingestor.js` |
+| `kafka_consumer_events` | Consumer anomaly events | 30 days on `ts` | `aggregator.ts` |
+
+## Lag Monitoring Job
 The `kafkaLagMonitor.js` job runs every 2 minutes to:
-1. Connect to Kafka admin API
-2. Fetch high watermarks for all topics
-3. Compare with committed offsets to calculate lag
-4. Update `kafka_consumer_health` collection with lag stats
+1. Connect to Kafka admin API and fetch high watermarks for all topics
+2. Compare with committed offsets to calculate per-partition lag
+3. Update `kafka_consumer_health` collection with lag stats
+4. Fetch Kafka Connect connector/task status via the Connect REST API
+5. Write connector status to `kafka_connect_status`
+6. Append lag snapshots to `kafka_lag_history` (capped collection)


### PR DESCRIPTION
## Summary

Adds backend support for the new React-based Health Manager dashboard by:

- Extracting system health query logic into a shared service module
- Creating new `/v2/health/*` endpoints with JWT auth
- Adding CORS support to legacy endpoints so the new frontend can call any `/o` or `/i` route with JWT Bearer tokens

## New v2 Health Endpoints

| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | `/v2/health/observability` | Mutation status from observability pipeline |
| GET | `/v2/health/aggregator` | Aggregator service status |
| GET | `/v2/health/kafka` | Kafka broker status |
| GET | `/v2/health/kafka/events` | Kafka event stream data |
| GET | `/v2/health/kafka/events/meta` | Kafka events metadata (30s cached) |

## Changes

### New files
- **`api/services/systemHealth.ts`** — Shared service with 5 exported functions (`collectObservability`, `getAggregatorStatus`, `getKafkaStatus`, `getKafkaEvents`, `getKafkaEventsMeta`). Includes 30-second meta cache with in-flight deduplication (thundering herd protection). Called by both legacy and v2 routes (DRY).
- **`api/v2/routes/health.ts`** — Express router for `/v2/health/*` using JWT auth via `validateUser`, with `paramsAdapter` + `transformResponse` middleware.

### Modified files
- **`api/utils/requestProcessor.js`** — Replaced ~300 lines of inline `/o/system/*` handler logic with thin wrappers that delegate to the shared service via lazy `import()`. Removed duplicated cache variables.
- **`api/v2/app.ts`** — Mounted health router at `/v2/health`. Fixed CORS to reflect request `Origin` header and set `Access-Control-Allow-Credentials: true` (required for cookie-based refresh tokens).
- **`api/api.js`** — Added CORS headers to all legacy endpoint responses: reflects `Origin`, allows `Authorization` header, sets `Allow-Credentials`. This enables the new React frontend to call legacy `/o` and `/i` endpoints directly with JWT Bearer tokens — no proxy or migration needed.

### Documentation
- **`frontend/express/public/core/health-manager/README.md`** — Documents all 4 tabs, backend collections, and endpoint contracts.

## Architecture

```
┌─────────────────────┐     JWT + CORS      ┌──────────────────────┐
│  React frontend     │ ──────────────────▶  │  /v2/health/*        │
│  (localhost:5173)    │                      │  (Express v2 app)    │
│                      │     JWT + CORS      ├──────────────────────┤
│                      │ ──────────────────▶  │  /o/* /i/*           │
│                      │                      │  (legacy api.js)     │
└─────────────────────┘                      └──────┬───────────────┘
                                                    │
                                             ┌──────▼───────────────┐
                                             │  systemHealth.ts     │
                                             │  (shared service)    │
                                             └──────────────────────┘
```

Both legacy handlers and v2 routes delegate to the same shared service — no logic duplication.