### PR TITLE
[Feat] Setup routes

### DIFF
--- a/api/utils/rights.js
+++ b/api/utils/rights.js
@@ -41,7 +41,28 @@ function validate_token_if_exists(params) {
                 try {
                     var decoded = (jwt.verify(bearerToken, secret));
                     if (decoded && decoded.memberId && decoded.type === 'access') {
-                        resolve(decoded.memberId);
+                        var _id = common.db.ObjectID(decoded.memberId);
+                        common.db.collection('members').findOne(
+                            { _id: _id },
+                            { projection: { _id: 1, token_invalid_before: 1 } },
+                            function(err, member) {
+                                if (err || !member) {
+                                    resolve('token-invalid');
+                                    return;
+                                }
+                                else {
+                                    if (
+                                        member.token_invalid_before &&
+                                        decoded.iat &&
+                                        member.token_invalid_before > decoded.iat * 1000
+                                    ) {
+                                        resolve('token-invalid');
+                                        return;
+                                    }
+
+                                    resolve(decoded.memberId);
+                                }
+                            });
                         return;
                     }
                 }

--- a/api/utils/rights.js
+++ b/api/utils/rights.js
@@ -54,7 +54,7 @@ function validate_token_if_exists(params) {
                                     if (
                                         member.token_invalid_before &&
                                         decoded.iat &&
-                                        member.token_invalid_before > decoded.iat * 1000
+                                        member.token_invalid_before > decoded.iat
                                     ) {
                                         resolve('token-invalid');
                                         return;

--- a/api/v2/app.ts
+++ b/api/v2/app.ts
@@ -20,6 +20,11 @@ const preventBruteforce = require('../../frontend/express/libs/preventBruteforce
 
 const app = express();
 
+// Match legacy: honor X-Forwarded-* so req.ip reflects the real client IP
+// behind the load balancer. Required for /forgot rate limiting to key on the
+// actual client rather than the LB's internal IP.
+app.set('trust proxy', true);
+
 app.use(function(_req: Request, _res: Response, next: NextFunction) {
     if (!preventBruteforce.db && common.db) {
         preventBruteforce.db = common.db;

--- a/api/v2/app.ts
+++ b/api/v2/app.ts
@@ -60,7 +60,7 @@ app.use(function(_req: Request, res: Response, next: NextFunction) {
     }
 
     if (_req.method === 'OPTIONS') {
-        res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
+        res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, PATCH, DELETE, OPTIONS');
         res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
         return res.sendStatus(200);
     }

--- a/api/v2/routes/apps.ts
+++ b/api/v2/routes/apps.ts
@@ -4,6 +4,7 @@ import express from 'express';
 import type { MemberPublic } from '../../../../web/src/shared/types/auth.js';
 import type { AppPublic } from '../../../../web/src/shared/types/app.js';
 import type { ObjectId } from 'mongodb';
+import { nowSec } from '../services/utils/time.ts';
 
 const require = createRequire(import.meta.url);
 const common = require('../../utils/common.js');
@@ -125,7 +126,7 @@ router.post('/create', async(req, _res) => {
         const trimmedKey = typeof key === 'string' ? key.trim() : '';
         const appKey = trimmedKey || common.sha1Hash(crypto.randomBytes(256).toString('hex'), true);
 
-        const now = Math.floor(Date.now() / 1000);
+        const now = nowSec();
         const newApp: Partial<AppDocument> = {
             name: name,
             key: appKey,

--- a/api/v2/routes/apps.ts
+++ b/api/v2/routes/apps.ts
@@ -1,4 +1,5 @@
 import { createRequire } from 'module';
+import crypto from 'crypto';
 import express from 'express';
 import type { MemberPublic } from '../../../../web/src/shared/types/auth.js';
 import type { AppPublic } from '../../../../web/src/shared/types/app.js';
@@ -8,6 +9,7 @@ const require = createRequire(import.meta.url);
 const common = require('../../utils/common.js');
 const { validateUser } = require('../../utils/rights.js');
 const log = require('../../utils/log.js')('v2:apps');
+const plugins = require('../../../plugins/pluginManager.js');
 
 interface AppDocument {
     _id: ObjectId;
@@ -26,6 +28,15 @@ interface AppDocument {
     has_image: boolean;
     locked?: boolean;
     plugins?: Record<string, any>;
+}
+
+interface CreateAppRequest {
+    category?: string;
+    country?: string;
+    key?: string;
+    name: string;
+    timezone: string;
+    type: string;
 }
 
 const router = express.Router();
@@ -91,6 +102,88 @@ router.get('/:id', async(req, _res) => {
         log.e('GET /v2/apps/:id error: %j', err);
     }
 });
+
+router.post('/create', async(req, _res) => {
+    const params = req.countlyParams;
+
+    try {
+        await validateUser(params);
+        const { member } = params;
+
+        const { name, type, timezone, key, country, category } = req.body as CreateAppRequest;
+
+        if (!name || typeof name !== 'string' || name.trim().length === 0) {
+            return common.returnMessage(params, 400, 'Name is required');
+        }
+        if (!type || typeof type !== 'string') {
+            return common.returnMessage(params, 400, 'Type is required');
+        }
+        if (!timezone || typeof timezone !== 'string') {
+            return common.returnMessage(params, 400, 'Timezone is required');
+        }
+
+        const trimmedKey = typeof key === 'string' ? key.trim() : '';
+        const appKey = trimmedKey || common.sha1Hash(crypto.randomBytes(256).toString('hex'), true);
+
+        const now = Math.floor(Date.now() / 1000);
+        const newApp: Partial<AppDocument> = {
+            name: name,
+            key: appKey,
+            type,
+            timezone,
+            country: country || '',
+            category: category || '',
+            created_at: now,
+            edited_at: now,
+            owner: (member._id as ObjectId).toString(),
+            seq: 0,
+            has_image: false,
+        };
+
+        let insertedAppId: ObjectId;
+
+        try {
+            insertedAppId = await new Promise<ObjectId>((resolve, reject) => {
+                common.db.collection('apps').insert(newApp, (err: any, result: any) => {
+                    if (err || !result?.ops?.[0]?._id) {
+                        return reject(err || new Error('Insert failed'));
+                    }
+                    resolve(result.ops[0]._id);
+                });
+            });
+        }
+        catch (insertErr: any) {
+            if (insertErr?.code === 11000) {
+                return common.returnMessage(params, 409, 'App key already in use');
+            }
+            throw insertErr;
+        }
+
+        newApp._id = insertedAppId;
+
+        // Ensure indexes on app_users<id> — matches legacy createApp behavior
+        const appUsersCol = common.db.collection('app_users' + insertedAppId);
+        appUsersCol.ensureIndex({ ls: -1 }, { background: true }, () => {});
+        appUsersCol.ensureIndex({ uid: 1 }, { background: true }, () => {});
+        appUsersCol.ensureIndex({ sc: 1 }, { background: true }, () => {});
+        appUsersCol.ensureIndex({ lac: -1 }, { background: true }, () => {});
+        appUsersCol.ensureIndex({ tsd: 1 }, { background: true }, () => {});
+        appUsersCol.ensureIndex({ did: 1 }, { background: true }, () => {});
+
+        // Plugin hook so plugin-specific per-app collections get created
+        plugins.dispatch('/i/apps/create', {
+            params,
+            appId: insertedAppId,
+            data: newApp,
+        });
+
+        common.returnOutput(params, newApp);
+    }
+    catch (err) {
+        log.e('POST /v2/apps/create error: %j', err);
+    }
+});
+
 
 const formatApp = (app: AppDocument, role: 'admin' | 'user'): AppPublic => ({
     _id: app._id.toString(),

--- a/api/v2/routes/apps.ts
+++ b/api/v2/routes/apps.ts
@@ -40,6 +40,16 @@ interface CreateAppRequest {
     type: string;
 }
 
+// Indexes ensured on app_users<id> at app creation. Matches legacy createApp.
+const APP_USERS_INDEX_SPECS: Array<Record<string, 1 | -1>> = [
+    { ls: -1 },
+    { uid: 1 },
+    { sc: 1 },
+    { lac: -1 },
+    { tsd: 1 },
+    { did: 1 },
+];
+
 const router = express.Router();
 
 // GET /v2/apps - list apps the current user has access to
@@ -162,14 +172,10 @@ router.post('/create', async(req, _res) => {
 
         newApp._id = insertedAppId;
 
-        // Ensure indexes on app_users<id> — matches legacy createApp behavior
         const appUsersCol = common.db.collection('app_users' + insertedAppId);
-        appUsersCol.ensureIndex({ ls: -1 }, { background: true }, () => {});
-        appUsersCol.ensureIndex({ uid: 1 }, { background: true }, () => {});
-        appUsersCol.ensureIndex({ sc: 1 }, { background: true }, () => {});
-        appUsersCol.ensureIndex({ lac: -1 }, { background: true }, () => {});
-        appUsersCol.ensureIndex({ tsd: 1 }, { background: true }, () => {});
-        appUsersCol.ensureIndex({ did: 1 }, { background: true }, () => {});
+        APP_USERS_INDEX_SPECS.forEach((spec) => {
+            appUsersCol.ensureIndex(spec, { background: true }, () => {});
+        });
 
         // Plugin hook so plugin-specific per-app collections get created
         plugins.dispatch('/i/apps/create', {

--- a/api/v2/routes/auth.ts
+++ b/api/v2/routes/auth.ts
@@ -528,9 +528,56 @@ router.post('/refresh', async function(req: Request, res: Response) {
     );
 });
 
-router.post('/logout', function(_req: Request, res: Response) {
-    res.clearCookie(REFRESH_COOKIE_NAME, { path: '/v2/auth' });
-    res.json({ data: { message: 'Logged out successfully' } });
+router.post('/logout', async function(req: Request, res: Response, next: NextFunction) {
+    try {
+        const refreshToken = req.cookies?.[REFRESH_COOKIE_NAME];
+        let memberId: string | null = null;
+
+        if (refreshToken) {
+            try {
+                const secret: string = common.config.api.jwtSecret;
+                const decoded = jwt.verify(refreshToken, secret) as JwtPayload;
+
+                if (decoded.type === 'refresh') {
+                    memberId = decoded.memberId;
+                }
+            }
+            catch {
+                // Invalid/expired cookie — logout still succeeds below.
+                // Intentionally swallowed: a stale cookie is not an error at logout time.
+            }
+        }
+
+        let member: Record<string, unknown> | null = null;
+
+        if (memberId) {
+            try {
+                member = await findMemberById(common.db.ObjectID(memberId));
+            }
+            catch {
+                // DB blip — keep going. We'll still clear the cookie.
+            }
+        }
+
+        if (member) {
+            plugins.callMethod("userLogout", {
+                req,
+                data: {
+                    uid: member._id,
+                    email: member.email,
+                    query: req.query
+                }
+            });
+
+            killOtherSessionsForUser({ userId: (member._id as { toString(): string }).toString() });
+        }
+
+        res.clearCookie(REFRESH_COOKIE_NAME, { path: '/v2/auth' });
+        res.json({ data: { message: 'Logged out successfully' } });
+    }
+    catch (err: unknown) {
+        next(err);
+    }
 });
 
 router.post('/forgot', async function(req: Request, res: Response, next: NextFunction) {

--- a/api/v2/routes/auth.ts
+++ b/api/v2/routes/auth.ts
@@ -45,7 +45,7 @@ function escapeRegEx(string: string): string {
 function findMemberByEmail(email: string): Promise<Record<string, unknown> | null> {
     return new Promise((resolve, reject) => {
         common.db.collection('members').findOne(
-            { email },
+            { email: { $regex: `^${escapeRegEx(email)}$`, $options: 'i' } },
             function(err: unknown, doc: Record<string, unknown> | null) {
                 if (err) {
                     return reject(err);
@@ -241,11 +241,8 @@ async function verifyCredentials(usernameOrEmail: string, password: string): Pro
             {
                 $or: [
                     { username: trimmedUsernameOrEmail },
-                    {
-                        email: {
-                            $regex: `^${escapeRegEx(trimmedUsernameOrEmail)}$`, $options: 'i'
-                        }
-                    }]
+                    { email: { $regex: `^${escapeRegEx(trimmedUsernameOrEmail)}$`, $options: 'i' }}
+                ]
             },
             function(err: any, doc: any) {
                 if (err) {

--- a/api/v2/routes/auth.ts
+++ b/api/v2/routes/auth.ts
@@ -18,327 +18,44 @@ import type { ApiError } from '../../../../web/src/shared/types/api.js';
 import jwt from 'jsonwebtoken';
 import crypto from 'crypto';
 import argon2 from 'argon2';
-import { validatePassword, killOtherSessionsForUser } from '../services/members.ts';
+import {
+    countMembers,
+    findMemberByEmail,
+    findMemberById,
+    insertMember,
+    killOtherSessionsForUser,
+    validatePassword,
+} from '../services/members.ts';
+import {
+    PASSWORD_RESET_TTL_SECONDS,
+    REFRESH_COOKIE_NAME,
+    findResetToken,
+    generateTokens,
+    getRefreshCookieOptions,
+    insertResetToken,
+    invalidateUserTokens,
+    isBruteforceBlocked,
+    isForgotBlocked,
+    nowSec,
+    passwordMatchesHash,
+    recordFailedLogin,
+    recordForgotFail,
+    removeResetToken,
+    resetFailedLogins,
+    stripPassword,
+    updateMemberPassword,
+    updateMemberPasswordWithHistory,
+    verifyCredentials,
+    type JwtPayload,
+} from '../services/auth/index.ts';
 
 
 const require = createRequire(import.meta.url);
 const common = require('../../utils/common.js');
-const preventBruteforce = require('../../../frontend/express/libs/preventBruteforce.js');
 const mail = require('../../parts/mgmt/mail.js');
 const plugins = require('../../../plugins/pluginManager.js');
 
 const router = express.Router();
-
-// TODO: make this value configurable in setting security tab once the page is added to the new dashboard
-const PASSWORD_RESET_TTL_SECONDS = 600;
-const REFRESH_COOKIE_NAME = 'cly_refresh_token';
-
-interface JwtPayload {
-    iat?: number;
-    memberId: string;
-    type: 'access' | 'refresh';
-}
-
-function countMembers(): Promise<number> {
-    return new Promise((resolve, reject) => {
-        common.db.collection('members').count(
-            function(err: unknown, count: number) {
-                if (err) {
-                    return reject(err);
-                }
-                resolve(count);
-            }
-        );
-    });
-}
-
-function escapeRegEx(string: string): string {
-    return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-function findMemberByEmail(email: string): Promise<Record<string, unknown> | null> {
-    return new Promise((resolve, reject) => {
-        common.db.collection('members').findOne(
-            { email: { $regex: `^${escapeRegEx(email)}$`, $options: 'i' } },
-            function(err: unknown, doc: Record<string, unknown> | null) {
-                if (err) {
-                    return reject(err);
-                }
-                resolve(doc);
-            }
-        );
-    });
-}
-
-function findMemberById(id: unknown): Promise<Record<string, unknown> | null> {
-    return new Promise((resolve, reject) => {
-        common.db.collection('members').findOne(
-            { _id: id },
-            function(err: unknown, doc: Record<string, unknown> | null) {
-                if (err) {
-                    return reject(err);
-                }
-                resolve(doc);
-            }
-        );
-    });
-}
-
-function findResetToken(prid: string): Promise<Record<string, unknown> | null> {
-    return new Promise((resolve, reject) => {
-        common.db.collection('password_reset').findOne(
-            { prid },
-            function(err: unknown, doc: Record<string, unknown> | null) {
-                if (err) {
-                    return reject(err);
-                }
-                resolve(doc);
-            }
-        );
-    });
-}
-
-function generateTokens(member: any): { accessToken: string; refreshToken: string } {
-    const secret: string = common.config.api.jwtSecret;
-    const accessToken = jwt.sign(
-        { memberId: member._id.toString(), type: 'access' } satisfies JwtPayload,
-        secret,
-        { expiresIn: common.config.api.jwtAccessTokenExpiry }
-    );
-    const refreshToken = jwt.sign(
-        { memberId: member._id.toString(), type: 'refresh' } satisfies JwtPayload,
-        secret,
-        { expiresIn: common.config.api.jwtRefreshTokenExpiry }
-    );
-    return { accessToken, refreshToken };
-}
-
-function getRefreshCookieOptions() {
-    return {
-        httpOnly: true,
-        secure: common.config.api.ssl?.enabled === true,
-        sameSite: 'strict' as const,
-        path: '/v2/auth',
-        maxAge: parseDaysToMs(common.config.api.jwtRefreshTokenExpiry),
-    };
-}
-
-function insertMember(doc: Record<string, unknown>): Promise<Record<string, unknown>> {
-    return new Promise((resolve, reject) => {
-        common.db.collection('members').insert(
-            doc,
-            { safe: true },
-            function(err: unknown, result: { ops: Record<string, unknown>[] }) {
-                if (err) {
-                    return reject(err);
-                }
-                resolve(result.ops[0]);
-            }
-        );
-    });
-}
-
-function insertResetToken(prid: string, userId: unknown, timestamp: number): Promise<void> {
-    return new Promise((resolve, reject) => {
-        common.db.collection('password_reset').insert(
-            { prid, user_id: userId, timestamp },
-            { safe: true },
-            function(err: unknown) {
-                if (err) {
-                    return reject(err);
-                }
-                resolve();
-            }
-        );
-    });
-}
-
-function invalidateUserTokens(memberId: unknown): Promise<void> {
-    return new Promise((resolve, reject) => {
-        common.db.collection('members').updateOne(
-            { _id: memberId },
-            { $set: { token_invalid_before: nowSec() } },
-            function(err: unknown) {
-                if (err) {
-                    console.error('Error invalidating user tokens:', err);
-                    return reject(err);
-                }
-                resolve();
-            }
-        );
-    });
-}
-
-function isArgon2Hash(hash: string): boolean {
-    return Boolean(hash && hash.startsWith('$argon2'));
-}
-
-function isBruteforceBlocked(username: string): Promise<{ blocked: boolean; fails: number }> {
-    return new Promise((resolve) => {
-        preventBruteforce.isBlocked("login", username, function(blocked: boolean, fails: number) {
-            resolve({ blocked, fails });
-        });
-    });
-}
-
-function isForgotBlocked(ip: string | undefined): Promise<{ blocked: boolean; fails: number }> {
-    if (!ip) {
-        return Promise.resolve({ blocked: false, fails: 0 });
-    }
-
-    return new Promise((resolve) => {
-        preventBruteforce.isBlocked("forgot", ip, function(blocked: boolean, fails: number) {
-            resolve({ blocked, fails });
-        });
-    });
-}
-
-function nowSec(): number {
-    return Math.round(Date.now() / 1000);
-}
-
-function parseDaysToMs(duration: string): number {
-    const days = Number.parseInt(duration, 10);
-
-    if (Number.isNaN(days)) {
-        return 7 * 24 * 60 * 60 * 1000;
-    }
-
-    return days * 24 * 60 * 60 * 1000;
-}
-
-async function passwordMatchesHash(password: string, storedHash: string): Promise<boolean> {
-    const secret = common.config.passwordSecret || "";
-    const effectivePassword = password + secret;
-
-    try {
-        if (isArgon2Hash(storedHash)) {
-            return await argon2.verify(storedHash, effectivePassword);
-        }
-
-        const sha1 = crypto.createHmac('sha1', '').update(effectivePassword).digest('hex');
-        const sha512 = crypto.createHmac('sha512', '').update(effectivePassword).digest('hex');
-
-        return storedHash === sha1 || storedHash === sha512;
-    }
-    catch {
-        return false;
-    }
-}
-
-function recordFailedLogin(username: string): void {
-    preventBruteforce.fail("login", username);
-}
-
-function recordForgotFail(ip: string | undefined): void {
-    preventBruteforce.fail("forgot", ip || 'Undefined IP');
-}
-
-function removeResetToken(prid: string): void {
-    common.db.collection('password_reset').remove({ prid }, function() {});
-}
-
-function resetFailedLogins(username: string): void {
-    preventBruteforce.reset("login", username);
-}
-
-function stripPassword(input: unknown): Record<string, unknown> {
-    if (typeof input !== 'object' || input === null) {
-        return {};
-    }
-
-    const clone = { ...input as Record<string, unknown> };
-
-    delete clone.password;
-
-    return clone;
-}
-
-function updateMemberPassword(id: unknown, hashedPassword: string): Promise<void> {
-    return new Promise((resolve, reject) => {
-        common.db.collection('members').updateOne(
-            { _id: id },
-            { $set: { password: hashedPassword, password_changed: nowSec() } },
-            function(err: unknown) {
-                if (err) {
-                    return reject(err);
-                }
-                resolve();
-            }
-        );
-    });
-}
-
-function updateMemberPasswordWithHistory(
-    id: unknown,
-    newHash: string,
-    oldHash: string,
-    rotationLimit: number
-): Promise<void> {
-    return new Promise((resolve, reject) => {
-        common.db.collection('members').updateOne(
-            { _id: id },
-            {
-                $set: { password: newHash, password_changed: nowSec() },
-                $push: { password_history: { $each: [oldHash], $slice: -rotationLimit } }
-            },
-            function(err: unknown) {
-                if (err) {
-                    return reject(err);
-                }
-                resolve();
-            }
-        );
-    });
-}
-
-async function verifyCredentials(usernameOrEmail: string, password: string): Promise<any | null> {
-    const trimmedUsernameOrEmail = `${usernameOrEmail}`.trim();
-
-    const member = await new Promise<any>((resolve, reject) => {
-        common.db.collection('members').findOne(
-            {
-                $or: [
-                    { username: trimmedUsernameOrEmail },
-                    { email: { $regex: `^${escapeRegEx(trimmedUsernameOrEmail)}$`, $options: 'i' }}
-                ]
-            },
-            function(err: any, doc: any) {
-                if (err) {
-                    return reject(err);
-                }
-                resolve(doc);
-            }
-        );
-    });
-
-    if (!member) {
-        return null;
-    }
-
-    if (member.locked) {
-        const err: any = new Error('User account is locked');
-        err.code = 'ACCOUNT_LOCKED';
-        throw err;
-    }
-
-    const match = await passwordMatchesHash(password, member.password);
-
-    if (!match) {
-        return null;
-    }
-
-    if (!isArgon2Hash(member.password)) {
-        const secret = common.config.passwordSecret || "";
-        const argon2Hash = await argon2.hash(password + secret);
-        common.db.collection('members').updateOne(
-            { _id: member._id },
-            { $set: { password: argon2Hash } }
-        );
-    }
-
-    return member;
-}
 
 router.get('/setup-status', async function(_req: Request, res: Response) {
     try {

--- a/api/v2/routes/auth.ts
+++ b/api/v2/routes/auth.ts
@@ -322,24 +322,15 @@ async function verifyCredentials(usernameOrEmail: string, password: string): Pro
         throw err;
     }
 
-    const secret = common.config.passwordSecret || "";
-    const effectivePassword = password + secret;
+    const match = await passwordMatchesHash(password, member.password);
 
-    if (isArgon2Hash(member.password)) {
-        const match = await argon2.verify(member.password, effectivePassword);
-        if (!match) {
-            return null;
-        }
+    if (!match) {
+        return null;
     }
-    else {
-        const sha1 = crypto.createHmac('sha1', '').update(effectivePassword).digest('hex');
-        const sha512 = crypto.createHmac('sha512', '').update(effectivePassword).digest('hex');
 
-        if (member.password !== sha1 && member.password !== sha512) {
-            return null;
-        }
-
-        const argon2Hash = await argon2.hash(effectivePassword);
+    if (!isArgon2Hash(member.password)) {
+        const secret = common.config.passwordSecret || "";
+        const argon2Hash = await argon2.hash(password + secret);
         common.db.collection('members').updateOne(
             { _id: member._id },
             { $set: { password: argon2Hash } }

--- a/api/v2/routes/auth.ts
+++ b/api/v2/routes/auth.ts
@@ -269,6 +269,29 @@ function updateMemberPassword(id: unknown, hashedPassword: string): Promise<void
     });
 }
 
+function updateMemberPasswordWithHistory(
+    id: unknown,
+    newHash: string,
+    oldHash: string,
+    rotationLimit: number
+): Promise<void> {
+    return new Promise((resolve, reject) => {
+        common.db.collection('members').updateOne(
+            { _id: id },
+            {
+                $set: { password: newHash, password_changed: nowSec() },
+                $push: { password_history: { $each: [oldHash], $slice: -rotationLimit } }
+            },
+            function(err: unknown) {
+                if (err) {
+                    return reject(err);
+                }
+                resolve();
+            }
+        );
+    });
+}
+
 async function verifyCredentials(usernameOrEmail: string, password: string): Promise<any | null> {
     const trimmedUsernameOrEmail = `${usernameOrEmail}`.trim();
 
@@ -757,7 +780,10 @@ router.post('/reset', async function(req: Request, res: Response, next: NextFunc
         }
 
         if (rotationLimit > 0) {
-            const candidates: string[] = [member.password as string];
+            const candidates: string[] = [
+                member.password as string,
+                ...((member.password_history as string[]) || [])
+            ];
             const matches = await Promise.all(
                 candidates.map(h => passwordMatchesHash(password, h))
             );
@@ -777,7 +803,17 @@ router.post('/reset', async function(req: Request, res: Response, next: NextFunc
         const secret = common.config.passwordSecret || "";
         const hashedPassword = await argon2.hash(password + secret);
 
-        await updateMemberPassword(member._id, hashedPassword);
+        if (rotationLimit > 0) {
+            await updateMemberPasswordWithHistory(
+                member._id,
+                hashedPassword,
+                member.password as string,
+                rotationLimit
+            );
+        }
+        else {
+            await updateMemberPassword(member._id, hashedPassword);
+        }
 
         // Clean up the consumed token
         removeResetToken(String(prid));

--- a/api/v2/routes/auth.ts
+++ b/api/v2/routes/auth.ts
@@ -117,6 +117,7 @@ router.post('/setup', async function(req: Request, res: Response, next: NextFunc
             global_admin: true,
             created_at: now,
             password_changed: now,
+            // Empty permission matrix; global_admin: true bypasses per-feature permission checks.
             permission: { c: {}, r: {}, u: {}, d: {}, _: { a: [], u: [[]] } },
             api_key: apiKey,
         };

--- a/api/v2/routes/auth.ts
+++ b/api/v2/routes/auth.ts
@@ -622,7 +622,7 @@ router.post('/forgot', async function(req: Request, res: Response, next: NextFun
             await insertResetToken(prid, member._id, timestamp);
             member.lang = member.lang || req.body.lang || "en";
             mail.sendPasswordResetInfo(member, prid);
-            plugins.callMethod("passwordRequest", { req, data: stripPassword(member) });
+            plugins.callMethod("passwordRequest", { req, data: req.body });
         }
 
         // Always return the same response to prevent email enumeration
@@ -726,7 +726,7 @@ router.post('/reset', async function(req: Request, res: Response, next: NextFunc
         resetFailedLogins(member.username as string);
         resetFailedLogins(member.email as string);
 
-        plugins.callMethod("passwordReset", { req, data: member });
+        plugins.callMethod("passwordReset", { req, data: stripPassword(member) });
 
         const response: ResetPasswordResponse = {
             message: 'Your password has been reset.',

--- a/api/v2/routes/auth.ts
+++ b/api/v2/routes/auth.ts
@@ -10,6 +10,9 @@ import type {
     ResetPasswordRequest,
     ResetPasswordResponse,
     ResetPasswordValidateResponse,
+    SetupRequest,
+    SetupResponse,
+    SetupStatusResponse,
 } from '../../../../web/src/shared/types/auth.js';
 import type { ApiError } from '../../../../web/src/shared/types/api.js';
 import jwt from 'jsonwebtoken';
@@ -186,6 +189,34 @@ function updateMemberPassword(id: unknown, hashedPassword: string): Promise<void
     });
 }
 
+function countMembers(): Promise<number> {
+    return new Promise((resolve, reject) => {
+        common.db.collection('members').count(
+            function(err: unknown, count: number) {
+                if (err) {
+                    return reject(err);
+                }
+                resolve(count);
+            }
+        );
+    });
+}
+
+function insertMember(doc: Record<string, unknown>): Promise<Record<string, unknown>> {
+    return new Promise((resolve, reject) => {
+        common.db.collection('members').insert(
+            doc,
+            { safe: true },
+            function(err: unknown, result: { ops: Record<string, unknown>[] }) {
+                if (err) {
+                    return reject(err);
+                }
+                resolve(result.ops[0]);
+            }
+        );
+    });
+}
+
 async function verifyCredentials(username: string, password: string): Promise<any | null> {
     const member = await new Promise<any>((resolve, reject) => {
         common.db.collection('members').findOne(
@@ -209,21 +240,24 @@ async function verifyCredentials(username: string, password: string): Promise<an
         throw err;
     }
 
+    const secret = common.config.passwordSecret || "";
+    const effectivePassword = password + secret;
+
     if (isArgon2Hash(member.password)) {
-        const match = await argon2.verify(member.password, password);
+        const match = await argon2.verify(member.password, effectivePassword);
         if (!match) {
             return null;
         }
     }
     else {
-        const sha1 = crypto.createHmac('sha1', '').update(password).digest('hex');
-        const sha512 = crypto.createHmac('sha512', '').update(password).digest('hex');
+        const sha1 = crypto.createHmac('sha1', '').update(effectivePassword).digest('hex');
+        const sha512 = crypto.createHmac('sha512', '').update(effectivePassword).digest('hex');
 
         if (member.password !== sha1 && member.password !== sha512) {
             return null;
         }
 
-        const argon2Hash = await argon2.hash(password);
+        const argon2Hash = await argon2.hash(effectivePassword);
         common.db.collection('members').updateOne(
             { _id: member._id },
             { $set: { password: argon2Hash } }
@@ -232,6 +266,117 @@ async function verifyCredentials(username: string, password: string): Promise<an
 
     return member;
 }
+
+router.get('/setup-status', async function(_req: Request, res: Response) {
+    try {
+        const count = await countMembers();
+        const response: SetupStatusResponse = { needsSetup: count === 0 };
+        res.json({ data: response });
+    }
+    catch (_err: unknown) {
+        const body: ApiError = { error: { code: 'DB_NOT_READY', message: 'Database is not available yet. Please retry.' } };
+        res.status(503).json(body);
+    }
+});
+
+router.post('/setup', async function(req: Request, res: Response, next: NextFunction) {
+    try {
+        const memberCount = await countMembers();
+
+        if (memberCount > 0) {
+            const body: ApiError = { error: { code: 'SETUP_ALREADY_COMPLETE', message: 'Server is already set up' } };
+            return res.status(409).json(body);
+        }
+
+        const { full_name, email, password, lang, createDemoApp } = req.body as SetupRequest;
+
+        if (!full_name || typeof full_name !== 'string' || full_name.trim().length === 0) {
+            const body: ApiError = { error: { code: 'VALIDATION_ERROR', message: 'Full name is required' } };
+            return res.status(400).json(body);
+        }
+
+        if (!email || typeof email !== 'string' || !email.includes('@')) {
+            const body: ApiError = { error: { code: 'VALIDATION_ERROR', message: 'A valid email address is required' } };
+            return res.status(400).json(body);
+        }
+
+        if (!password || typeof password !== 'string') {
+            const body: ApiError = { error: { code: 'VALIDATION_ERROR', message: 'Password is required' } };
+            return res.status(400).json(body);
+        }
+
+        const passwordError = validatePassword(password);
+
+        if (passwordError !== null) {
+            const body: ApiError = { error: { code: 'WEAK_PASSWORD', message: passwordError } };
+            return res.status(400).json(body);
+        }
+
+        const secret = common.config.passwordSecret || "";
+        const hashedPassword = await argon2.hash(password + secret);
+
+        const apiKey = common.md5Hash(crypto.randomBytes(48).toString('hex') + Math.random());
+
+        const now = Math.floor(Date.now() / 1000);
+        const doc: Record<string, unknown> = {
+            full_name: (full_name + "").trim(),
+            username: (email + "").trim(),
+            password: hashedPassword,
+            email: (email + "").trim(),
+            global_admin: true,
+            created_at: now,
+            password_changed: now,
+            permission: { c: {}, r: {}, u: {}, d: {}, _: { a: [], u: [[]] } },
+            api_key: apiKey,
+        };
+
+        if (lang && typeof lang === 'string') {
+            doc.lang = lang;
+        }
+
+        let member: Record<string, unknown>;
+
+        try {
+            member = await insertMember(doc);
+        }
+        catch (insertErr: unknown) {
+            // Guard against TOCTOU race: if a concurrent request already
+            // inserted a member between our count check and this insert,
+            // the duplicate key error (code 11000) surfaces here.
+            const mongoErr = insertErr as { code?: number };
+
+            if (mongoErr.code === 11000) {
+                const body: ApiError = { error: { code: 'SETUP_ALREADY_COMPLETE', message: 'Server is already set up' } };
+                return res.status(409).json(body);
+            }
+
+            throw insertErr;
+        }
+
+        const { accessToken, refreshToken } = generateTokens(member);
+
+        res.cookie(REFRESH_COOKIE_NAME, refreshToken, getRefreshCookieOptions());
+
+        const response: SetupResponse = {
+            token: accessToken,
+            member: {
+                _id: (member._id as { toString(): string }).toString(),
+                full_name: member.full_name as string,
+                username: member.username as string,
+                email: member.email as string,
+                global_admin: true,
+                lang: member.lang as string | undefined,
+                api_key: member.api_key as string,
+            },
+            createDemoApp: !!createDemoApp,
+        };
+
+        res.json({ data: response });
+    }
+    catch (err: unknown) {
+        next(err);
+    }
+});
 
 router.post('/login', async function(req: Request, res: Response, next: NextFunction) {
     try {

--- a/api/v2/routes/auth.ts
+++ b/api/v2/routes/auth.ts
@@ -34,6 +34,7 @@ const PASSWORD_RESET_TTL_SECONDS = 600;
 const REFRESH_COOKIE_NAME = 'cly_refresh_token';
 
 interface JwtPayload {
+    iat?: number;
     memberId: string;
     type: 'access' | 'refresh';
 }
@@ -541,6 +542,14 @@ router.post('/refresh', async function(req: Request, res: Response) {
                 return res.status(401).json(body);
             }
 
+            if (member.token_invalid_before && decoded.iat && decoded.iat < member.token_invalid_before) {
+                const body: ApiError = { error: { code: 'TOKEN_EXPIRED', message: 'Token has been invalidated' } };
+
+                res.clearCookie(REFRESH_COOKIE_NAME, { path: '/v2/auth' });
+
+                return res.status(401).json(body);
+            }
+
             const tokens = generateTokens(member);
 
             res.cookie(REFRESH_COOKIE_NAME, tokens.refreshToken, getRefreshCookieOptions());
@@ -736,6 +745,7 @@ router.post('/reset', async function(req: Request, res: Response, next: NextFunc
         // Clean up the consumed token
         removeResetToken(String(prid));
 
+        await invalidateUserTokens(member._id);
         // Kill other sessions for security (matches legacy behavior)
         killOtherSessionsForUser({ userId: (member._id as { toString(): string }).toString() });
 

--- a/api/v2/routes/auth.ts
+++ b/api/v2/routes/auth.ts
@@ -206,6 +206,18 @@ function countMembers(): Promise<number> {
     });
 }
 
+function stripPassword(input: unknown): Record<string, unknown> {
+    if (typeof input !== 'object' || input === null) {
+        return {};
+    }
+
+    const clone = { ...input as Record<string, unknown> };
+
+    delete clone.password;
+
+    return clone;
+}
+
 function insertMember(doc: Record<string, unknown>): Promise<Record<string, unknown>> {
     return new Promise((resolve, reject) => {
         common.db.collection('members').insert(
@@ -399,7 +411,7 @@ router.post('/login', async function(req: Request, res: Response, next: NextFunc
         if (!username || !password) {
             const body: ApiError = { error: { code: 'VALIDATION_ERROR', message: 'Username and password are required' } };
 
-            plugins.callMethod("loginFailed", { req, data: req.body, reason: 'VALIDATION_ERROR' });
+            plugins.callMethod("loginFailed", { req, data: stripPassword(req.body), reason: 'VALIDATION_ERROR' });
 
             return res.status(400).json(body);
         }
@@ -410,7 +422,7 @@ router.post('/login', async function(req: Request, res: Response, next: NextFunc
         if (blocked) {
             const body: ApiError = { error: { code: 'LOGIN_BLOCKED', message: 'Too many failed attempts. Please try again later.' } };
 
-            plugins.callMethod("loginFailed", { req, data: req.body, reason: 'LOGIN_BLOCKED' });
+            plugins.callMethod("loginFailed", { req, data: stripPassword(req.body), reason: 'LOGIN_BLOCKED' });
 
             return res.status(429).json(body);
         }
@@ -421,7 +433,8 @@ router.post('/login', async function(req: Request, res: Response, next: NextFunc
             const body: ApiError = { error: { code: 'INVALID_CREDENTIALS', message: 'Invalid username or password' } };
 
             recordFailedLogin(username);
-            plugins.callMethod("loginFailed", { req, data: req.body, reason: 'INVALID_CREDENTIALS' });
+
+            plugins.callMethod("loginFailed", { req, data: stripPassword(req.body), reason: 'INVALID_CREDENTIALS' });
 
             return res.status(401).json(body);
         }
@@ -443,7 +456,7 @@ router.post('/login', async function(req: Request, res: Response, next: NextFunc
 
         common.db.collection('members').updateOne({ _id: member._id }, { $set: update });
 
-        plugins.callMethod("loginSuccessful", { req, data: member });
+        plugins.callMethod("loginSuccessful", { req, data: stripPassword(member) });
 
         res.cookie(REFRESH_COOKIE_NAME, refreshToken, getRefreshCookieOptions());
 
@@ -466,7 +479,7 @@ router.post('/login', async function(req: Request, res: Response, next: NextFunc
         if (err.code === 'ACCOUNT_LOCKED') {
             const body: ApiError = { error: { code: 'ACCOUNT_LOCKED', message: err.message } };
 
-            plugins.callMethod("loginFailed", { req, data: req.body, reason: 'ACCOUNT_LOCKED' });
+            plugins.callMethod("loginFailed", { req, data: stripPassword(req.body), reason: 'ACCOUNT_LOCKED' });
 
             return res.status(401).json(body);
         }
@@ -612,7 +625,7 @@ router.post('/forgot', async function(req: Request, res: Response, next: NextFun
             await insertResetToken(prid, member._id, timestamp);
             member.lang = member.lang || req.body.lang || "en";
             mail.sendPasswordResetInfo(member, prid);
-            plugins.callMethod("passwordRequest", { req, data: req.body });
+            plugins.callMethod("passwordReset", { req, data: stripPassword(member) });
         }
 
         // Always return the same response to prevent email enumeration

--- a/api/v2/routes/auth.ts
+++ b/api/v2/routes/auth.ts
@@ -21,6 +21,7 @@ import {
     countMembers,
     findMemberByEmail,
     findMemberById,
+    formatMember,
     insertMember,
     killOtherSessionsForUser,
     validatePassword,
@@ -482,15 +483,7 @@ router.post('/setup', async function(req: Request, res: Response, next: NextFunc
 
         const response: SetupResponse = {
             token: accessToken,
-            member: {
-                _id: (member._id as { toString(): string }).toString(),
-                full_name: member.full_name as string,
-                username: member.username as string,
-                email: member.email as string,
-                global_admin: true,
-                lang: member.lang as string | undefined,
-                api_key: member.api_key as string,
-            },
+            member: formatMember(member),
         };
 
         res.json({ data: response });

--- a/api/v2/routes/auth.ts
+++ b/api/v2/routes/auth.ts
@@ -152,6 +152,22 @@ function insertResetToken(prid: string, userId: unknown, timestamp: number): Pro
     });
 }
 
+function invalidateUserTokens(memberId: unknown): Promise<void> {
+    return new Promise((resolve, reject) => {
+        common.db.collection('members').updateOne(
+            { _id: memberId },
+            { $set: { token_invalid_before: nowSec() } },
+            function(err: unknown) {
+                if (err) {
+                    console.error('Error invalidating user tokens:', err);
+                    return reject(err);
+                }
+                resolve();
+            }
+        );
+    });
+}
+
 function isArgon2Hash(hash: string): boolean {
     return Boolean(hash && hash.startsWith('$argon2'));
 }
@@ -579,6 +595,7 @@ router.post('/logout', async function(req: Request, res: Response, next: NextFun
                 }
             });
 
+            await invalidateUserTokens(member._id);
             killOtherSessionsForUser({ userId: (member._id as { toString(): string }).toString() });
         }
 

--- a/api/v2/routes/auth.ts
+++ b/api/v2/routes/auth.ts
@@ -78,7 +78,7 @@ router.post('/setup', async function(req: Request, res: Response, next: NextFunc
             return res.status(409).json(body);
         }
 
-        const { full_name, username, email, password, lang, createDemoApp } = req.body as SetupRequest;
+        const { full_name, username, email, password, lang } = req.body as SetupRequest;
         const trimmedEmail = typeof email === 'string' ? email.trim() : '';
         const trimmedUsername = typeof username === 'string' ? username.trim() : '';
 
@@ -166,7 +166,6 @@ router.post('/setup', async function(req: Request, res: Response, next: NextFunc
                 lang: member.lang as string | undefined,
                 api_key: member.api_key as string,
             },
-            createDemoApp: !!createDemoApp,
         };
 
         res.json({ data: response });

--- a/api/v2/routes/auth.ts
+++ b/api/v2/routes/auth.ts
@@ -78,11 +78,17 @@ router.post('/setup', async function(req: Request, res: Response, next: NextFunc
             return res.status(409).json(body);
         }
 
-        const { full_name, email, password, lang, createDemoApp } = req.body as SetupRequest;
+        const { full_name, username, email, password, lang, createDemoApp } = req.body as SetupRequest;
         const trimmedEmail = typeof email === 'string' ? email.trim() : '';
+        const trimmedUsername = typeof username === 'string' ? username.trim() : '';
 
         if (!full_name || typeof full_name !== 'string' || full_name.trim().length === 0) {
             const body: ApiError = { error: { code: 'VALIDATION_ERROR', message: 'Full name is required' } };
+            return res.status(400).json(body);
+        }
+
+        if (!trimmedUsername) {
+            const body: ApiError = { error: { code: 'VALIDATION_ERROR', message: 'Username is required' } };
             return res.status(400).json(body);
         }
 
@@ -111,7 +117,7 @@ router.post('/setup', async function(req: Request, res: Response, next: NextFunc
         const now = nowSec();
         const doc: Record<string, unknown> = {
             full_name: (full_name + "").trim(),
-            username: trimmedEmail,
+            username: trimmedUsername,
             password: hashedPassword,
             email: trimmedEmail,
             global_admin: true,

--- a/api/v2/routes/auth.ts
+++ b/api/v2/routes/auth.ts
@@ -207,6 +207,25 @@ function parseDaysToMs(duration: string): number {
     return days * 24 * 60 * 60 * 1000;
 }
 
+async function passwordMatchesHash(password: string, storedHash: string): Promise<boolean> {
+    const secret = common.config.passwordSecret || "";
+    const effectivePassword = password + secret;
+
+    try {
+        if (isArgon2Hash(storedHash)) {
+            return await argon2.verify(storedHash, effectivePassword);
+        }
+
+        const sha1 = crypto.createHmac('sha1', '').update(effectivePassword).digest('hex');
+        const sha512 = crypto.createHmac('sha512', '').update(effectivePassword).digest('hex');
+
+        return storedHash === sha1 || storedHash === sha512;
+    }
+    catch {
+        return false;
+    }
+}
+
 function recordFailedLogin(username: string): void {
     preventBruteforce.fail("login", username);
 }
@@ -726,6 +745,7 @@ router.post('/reset', async function(req: Request, res: Response, next: NextFunc
         }
 
         const member = await findMemberById(resetDoc.user_id);
+        const rotationLimit = Number(plugins.getConfig('security').password_rotation || 0);
 
         if (!member) {
             removeResetToken(String(prid));
@@ -734,6 +754,23 @@ router.post('/reset', async function(req: Request, res: Response, next: NextFunc
             };
 
             return res.status(400).json(body);
+        }
+
+        if (rotationLimit > 0) {
+            const candidates: string[] = [member.password as string];
+            const matches = await Promise.all(
+                candidates.map(h => passwordMatchesHash(password, h))
+            );
+
+            if (matches.some(Boolean)) {
+                const body: ApiError = {
+                    error: {
+                        code: 'WEAK_PASSWORD',
+                        message: `You cannot reuse one of your last ${rotationLimit} passwords.`
+                    }
+                };
+                return res.status(400).json(body);
+            }
         }
 
         // Hash with the same secret the legacy system uses

--- a/api/v2/routes/auth.ts
+++ b/api/v2/routes/auth.ts
@@ -108,7 +108,7 @@ router.post('/setup', async function(req: Request, res: Response, next: NextFunc
 
         const apiKey = common.md5Hash(crypto.randomBytes(48).toString('hex') + Math.random());
 
-        const now = Math.floor(Date.now() / 1000);
+        const now = nowSec();
         const doc: Record<string, unknown> = {
             full_name: (full_name + "").trim(),
             username: trimmedEmail,

--- a/api/v2/routes/auth.ts
+++ b/api/v2/routes/auth.ts
@@ -14,7 +14,6 @@ import type {
     SetupResponse,
     SetupStatusResponse,
 } from '../../../../web/src/shared/types/auth.js';
-import type { ApiError } from '../../../../web/src/shared/types/api.js';
 import jwt from 'jsonwebtoken';
 import crypto from 'crypto';
 import argon2 from 'argon2';
@@ -29,6 +28,7 @@ import {
 import {
     PASSWORD_RESET_TTL_SECONDS,
     REFRESH_COOKIE_NAME,
+    apiError,
     findResetToken,
     generateTokens,
     getRefreshCookieOptions,
@@ -57,120 +57,39 @@ const plugins = require('../../../plugins/pluginManager.js');
 
 const router = express.Router();
 
-router.get('/setup-status', async function(_req: Request, res: Response) {
+router.post('/forgot', async function(req: Request, res: Response, next: NextFunction) {
     try {
-        const count = await countMembers();
-        const response: SetupStatusResponse = { needsSetup: count === 0 };
-        res.json({ data: response });
-    }
-    catch (_err: unknown) {
-        const body: ApiError = { error: { code: 'DB_NOT_READY', message: 'Database is not available yet. Please retry.' } };
-        res.status(503).json(body);
-    }
-});
+        const { email } = req.body as ForgotPasswordRequest;
 
-router.post('/setup', async function(req: Request, res: Response, next: NextFunction) {
-    try {
-        const memberCount = await countMembers();
-
-        if (memberCount > 0) {
-            const body: ApiError = { error: { code: 'SETUP_ALREADY_COMPLETE', message: 'Server is already set up' } };
-            return res.status(409).json(body);
+        if (!email || typeof email !== 'string' || !email.includes('@')) {
+            return apiError(res, 400, 'VALIDATION_ERROR', 'A valid email address is required');
         }
 
-        const { full_name, username, email, password, lang } = req.body as SetupRequest;
-        const trimmedEmail = typeof email === 'string' ? email.trim() : '';
-        const trimmedUsername = typeof username === 'string' ? username.trim() : '';
+        const trimmedEmail = email.trim();
+        const { blocked } = await isForgotBlocked(req.ip);
 
-        if (!full_name || typeof full_name !== 'string' || full_name.trim().length === 0) {
-            const body: ApiError = { error: { code: 'VALIDATION_ERROR', message: 'Full name is required' } };
-            return res.status(400).json(body);
+        if (blocked) {
+            return apiError(res, 429, 'LOGIN_BLOCKED', 'Too many requests. Please try again later.');
         }
 
-        if (!trimmedUsername) {
-            const body: ApiError = { error: { code: 'VALIDATION_ERROR', message: 'Username is required' } };
-            return res.status(400).json(body);
+        // Always record a fail to rate-limit regardless of email existence (anti-enumeration)
+        recordForgotFail(req.ip);
+
+        const member = await findMemberByEmail(trimmedEmail);
+
+        if (member) {
+            const prid = crypto.randomBytes(32).toString('hex');
+            const timestamp = nowSec();
+
+            await insertResetToken(prid, member._id, timestamp);
+            member.lang = member.lang || req.body.lang || "en";
+            mail.sendPasswordResetInfo(member, prid);
+            plugins.callMethod("passwordRequest", { req, data: stripPassword(member) });
         }
 
-        if (!/^[a-zA-Z0-9_.-]{3,50}$/.test(trimmedUsername)) {
-            const body: ApiError = { error: { code: 'VALIDATION_ERROR', message: 'Username must be 3-50 characters using letters, numbers, dot, underscore, or hyphen.' } };
-            return res.status(400).json(body);
-        }
-
-        if (!trimmedEmail || !trimmedEmail.includes('@')) {
-            const body: ApiError = { error: { code: 'VALIDATION_ERROR', message: 'A valid email address is required' } };
-            return res.status(400).json(body);
-        }
-
-        if (!password || typeof password !== 'string') {
-            const body: ApiError = { error: { code: 'VALIDATION_ERROR', message: 'Password is required' } };
-            return res.status(400).json(body);
-        }
-
-        const passwordError = validatePassword(password);
-
-        if (passwordError !== null) {
-            const body: ApiError = { error: { code: 'WEAK_PASSWORD', message: passwordError } };
-            return res.status(400).json(body);
-        }
-
-        const secret = common.config.passwordSecret || "";
-        const hashedPassword = await argon2.hash(password + secret);
-
-        const apiKey = common.md5Hash(crypto.randomBytes(48).toString('hex') + Math.random());
-
-        const now = nowSec();
-        const doc: Record<string, unknown> = {
-            full_name: (full_name + "").trim(),
-            username: trimmedUsername,
-            password: hashedPassword,
-            email: trimmedEmail,
-            global_admin: true,
-            created_at: now,
-            password_changed: now,
-            // Empty permission matrix; global_admin: true bypasses per-feature permission checks.
-            permission: { c: {}, r: {}, u: {}, d: {}, _: { a: [], u: [[]] } },
-            api_key: apiKey,
-        };
-
-        if (lang && typeof lang === 'string') {
-            doc.lang = lang;
-        }
-
-        let member: Record<string, unknown>;
-
-        try {
-            member = await insertMember(doc);
-        }
-        catch (insertErr: unknown) {
-            // Guard against TOCTOU race: if a concurrent request already
-            // inserted a member between our count check and this insert,
-            // the duplicate key error (code 11000) surfaces here.
-            const mongoErr = insertErr as { code?: number };
-
-            if (mongoErr.code === 11000) {
-                const body: ApiError = { error: { code: 'SETUP_ALREADY_COMPLETE', message: 'Server is already set up' } };
-                return res.status(409).json(body);
-            }
-
-            throw insertErr;
-        }
-
-        const { accessToken, refreshToken } = generateTokens(member);
-
-        res.cookie(REFRESH_COOKIE_NAME, refreshToken, getRefreshCookieOptions());
-
-        const response: SetupResponse = {
-            token: accessToken,
-            member: {
-                _id: (member._id as { toString(): string }).toString(),
-                full_name: member.full_name as string,
-                username: member.username as string,
-                email: member.email as string,
-                global_admin: true,
-                lang: member.lang as string | undefined,
-                api_key: member.api_key as string,
-            },
+        // Always return the same response to prevent email enumeration
+        const response: ForgotPasswordResponse = {
+            message: 'If an account with that email exists, a reset link has been sent.',
         };
 
         res.json({ data: response });
@@ -185,34 +104,28 @@ router.post('/login', async function(req: Request, res: Response, next: NextFunc
         const { username, password } = req.body as LoginRequest;
 
         if (!username || !password) {
-            const body: ApiError = { error: { code: 'VALIDATION_ERROR', message: 'Username and password are required' } };
-
             plugins.callMethod("loginFailed", { req, data: stripPassword(req.body), reason: 'VALIDATION_ERROR' });
 
-            return res.status(400).json(body);
+            return apiError(res, 400, 'VALIDATION_ERROR', 'Username and password are required');
         }
 
         // Check brute force block before attempting login
         const { blocked } = await isBruteforceBlocked(username);
 
         if (blocked) {
-            const body: ApiError = { error: { code: 'LOGIN_BLOCKED', message: 'Too many failed attempts. Please try again later.' } };
-
             plugins.callMethod("loginFailed", { req, data: stripPassword(req.body), reason: 'LOGIN_BLOCKED' });
 
-            return res.status(429).json(body);
+            return apiError(res, 429, 'LOGIN_BLOCKED', 'Too many failed attempts. Please try again later.');
         }
 
         const member = await verifyCredentials(username, password);
 
         if (!member) {
-            const body: ApiError = { error: { code: 'INVALID_CREDENTIALS', message: 'Invalid username or password' } };
-
             recordFailedLogin(username);
 
             plugins.callMethod("loginFailed", { req, data: stripPassword(req.body), reason: 'INVALID_CREDENTIALS' });
 
-            return res.status(401).json(body);
+            return apiError(res, 401, 'INVALID_CREDENTIALS', 'Invalid username or password');
         }
 
         // Login successful - reset failed attempts
@@ -253,76 +166,13 @@ router.post('/login', async function(req: Request, res: Response, next: NextFunc
     }
     catch (err: any) {
         if (err.code === 'ACCOUNT_LOCKED') {
-            const body: ApiError = { error: { code: 'ACCOUNT_LOCKED', message: err.message } };
-
             plugins.callMethod("loginFailed", { req, data: stripPassword(req.body), reason: 'ACCOUNT_LOCKED' });
 
-            return res.status(401).json(body);
+            return apiError(res, 401, 'ACCOUNT_LOCKED', err.message);
         }
 
         next(err);
     }
-});
-
-router.post('/refresh', async function(req: Request, res: Response) {
-    const refreshToken = req.cookies?.[REFRESH_COOKIE_NAME];
-
-    if (!refreshToken) {
-        const body: ApiError = { error: { code: 'VALIDATION_ERROR', message: 'Refresh token is required' } };
-        return res.status(400).json(body);
-    }
-
-    const secret: string = common.config.api.jwtSecret;
-
-    let decoded: JwtPayload;
-    try {
-        decoded = jwt.verify(refreshToken, secret) as JwtPayload;
-    }
-    catch (err: any) {
-        res.clearCookie(REFRESH_COOKIE_NAME, { path: '/v2/auth' });
-        const code = err.name === 'TokenExpiredError' ? 'TOKEN_EXPIRED' : 'UNAUTHORIZED';
-        const body: ApiError = { error: { code, message: 'Invalid or expired refresh token' } };
-        return res.status(401).json(body);
-    }
-
-    if (decoded.type !== 'refresh') {
-        const body: ApiError = { error: { code: 'UNAUTHORIZED', message: 'Invalid token type' } };
-        return res.status(401).json(body);
-    }
-
-    common.db.collection('members').findOne(
-        { _id: common.db.ObjectID(decoded.memberId) },
-        { projection: { password: 0 } },
-        function(err: any, member: any) {
-            if (err || !member) {
-                const body: ApiError = { error: { code: 'UNAUTHORIZED', message: 'User not found' } };
-                return res.status(401).json(body);
-            }
-
-            if (member.locked) {
-                const body: ApiError = { error: { code: 'ACCOUNT_LOCKED', message: 'User account is locked' } };
-                return res.status(401).json(body);
-            }
-
-            if (member.token_invalid_before && decoded.iat && decoded.iat < member.token_invalid_before) {
-                const body: ApiError = { error: { code: 'TOKEN_EXPIRED', message: 'Token has been invalidated' } };
-
-                res.clearCookie(REFRESH_COOKIE_NAME, { path: '/v2/auth' });
-
-                return res.status(401).json(body);
-            }
-
-            const tokens = generateTokens(member);
-
-            res.cookie(REFRESH_COOKIE_NAME, tokens.refreshToken, getRefreshCookieOptions());
-
-            const response: RefreshTokenResponse = {
-                token: tokens.accessToken,
-            };
-
-            res.json({ data: response });
-        }
-    );
 });
 
 router.post('/logout', async function(req: Request, res: Response, next: NextFunction) {
@@ -378,80 +228,58 @@ router.post('/logout', async function(req: Request, res: Response, next: NextFun
     }
 });
 
-router.post('/forgot', async function(req: Request, res: Response, next: NextFunction) {
+router.post('/refresh', async function(req: Request, res: Response) {
+    const refreshToken = req.cookies?.[REFRESH_COOKIE_NAME];
+
+    if (!refreshToken) {
+        return apiError(res, 400, 'VALIDATION_ERROR', 'Refresh token is required');
+    }
+
+    const secret: string = common.config.api.jwtSecret;
+
+    let decoded: JwtPayload;
     try {
-        const { email } = req.body as ForgotPasswordRequest;
+        decoded = jwt.verify(refreshToken, secret) as JwtPayload;
+    }
+    catch (err: any) {
+        res.clearCookie(REFRESH_COOKIE_NAME, { path: '/v2/auth' });
+        const code = err.name === 'TokenExpiredError' ? 'TOKEN_EXPIRED' : 'UNAUTHORIZED';
+        return apiError(res, 401, code, 'Invalid or expired refresh token');
+    }
 
-        if (!email || typeof email !== 'string' || !email.includes('@')) {
-            const body: ApiError = { error: { code: 'VALIDATION_ERROR', message: 'A valid email address is required' } };
-            return res.status(400).json(body);
-        }
+    if (decoded.type !== 'refresh') {
+        return apiError(res, 401, 'UNAUTHORIZED', 'Invalid token type');
+    }
 
-        const trimmedEmail = email.trim();
-        const { blocked } = await isForgotBlocked(req.ip);
+    common.db.collection('members').findOne(
+        { _id: common.db.ObjectID(decoded.memberId) },
+        { projection: { password: 0 } },
+        function(err: any, member: any) {
+            if (err || !member) {
+                return apiError(res, 401, 'UNAUTHORIZED', 'User not found');
+            }
 
-        if (blocked) {
-            const body: ApiError = {
-                error: { code: 'LOGIN_BLOCKED', message: 'Too many requests. Please try again later.' }
+            if (member.locked) {
+                return apiError(res, 401, 'ACCOUNT_LOCKED', 'User account is locked');
+            }
+
+            if (member.token_invalid_before && decoded.iat && decoded.iat < member.token_invalid_before) {
+                res.clearCookie(REFRESH_COOKIE_NAME, { path: '/v2/auth' });
+
+                return apiError(res, 401, 'TOKEN_EXPIRED', 'Token has been invalidated');
+            }
+
+            const tokens = generateTokens(member);
+
+            res.cookie(REFRESH_COOKIE_NAME, tokens.refreshToken, getRefreshCookieOptions());
+
+            const response: RefreshTokenResponse = {
+                token: tokens.accessToken,
             };
 
-            return res.status(429).json(body);
+            res.json({ data: response });
         }
-
-        // Always record a fail to rate-limit regardless of email existence (anti-enumeration)
-        recordForgotFail(req.ip);
-
-        const member = await findMemberByEmail(trimmedEmail);
-
-        if (member) {
-            const prid = crypto.randomBytes(32).toString('hex');
-            const timestamp = nowSec();
-
-            await insertResetToken(prid, member._id, timestamp);
-            member.lang = member.lang || req.body.lang || "en";
-            mail.sendPasswordResetInfo(member, prid);
-            plugins.callMethod("passwordRequest", { req, data: stripPassword(member) });
-        }
-
-        // Always return the same response to prevent email enumeration
-        const response: ForgotPasswordResponse = {
-            message: 'If an account with that email exists, a reset link has been sent.',
-        };
-
-        res.json({ data: response });
-    }
-    catch (err: unknown) {
-        next(err);
-    }
-});
-
-router.get('/reset/:prid', async function(req: Request, res: Response, next: NextFunction) {
-    try {
-        const prid = String(req.params.prid);
-
-        const resetDoc = await findResetToken(prid);
-
-        if (!resetDoc) {
-            const body: ApiError = { error: { code: 'RESET_TOKEN_NOT_FOUND', message: 'Reset link is invalid' } };
-            return res.status(404).json(body);
-        }
-
-        if (nowSec() - (resetDoc.timestamp as number) > PASSWORD_RESET_TTL_SECONDS) {
-            removeResetToken(prid);
-            const body: ApiError = { error: { code: 'RESET_TOKEN_EXPIRED', message: 'Reset link has expired' } };
-            return res.status(410).json(body);
-        }
-
-        const response: ResetPasswordValidateResponse = {
-            valid: true,
-            newInvite: !!resetDoc.newInvite,
-        };
-
-        res.json({ data: response });
-    }
-    catch (err: unknown) {
-        next(err);
-    }
+    );
 });
 
 router.post('/reset', async function(req: Request, res: Response, next: NextFunction) {
@@ -459,32 +287,25 @@ router.post('/reset', async function(req: Request, res: Response, next: NextFunc
         const { prid, password } = req.body as ResetPasswordRequest;
 
         if (!prid || !password) {
-            const body: ApiError = {
-                error: { code: 'VALIDATION_ERROR', message: 'Reset token and new password are required' }
-            };
-
-            return res.status(400).json(body);
+            return apiError(res, 400, 'VALIDATION_ERROR', 'Reset token and new password are required');
         }
 
         // Validate password strength via legacy security config
         const passwordError = validatePassword(password);
 
         if (passwordError !== null) {
-            const body: ApiError = { error: { code: 'WEAK_PASSWORD', message: passwordError } };
-            return res.status(400).json(body);
+            return apiError(res, 400, 'WEAK_PASSWORD', passwordError);
         }
 
         const resetDoc = await findResetToken(String(prid));
 
         if (!resetDoc) {
-            const body: ApiError = { error: { code: 'RESET_TOKEN_NOT_FOUND', message: 'Reset link is invalid' } };
-            return res.status(404).json(body);
+            return apiError(res, 404, 'RESET_TOKEN_NOT_FOUND', 'Reset link is invalid');
         }
 
         if (nowSec() - (resetDoc.timestamp as number) > PASSWORD_RESET_TTL_SECONDS) {
             removeResetToken(String(prid));
-            const body: ApiError = { error: { code: 'RESET_TOKEN_EXPIRED', message: 'Reset link has expired' } };
-            return res.status(410).json(body);
+            return apiError(res, 410, 'RESET_TOKEN_EXPIRED', 'Reset link has expired');
         }
 
         const member = await findMemberById(resetDoc.user_id);
@@ -492,11 +313,7 @@ router.post('/reset', async function(req: Request, res: Response, next: NextFunc
 
         if (!member) {
             removeResetToken(String(prid));
-            const body: ApiError = {
-                error: { code: 'RESET_TOKEN_INVALID', message: 'User associated with this reset link no longer exists' }
-            };
-
-            return res.status(400).json(body);
+            return apiError(res, 400, 'RESET_TOKEN_INVALID', 'User associated with this reset link no longer exists');
         }
 
         if (rotationLimit > 0) {
@@ -509,13 +326,7 @@ router.post('/reset', async function(req: Request, res: Response, next: NextFunc
             );
 
             if (matches.some(Boolean)) {
-                const body: ApiError = {
-                    error: {
-                        code: 'WEAK_PASSWORD',
-                        message: `You cannot reuse one of your last ${rotationLimit} passwords.`
-                    }
-                };
-                return res.status(400).json(body);
+                return apiError(res, 400, 'WEAK_PASSWORD', `You cannot reuse one of your last ${rotationLimit} passwords.`);
             }
         }
 
@@ -556,6 +367,147 @@ router.post('/reset', async function(req: Request, res: Response, next: NextFunc
     }
     catch (err: unknown) {
         next(err);
+    }
+});
+
+router.get('/reset/:prid', async function(req: Request, res: Response, next: NextFunction) {
+    try {
+        const prid = String(req.params.prid);
+
+        const resetDoc = await findResetToken(prid);
+
+        if (!resetDoc) {
+            return apiError(res, 404, 'RESET_TOKEN_NOT_FOUND', 'Reset link is invalid');
+        }
+
+        if (nowSec() - (resetDoc.timestamp as number) > PASSWORD_RESET_TTL_SECONDS) {
+            removeResetToken(prid);
+            return apiError(res, 410, 'RESET_TOKEN_EXPIRED', 'Reset link has expired');
+        }
+
+        const response: ResetPasswordValidateResponse = {
+            valid: true,
+            newInvite: !!resetDoc.newInvite,
+        };
+
+        res.json({ data: response });
+    }
+    catch (err: unknown) {
+        next(err);
+    }
+});
+
+router.post('/setup', async function(req: Request, res: Response, next: NextFunction) {
+    try {
+        const memberCount = await countMembers();
+
+        if (memberCount > 0) {
+            return apiError(res, 409, 'SETUP_ALREADY_COMPLETE', 'Server is already set up');
+        }
+
+        const { full_name, username, email, password, lang } = req.body as SetupRequest;
+        const trimmedEmail = typeof email === 'string' ? email.trim() : '';
+        const trimmedUsername = typeof username === 'string' ? username.trim() : '';
+
+        if (!full_name || typeof full_name !== 'string' || full_name.trim().length === 0) {
+            return apiError(res, 400, 'VALIDATION_ERROR', 'Full name is required');
+        }
+
+        if (!trimmedUsername) {
+            return apiError(res, 400, 'VALIDATION_ERROR', 'Username is required');
+        }
+
+        if (!/^[a-zA-Z0-9_.-]{3,50}$/.test(trimmedUsername)) {
+            return apiError(res, 400, 'VALIDATION_ERROR', 'Username must be 3-50 characters using letters, numbers, dot, underscore, or hyphen.');
+        }
+
+        if (!trimmedEmail || !trimmedEmail.includes('@')) {
+            return apiError(res, 400, 'VALIDATION_ERROR', 'A valid email address is required');
+        }
+
+        if (!password || typeof password !== 'string') {
+            return apiError(res, 400, 'VALIDATION_ERROR', 'Password is required');
+        }
+
+        const passwordError = validatePassword(password);
+
+        if (passwordError !== null) {
+            return apiError(res, 400, 'WEAK_PASSWORD', passwordError);
+        }
+
+        const secret = common.config.passwordSecret || "";
+        const hashedPassword = await argon2.hash(password + secret);
+
+        const apiKey = common.md5Hash(crypto.randomBytes(48).toString('hex') + Math.random());
+
+        const now = nowSec();
+        const doc: Record<string, unknown> = {
+            full_name: (full_name + "").trim(),
+            username: trimmedUsername,
+            password: hashedPassword,
+            email: trimmedEmail,
+            global_admin: true,
+            created_at: now,
+            password_changed: now,
+            // Empty permission matrix; global_admin: true bypasses per-feature permission checks.
+            permission: { c: {}, r: {}, u: {}, d: {}, _: { a: [], u: [[]] } },
+            api_key: apiKey,
+        };
+
+        if (lang && typeof lang === 'string') {
+            doc.lang = lang;
+        }
+
+        let member: Record<string, unknown>;
+
+        try {
+            member = await insertMember(doc);
+        }
+        catch (insertErr: unknown) {
+            // Guard against TOCTOU race: if a concurrent request already
+            // inserted a member between our count check and this insert,
+            // the duplicate key error (code 11000) surfaces here.
+            const mongoErr = insertErr as { code?: number };
+
+            if (mongoErr.code === 11000) {
+                return apiError(res, 409, 'SETUP_ALREADY_COMPLETE', 'Server is already set up');
+            }
+
+            throw insertErr;
+        }
+
+        const { accessToken, refreshToken } = generateTokens(member);
+
+        res.cookie(REFRESH_COOKIE_NAME, refreshToken, getRefreshCookieOptions());
+
+        const response: SetupResponse = {
+            token: accessToken,
+            member: {
+                _id: (member._id as { toString(): string }).toString(),
+                full_name: member.full_name as string,
+                username: member.username as string,
+                email: member.email as string,
+                global_admin: true,
+                lang: member.lang as string | undefined,
+                api_key: member.api_key as string,
+            },
+        };
+
+        res.json({ data: response });
+    }
+    catch (err: unknown) {
+        next(err);
+    }
+});
+
+router.get('/setup-status', async function(_req: Request, res: Response) {
+    try {
+        const count = await countMembers();
+        const response: SetupStatusResponse = { needsSetup: count === 0 };
+        res.json({ data: response });
+    }
+    catch (_err: unknown) {
+        apiError(res, 503, 'DB_NOT_READY', 'Database is not available yet. Please retry.');
     }
 });
 

--- a/api/v2/routes/auth.ts
+++ b/api/v2/routes/auth.ts
@@ -38,6 +38,19 @@ interface JwtPayload {
     type: 'access' | 'refresh';
 }
 
+function countMembers(): Promise<number> {
+    return new Promise((resolve, reject) => {
+        common.db.collection('members').count(
+            function(err: unknown, count: number) {
+                if (err) {
+                    return reject(err);
+                }
+                resolve(count);
+            }
+        );
+    });
+}
+
 function escapeRegEx(string: string): string {
     return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
@@ -109,6 +122,21 @@ function getRefreshCookieOptions() {
     };
 }
 
+function insertMember(doc: Record<string, unknown>): Promise<Record<string, unknown>> {
+    return new Promise((resolve, reject) => {
+        common.db.collection('members').insert(
+            doc,
+            { safe: true },
+            function(err: unknown, result: { ops: Record<string, unknown>[] }) {
+                if (err) {
+                    return reject(err);
+                }
+                resolve(result.ops[0]);
+            }
+        );
+    });
+}
+
 function insertResetToken(prid: string, userId: unknown, timestamp: number): Promise<void> {
     return new Promise((resolve, reject) => {
         common.db.collection('password_reset').insert(
@@ -178,34 +206,6 @@ function resetFailedLogins(username: string): void {
     preventBruteforce.reset("login", username);
 }
 
-function updateMemberPassword(id: unknown, hashedPassword: string): Promise<void> {
-    return new Promise((resolve, reject) => {
-        common.db.collection('members').updateOne(
-            { _id: id },
-            { $set: { password: hashedPassword, password_changed: nowSec() } },
-            function(err: unknown) {
-                if (err) {
-                    return reject(err);
-                }
-                resolve();
-            }
-        );
-    });
-}
-
-function countMembers(): Promise<number> {
-    return new Promise((resolve, reject) => {
-        common.db.collection('members').count(
-            function(err: unknown, count: number) {
-                if (err) {
-                    return reject(err);
-                }
-                resolve(count);
-            }
-        );
-    });
-}
-
 function stripPassword(input: unknown): Record<string, unknown> {
     if (typeof input !== 'object' || input === null) {
         return {};
@@ -218,16 +218,16 @@ function stripPassword(input: unknown): Record<string, unknown> {
     return clone;
 }
 
-function insertMember(doc: Record<string, unknown>): Promise<Record<string, unknown>> {
+function updateMemberPassword(id: unknown, hashedPassword: string): Promise<void> {
     return new Promise((resolve, reject) => {
-        common.db.collection('members').insert(
-            doc,
-            { safe: true },
-            function(err: unknown, result: { ops: Record<string, unknown>[] }) {
+        common.db.collection('members').updateOne(
+            { _id: id },
+            { $set: { password: hashedPassword, password_changed: nowSec() } },
+            function(err: unknown) {
                 if (err) {
                     return reject(err);
                 }
-                resolve(result.ops[0]);
+                resolve();
             }
         );
     });

--- a/api/v2/routes/auth.ts
+++ b/api/v2/routes/auth.ts
@@ -622,7 +622,7 @@ router.post('/forgot', async function(req: Request, res: Response, next: NextFun
             await insertResetToken(prid, member._id, timestamp);
             member.lang = member.lang || req.body.lang || "en";
             mail.sendPasswordResetInfo(member, prid);
-            plugins.callMethod("passwordRequest", { req, data: stripPassword(req.body) });
+            plugins.callMethod("passwordRequest", { req, data: stripPassword(member) });
         }
 
         // Always return the same response to prevent email enumeration

--- a/api/v2/routes/auth.ts
+++ b/api/v2/routes/auth.ts
@@ -33,29 +33,13 @@ const router = express.Router();
 const PASSWORD_RESET_TTL_SECONDS = 600;
 const REFRESH_COOKIE_NAME = 'cly_refresh_token';
 
-function parseDaysToMs(duration: string): number {
-    const days = Number.parseInt(duration, 10);
-
-    if (Number.isNaN(days)) {
-        return 7 * 24 * 60 * 60 * 1000;
-    }
-
-    return days * 24 * 60 * 60 * 1000;
-}
-
-function getRefreshCookieOptions() {
-    return {
-        httpOnly: true,
-        secure: common.config.api.ssl?.enabled === true,
-        sameSite: 'strict' as const,
-        path: '/v2/auth',
-        maxAge: parseDaysToMs(common.config.api.jwtRefreshTokenExpiry),
-    };
-}
-
 interface JwtPayload {
     memberId: string;
     type: 'access' | 'refresh';
+}
+
+function escapeRegEx(string: string): string {
+    return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function findMemberByEmail(email: string): Promise<Record<string, unknown> | null> {
@@ -115,6 +99,16 @@ function generateTokens(member: any): { accessToken: string; refreshToken: strin
     return { accessToken, refreshToken };
 }
 
+function getRefreshCookieOptions() {
+    return {
+        httpOnly: true,
+        secure: common.config.api.ssl?.enabled === true,
+        sameSite: 'strict' as const,
+        path: '/v2/auth',
+        maxAge: parseDaysToMs(common.config.api.jwtRefreshTokenExpiry),
+    };
+}
+
 function insertResetToken(prid: string, userId: unknown, timestamp: number): Promise<void> {
     return new Promise((resolve, reject) => {
         common.db.collection('password_reset').insert(
@@ -156,6 +150,16 @@ function isForgotBlocked(ip: string | undefined): Promise<{ blocked: boolean; fa
 
 function nowSec(): number {
     return Math.round(Date.now() / 1000);
+}
+
+function parseDaysToMs(duration: string): number {
+    const days = Number.parseInt(duration, 10);
+
+    if (Number.isNaN(days)) {
+        return 7 * 24 * 60 * 60 * 1000;
+    }
+
+    return days * 24 * 60 * 60 * 1000;
 }
 
 function recordFailedLogin(username: string): void {
@@ -217,10 +221,20 @@ function insertMember(doc: Record<string, unknown>): Promise<Record<string, unkn
     });
 }
 
-async function verifyCredentials(username: string, password: string): Promise<any | null> {
+async function verifyCredentials(usernameOrEmail: string, password: string): Promise<any | null> {
+    const trimmedUsernameOrEmail = `${usernameOrEmail}`.trim();
+
     const member = await new Promise<any>((resolve, reject) => {
         common.db.collection('members').findOne(
-            { $or: [{ username }, { email: username }] },
+            {
+                $or: [
+                    { username: trimmedUsernameOrEmail },
+                    {
+                        email: {
+                            $regex: `^${escapeRegEx(trimmedUsernameOrEmail)}$`, $options: 'i'
+                        }
+                    }]
+            },
             function(err: any, doc: any) {
                 if (err) {
                     return reject(err);

--- a/api/v2/routes/auth.ts
+++ b/api/v2/routes/auth.ts
@@ -622,7 +622,7 @@ router.post('/forgot', async function(req: Request, res: Response, next: NextFun
             await insertResetToken(prid, member._id, timestamp);
             member.lang = member.lang || req.body.lang || "en";
             mail.sendPasswordResetInfo(member, prid);
-            plugins.callMethod("passwordReset", { req, data: stripPassword(member) });
+            plugins.callMethod("passwordRequest", { req, data: stripPassword(member) });
         }
 
         // Always return the same response to prevent email enumeration

--- a/api/v2/routes/auth.ts
+++ b/api/v2/routes/auth.ts
@@ -433,11 +433,11 @@ router.post('/login', async function(req: Request, res: Response, next: NextFunc
 
         const update: { last_login: number; password_changed?: number; lang?: string } = { last_login: nowSec() };
 
-        if (member?.password_changed === 'undefined') {
+        if (member.password_changed === undefined) {
             update.password_changed = member.created_at || nowSec();
         }
 
-        if (req.body?.lang !== member.lang) {
+        if (req.body.lang && req.body.lang !== member.lang) {
             update.lang = req.body.lang;
         }
 

--- a/api/v2/routes/auth.ts
+++ b/api/v2/routes/auth.ts
@@ -92,6 +92,11 @@ router.post('/setup', async function(req: Request, res: Response, next: NextFunc
             return res.status(400).json(body);
         }
 
+        if (!/^[a-zA-Z0-9_.-]{3,50}$/.test(trimmedUsername)) {
+            const body: ApiError = { error: { code: 'VALIDATION_ERROR', message: 'Username must be 3-50 characters using letters, numbers, dot, underscore, or hyphen.' } };
+            return res.status(400).json(body);
+        }
+
         if (!trimmedEmail || !trimmedEmail.includes('@')) {
             const body: ApiError = { error: { code: 'VALIDATION_ERROR', message: 'A valid email address is required' } };
             return res.status(400).json(body);

--- a/api/v2/routes/auth.ts
+++ b/api/v2/routes/auth.ts
@@ -700,11 +700,6 @@ router.post('/reset', async function(req: Request, res: Response, next: NextFunc
             return res.status(400).json(body);
         }
 
-        if (member.locked) {
-            const body: ApiError = { error: { code: 'ACCOUNT_LOCKED', message: 'User account is locked' } };
-            return res.status(401).json(body);
-        }
-
         // Hash with the same secret the legacy system uses
         const secret = common.config.passwordSecret || "";
         const hashedPassword = await argon2.hash(password + secret);

--- a/api/v2/routes/auth.ts
+++ b/api/v2/routes/auth.ts
@@ -79,13 +79,14 @@ router.post('/setup', async function(req: Request, res: Response, next: NextFunc
         }
 
         const { full_name, email, password, lang, createDemoApp } = req.body as SetupRequest;
+        const trimmedEmail = typeof email === 'string' ? email.trim() : '';
 
         if (!full_name || typeof full_name !== 'string' || full_name.trim().length === 0) {
             const body: ApiError = { error: { code: 'VALIDATION_ERROR', message: 'Full name is required' } };
             return res.status(400).json(body);
         }
 
-        if (!email || typeof email !== 'string' || !email.includes('@')) {
+        if (!trimmedEmail || !trimmedEmail.includes('@')) {
             const body: ApiError = { error: { code: 'VALIDATION_ERROR', message: 'A valid email address is required' } };
             return res.status(400).json(body);
         }
@@ -110,9 +111,9 @@ router.post('/setup', async function(req: Request, res: Response, next: NextFunc
         const now = Math.floor(Date.now() / 1000);
         const doc: Record<string, unknown> = {
             full_name: (full_name + "").trim(),
-            username: (email + "").trim(),
+            username: trimmedEmail,
             password: hashedPassword,
-            email: (email + "").trim(),
+            email: trimmedEmail,
             global_admin: true,
             created_at: now,
             password_changed: now,

--- a/api/v2/routes/auth.ts
+++ b/api/v2/routes/auth.ts
@@ -431,6 +431,17 @@ router.post('/login', async function(req: Request, res: Response, next: NextFunc
 
         const { accessToken, refreshToken } = generateTokens(member);
 
+        const update: { last_login: number; password_changed?: number; lang?: string } = { last_login: nowSec() };
+
+        if (member?.password_changed === 'undefined') {
+            update.password_changed = member.created_at || nowSec();
+        }
+
+        if (req.body?.lang !== member.lang) {
+            update.lang = req.body.lang;
+        }
+
+        common.db.collection('members').updateOne({ _id: member._id }, { $set: update });
 
         plugins.callMethod("loginSuccessful", { req, data: member });
 

--- a/api/v2/routes/auth.ts
+++ b/api/v2/routes/auth.ts
@@ -622,7 +622,7 @@ router.post('/forgot', async function(req: Request, res: Response, next: NextFun
             await insertResetToken(prid, member._id, timestamp);
             member.lang = member.lang || req.body.lang || "en";
             mail.sendPasswordResetInfo(member, prid);
-            plugins.callMethod("passwordRequest", { req, data: req.body });
+            plugins.callMethod("passwordRequest", { req, data: stripPassword(req.body) });
         }
 
         // Always return the same response to prevent email enumeration

--- a/api/v2/routes/auth.ts
+++ b/api/v2/routes/auth.ts
@@ -398,6 +398,9 @@ router.post('/login', async function(req: Request, res: Response, next: NextFunc
 
         if (!username || !password) {
             const body: ApiError = { error: { code: 'VALIDATION_ERROR', message: 'Username and password are required' } };
+
+            plugins.callMethod("loginFailed", { req, data: req.body, reason: 'VALIDATION_ERROR' });
+
             return res.status(400).json(body);
         }
 
@@ -406,14 +409,20 @@ router.post('/login', async function(req: Request, res: Response, next: NextFunc
 
         if (blocked) {
             const body: ApiError = { error: { code: 'LOGIN_BLOCKED', message: 'Too many failed attempts. Please try again later.' } };
+
+            plugins.callMethod("loginFailed", { req, data: req.body, reason: 'LOGIN_BLOCKED' });
+
             return res.status(429).json(body);
         }
 
         const member = await verifyCredentials(username, password);
 
         if (!member) {
-            recordFailedLogin(username);
             const body: ApiError = { error: { code: 'INVALID_CREDENTIALS', message: 'Invalid username or password' } };
+
+            recordFailedLogin(username);
+            plugins.callMethod("loginFailed", { req, data: req.body, reason: 'INVALID_CREDENTIALS' });
+
             return res.status(401).json(body);
         }
 
@@ -422,10 +431,8 @@ router.post('/login', async function(req: Request, res: Response, next: NextFunc
 
         const { accessToken, refreshToken } = generateTokens(member);
 
-        common.db.collection('members').updateOne(
-            { _id: member._id },
-            { $set: { last_login: Math.floor(Date.now() / 1000) } }
-        );
+
+        plugins.callMethod("loginSuccessful", { req, data: member });
 
         res.cookie(REFRESH_COOKIE_NAME, refreshToken, getRefreshCookieOptions());
 
@@ -447,8 +454,12 @@ router.post('/login', async function(req: Request, res: Response, next: NextFunc
     catch (err: any) {
         if (err.code === 'ACCOUNT_LOCKED') {
             const body: ApiError = { error: { code: 'ACCOUNT_LOCKED', message: err.message } };
+
+            plugins.callMethod("loginFailed", { req, data: req.body, reason: 'ACCOUNT_LOCKED' });
+
             return res.status(401).json(body);
         }
+
         next(err);
     }
 });

--- a/api/v2/routes/auth.ts
+++ b/api/v2/routes/auth.ts
@@ -610,7 +610,7 @@ router.post('/forgot', async function(req: Request, res: Response, next: NextFun
             const timestamp = nowSec();
 
             await insertResetToken(prid, member._id, timestamp);
-
+            member.lang = member.lang || req.body.lang || "en";
             mail.sendPasswordResetInfo(member, prid);
             plugins.callMethod("passwordRequest", { req, data: req.body });
         }

--- a/api/v2/routes/users.ts
+++ b/api/v2/routes/users.ts
@@ -6,29 +6,87 @@ const common = require('../../utils/common.js');
 const { validateUser } = require('../../utils/rights.js');
 const log = require('../../utils/log.js')('v2:users');
 
+// Mirrors AVAILABLE_LOCALES on the frontend (web/src/i18n.ts).
+const ALLOWED_LANGS = ['en', 'tr', 'cs'] as const;
+type AllowedLang = (typeof ALLOWED_LANGS)[number];
+
 const router = express.Router();
+
+function formatMember(member: any, langOverride?: string) {
+    return {
+        _id: member._id.toString(),
+        full_name: member.full_name,
+        username: member.username,
+        email: member.email,
+        global_admin: member.global_admin === true,
+        lang: langOverride ?? member.lang,
+        api_key: member.api_key,
+        permission: member.permission,
+    };
+}
 
 router.get('/me', async(req, _res) => {
     const params = req.countlyParams;
 
     try {
         await validateUser(params);
-
         const { member } = params;
 
-        common.returnOutput(params, {
-            _id: member._id.toString(),
-            full_name: member.full_name,
-            username: member.username,
-            email: member.email,
-            global_admin: member.global_admin === true,
-            lang: member.lang,
-            api_key: member.api_key,
-            permission: member.permission
-        });
+        common.returnOutput(params, formatMember(member));
     }
     catch (err) {
         log.e('GET /v2/users/me error: %j', err);
+    }
+});
+
+router.patch('/me', async(req, _res) => {
+    const params = req.countlyParams;
+
+    try {
+        await validateUser(params);
+        const { member } = params;
+
+        const body = (req.body || {}) as { lang?: unknown };
+
+        // Whitelist: only `lang` is mutable through this endpoint for now.
+        // Reject any unrecognized field so future additions are explicit.
+        const allowedKeys = new Set(['lang']);
+        const unknownKeys = Object.keys(body).filter((k) => !allowedKeys.has(k));
+
+        if (unknownKeys.length > 0) {
+            return common.returnMessage(params, 400, `Unknown field(s): ${unknownKeys.join(', ')}`);
+        }
+
+        const updates: Record<string, unknown> = {};
+
+        if ('lang' in body) {
+            if (typeof body.lang !== 'string' || !ALLOWED_LANGS.includes(body.lang as AllowedLang)) {
+                return common.returnMessage(params, 400, `Invalid lang code; expected one of: ${ALLOWED_LANGS.join(', ')}`);
+            }
+            updates.lang = body.lang;
+        }
+
+        if (Object.keys(updates).length === 0) {
+            return common.returnMessage(params, 400, 'No updateable fields provided');
+        }
+
+        await new Promise<void>((resolve, reject) => {
+            common.db.collection('members').updateOne(
+                { _id: member._id },
+                { $set: updates },
+                (err: unknown) => {
+                    if (err) {
+                        return reject(err);
+                    }
+                    resolve();
+                }
+            );
+        });
+
+        common.returnOutput(params, formatMember(member, updates.lang as string | undefined));
+    }
+    catch (err) {
+        log.e('PATCH /v2/users/me error: %j', err);
     }
 });
 

--- a/api/v2/routes/users.ts
+++ b/api/v2/routes/users.ts
@@ -1,5 +1,6 @@
 import { createRequire } from 'module';
 import express from 'express';
+import { formatMember } from '../services/members.ts';
 
 const require = createRequire(import.meta.url);
 const common = require('../../utils/common.js');
@@ -11,19 +12,6 @@ const ALLOWED_LANGS = ['en', 'tr', 'cs'] as const;
 type AllowedLang = (typeof ALLOWED_LANGS)[number];
 
 const router = express.Router();
-
-function formatMember(member: any, langOverride?: string) {
-    return {
-        _id: member._id.toString(),
-        full_name: member.full_name,
-        username: member.username,
-        email: member.email,
-        global_admin: member.global_admin === true,
-        lang: langOverride ?? member.lang,
-        api_key: member.api_key,
-        permission: member.permission,
-    };
-}
 
 router.get('/me', async(req, _res) => {
     const params = req.countlyParams;

--- a/api/v2/services/auth/brute-force.ts
+++ b/api/v2/services/auth/brute-force.ts
@@ -1,0 +1,36 @@
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const preventBruteforce = require('../../../../frontend/express/libs/preventBruteforce.js');
+
+export function isBruteforceBlocked(username: string): Promise<{ blocked: boolean; fails: number }> {
+    return new Promise((resolve) => {
+        preventBruteforce.isBlocked("login", username, function(blocked: boolean, fails: number) {
+            resolve({ blocked, fails });
+        });
+    });
+}
+
+export function isForgotBlocked(ip: string | undefined): Promise<{ blocked: boolean; fails: number }> {
+    if (!ip) {
+        return Promise.resolve({ blocked: false, fails: 0 });
+    }
+
+    return new Promise((resolve) => {
+        preventBruteforce.isBlocked("forgot", ip, function(blocked: boolean, fails: number) {
+            resolve({ blocked, fails });
+        });
+    });
+}
+
+export function recordFailedLogin(username: string): void {
+    preventBruteforce.fail("login", username);
+}
+
+export function recordForgotFail(ip: string | undefined): void {
+    preventBruteforce.fail("forgot", ip || 'Undefined IP');
+}
+
+export function resetFailedLogins(username: string): void {
+    preventBruteforce.reset("login", username);
+}

--- a/api/v2/services/auth/helpers.ts
+++ b/api/v2/services/auth/helpers.ts
@@ -1,0 +1,19 @@
+export function escapeRegEx(string: string): string {
+    return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+export function nowSec(): number {
+    return Math.round(Date.now() / 1000);
+}
+
+export function stripPassword(input: unknown): Record<string, unknown> {
+    if (typeof input !== 'object' || input === null) {
+        return {};
+    }
+
+    const clone = { ...input as Record<string, unknown> };
+
+    delete clone.password;
+
+    return clone;
+}

--- a/api/v2/services/auth/helpers.ts
+++ b/api/v2/services/auth/helpers.ts
@@ -1,9 +1,7 @@
+export { nowSec } from '../utils/time.ts';
+
 export function escapeRegEx(string: string): string {
     return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-export function nowSec(): number {
-    return Math.round(Date.now() / 1000);
 }
 
 export function stripPassword(input: unknown): Record<string, unknown> {

--- a/api/v2/services/auth/index.ts
+++ b/api/v2/services/auth/index.ts
@@ -1,0 +1,5 @@
+export * from './brute-force.ts';
+export * from './helpers.ts';
+export * from './password.ts';
+export * from './reset-tokens.ts';
+export * from './tokens.ts';

--- a/api/v2/services/auth/index.ts
+++ b/api/v2/services/auth/index.ts
@@ -2,4 +2,5 @@ export * from './brute-force.ts';
 export * from './helpers.ts';
 export * from './password.ts';
 export * from './reset-tokens.ts';
+export * from './responses.ts';
 export * from './tokens.ts';

--- a/api/v2/services/auth/password.ts
+++ b/api/v2/services/auth/password.ts
@@ -1,0 +1,116 @@
+import { createRequire } from 'module';
+import argon2 from 'argon2';
+import crypto from 'crypto';
+import { escapeRegEx, nowSec } from './helpers.ts';
+
+const require = createRequire(import.meta.url);
+const common = require('../../../utils/common.js');
+
+export function isArgon2Hash(hash: string): boolean {
+    return Boolean(hash && hash.startsWith('$argon2'));
+}
+
+export async function passwordMatchesHash(password: string, storedHash: string): Promise<boolean> {
+    const secret = common.config.passwordSecret || "";
+    const effectivePassword = password + secret;
+
+    try {
+        if (isArgon2Hash(storedHash)) {
+            return await argon2.verify(storedHash, effectivePassword);
+        }
+
+        const sha1 = crypto.createHmac('sha1', '').update(effectivePassword).digest('hex');
+        const sha512 = crypto.createHmac('sha512', '').update(effectivePassword).digest('hex');
+
+        return storedHash === sha1 || storedHash === sha512;
+    }
+    catch {
+        return false;
+    }
+}
+
+export function updateMemberPassword(id: unknown, hashedPassword: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+        common.db.collection('members').updateOne(
+            { _id: id },
+            { $set: { password: hashedPassword, password_changed: nowSec() } },
+            function(err: unknown) {
+                if (err) {
+                    return reject(err);
+                }
+                resolve();
+            }
+        );
+    });
+}
+
+export function updateMemberPasswordWithHistory(
+    id: unknown,
+    newHash: string,
+    oldHash: string,
+    rotationLimit: number
+): Promise<void> {
+    return new Promise((resolve, reject) => {
+        common.db.collection('members').updateOne(
+            { _id: id },
+            {
+                $set: { password: newHash, password_changed: nowSec() },
+                $push: { password_history: { $each: [oldHash], $slice: -rotationLimit } }
+            },
+            function(err: unknown) {
+                if (err) {
+                    return reject(err);
+                }
+                resolve();
+            }
+        );
+    });
+}
+
+export async function verifyCredentials(usernameOrEmail: string, password: string): Promise<any | null> {
+    const trimmedUsernameOrEmail = `${usernameOrEmail}`.trim();
+
+    const member = await new Promise<any>((resolve, reject) => {
+        common.db.collection('members').findOne(
+            {
+                $or: [
+                    { username: trimmedUsernameOrEmail },
+                    { email: { $regex: `^${escapeRegEx(trimmedUsernameOrEmail)}$`, $options: 'i' }}
+                ]
+            },
+            function(err: any, doc: any) {
+                if (err) {
+                    return reject(err);
+                }
+                resolve(doc);
+            }
+        );
+    });
+
+    if (!member) {
+        return null;
+    }
+
+    if (member.locked) {
+        const err: any = new Error('User account is locked');
+        err.code = 'ACCOUNT_LOCKED';
+        throw err;
+    }
+
+    const match = await passwordMatchesHash(password, member.password);
+
+    if (!match) {
+        return null;
+    }
+
+    if (!isArgon2Hash(member.password)) {
+        const secret = common.config.passwordSecret || "";
+        const argon2Hash = await argon2.hash(password + secret);
+        common.db.collection('members').updateOne(
+            { _id: member._id },
+            { $set: { password: argon2Hash } }
+        );
+    }
+
+    return member;
+}

--- a/api/v2/services/auth/password.ts
+++ b/api/v2/services/auth/password.ts
@@ -74,7 +74,7 @@ export async function verifyCredentials(usernameOrEmail: string, password: strin
         common.db.collection('members').findOne(
             {
                 $or: [
-                    { username: trimmedUsernameOrEmail },
+                    { username: { $regex: `^${escapeRegEx(trimmedUsernameOrEmail)}$`, $options: 'i' }},
                     { email: { $regex: `^${escapeRegEx(trimmedUsernameOrEmail)}$`, $options: 'i' }}
                 ]
             },

--- a/api/v2/services/auth/reset-tokens.ts
+++ b/api/v2/services/auth/reset-tokens.ts
@@ -1,0 +1,40 @@
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const common = require('../../../utils/common.js');
+
+// TODO: make this value configurable in setting security tab once the page is added to the new dashboard
+export const PASSWORD_RESET_TTL_SECONDS = 600;
+
+export function findResetToken(prid: string): Promise<Record<string, unknown> | null> {
+    return new Promise((resolve, reject) => {
+        common.db.collection('password_reset').findOne(
+            { prid },
+            function(err: unknown, doc: Record<string, unknown> | null) {
+                if (err) {
+                    return reject(err);
+                }
+                resolve(doc);
+            }
+        );
+    });
+}
+
+export function insertResetToken(prid: string, userId: unknown, timestamp: number): Promise<void> {
+    return new Promise((resolve, reject) => {
+        common.db.collection('password_reset').insert(
+            { prid, user_id: userId, timestamp },
+            { safe: true },
+            function(err: unknown) {
+                if (err) {
+                    return reject(err);
+                }
+                resolve();
+            }
+        );
+    });
+}
+
+export function removeResetToken(prid: string): void {
+    common.db.collection('password_reset').remove({ prid }, function() {});
+}

--- a/api/v2/services/auth/responses.ts
+++ b/api/v2/services/auth/responses.ts
@@ -1,0 +1,11 @@
+import type { Response } from 'express';
+import type { ApiError } from '../../../../web/src/shared/types/api.js';
+
+/**
+ * Sends a v2-shaped error response: { error: { code, message } }.
+ * Returns the Response so call sites can chain `return apiError(...)` for early exit.
+ */
+export function apiError(res: Response, status: number, code: string, message: string) {
+    const body: ApiError = { error: { code, message } };
+    return res.status(status).json(body);
+}

--- a/api/v2/services/auth/tokens.ts
+++ b/api/v2/services/auth/tokens.ts
@@ -1,0 +1,65 @@
+import { createRequire } from 'module';
+import jwt from 'jsonwebtoken';
+import { nowSec } from './helpers.ts';
+
+const require = createRequire(import.meta.url);
+const common = require('../../../utils/common.js');
+
+export const REFRESH_COOKIE_NAME = 'cly_refresh_token';
+
+export interface JwtPayload {
+    iat?: number;
+    memberId: string;
+    type: 'access' | 'refresh';
+}
+
+export function generateTokens(member: any): { accessToken: string; refreshToken: string } {
+    const secret: string = common.config.api.jwtSecret;
+    const accessToken = jwt.sign(
+        { memberId: member._id.toString(), type: 'access' } satisfies JwtPayload,
+        secret,
+        { expiresIn: common.config.api.jwtAccessTokenExpiry }
+    );
+    const refreshToken = jwt.sign(
+        { memberId: member._id.toString(), type: 'refresh' } satisfies JwtPayload,
+        secret,
+        { expiresIn: common.config.api.jwtRefreshTokenExpiry }
+    );
+    return { accessToken, refreshToken };
+}
+
+export function getRefreshCookieOptions() {
+    return {
+        httpOnly: true,
+        secure: common.config.api.ssl?.enabled === true,
+        sameSite: 'strict' as const,
+        path: '/v2/auth',
+        maxAge: parseDaysToMs(common.config.api.jwtRefreshTokenExpiry),
+    };
+}
+
+export function parseDaysToMs(duration: string): number {
+    const days = Number.parseInt(duration, 10);
+
+    if (Number.isNaN(days)) {
+        return 7 * 24 * 60 * 60 * 1000;
+    }
+
+    return days * 24 * 60 * 60 * 1000;
+}
+
+export function invalidateUserTokens(memberId: unknown): Promise<void> {
+    return new Promise((resolve, reject) => {
+        common.db.collection('members').updateOne(
+            { _id: memberId },
+            { $set: { token_invalid_before: nowSec() } },
+            function(err: unknown) {
+                if (err) {
+                    console.error('Error invalidating user tokens:', err);
+                    return reject(err);
+                }
+                resolve();
+            }
+        );
+    });
+}

--- a/api/v2/services/members.ts
+++ b/api/v2/services/members.ts
@@ -84,3 +84,22 @@ export function insertMember(doc: Record<string, unknown>): Promise<Record<strin
         );
     });
 }
+
+/**
+ * Wire-format projection of a member doc for v2 responses.
+ * Used by /v2/users/me, /v2/users/me PATCH, and /v2/auth/setup.
+ * Pass `langOverride` after a write that just mutated the lang field
+ * to surface the new value without re-reading the doc.
+ */
+export function formatMember(member: any, langOverride?: string) {
+    return {
+        _id: member._id.toString(),
+        full_name: member.full_name,
+        username: member.username,
+        email: member.email,
+        global_admin: member.global_admin === true,
+        lang: langOverride ?? member.lang,
+        api_key: member.api_key,
+        permission: member.permission,
+    };
+}

--- a/api/v2/services/members.ts
+++ b/api/v2/services/members.ts
@@ -1,5 +1,6 @@
 import { createRequire } from 'module';
 import type { KillOtherSessionsOptions } from '../../../../web/src/shared/types/auth.js';
+import { escapeRegEx } from './auth/helpers.ts';
 
 const require = createRequire(import.meta.url);
 const membersUtility = require('../../../frontend/express/libs/members.js');
@@ -26,4 +27,60 @@ export function killOtherSessionsForUser(options: KillOtherSessionsOptions): voi
         options.currentSessionId,
         common.db
     );
+}
+
+export function countMembers(): Promise<number> {
+    return new Promise((resolve, reject) => {
+        common.db.collection('members').count(
+            function(err: unknown, count: number) {
+                if (err) {
+                    return reject(err);
+                }
+                resolve(count);
+            }
+        );
+    });
+}
+
+export function findMemberByEmail(email: string): Promise<Record<string, unknown> | null> {
+    return new Promise((resolve, reject) => {
+        common.db.collection('members').findOne(
+            { email: { $regex: `^${escapeRegEx(email)}$`, $options: 'i' } },
+            function(err: unknown, doc: Record<string, unknown> | null) {
+                if (err) {
+                    return reject(err);
+                }
+                resolve(doc);
+            }
+        );
+    });
+}
+
+export function findMemberById(id: unknown): Promise<Record<string, unknown> | null> {
+    return new Promise((resolve, reject) => {
+        common.db.collection('members').findOne(
+            { _id: id },
+            function(err: unknown, doc: Record<string, unknown> | null) {
+                if (err) {
+                    return reject(err);
+                }
+                resolve(doc);
+            }
+        );
+    });
+}
+
+export function insertMember(doc: Record<string, unknown>): Promise<Record<string, unknown>> {
+    return new Promise((resolve, reject) => {
+        common.db.collection('members').insert(
+            doc,
+            { safe: true },
+            function(err: unknown, result: { ops: Record<string, unknown>[] }) {
+                if (err) {
+                    return reject(err);
+                }
+                resolve(result.ops[0]);
+            }
+        );
+    });
 }

--- a/api/v2/services/utils/time.ts
+++ b/api/v2/services/utils/time.ts
@@ -1,0 +1,3 @@
+export function nowSec(): number {
+    return Math.round(Date.now() / 1000);
+}


### PR DESCRIPTION
# v2 auth + apps: hardening, JWT revocation fix, app-creation endpoint, structure

## Summary
This PR ships the security and structure pass over the v2 auth surface, plus the two endpoints needed to complete the new dashboard's setup → app-creation → language-persistence flow. Most of `/v2/auth/*` already existed; this PR fixes a critical revocation bug, adds password rotation, hardens setup, splits the route file into focused service modules, and unifies repeated patterns.

## What this PR adds vs. modifies

| Endpoint | Status |
|---|---|
| `POST /v2/apps/create` | **New** |
| `PATCH /v2/users/me` | **New** |
| `POST /v2/auth/setup` | Modified (distinct username, format validation, email trim, removed dead `createDemoApp` field) |
| `POST /v2/auth/login` | Modified (case-insensitive username match, `stripPassword` on hooks, refactored `verifyCredentials`) |
| `POST /v2/auth/logout` | Modified (`invalidateUserTokens` for cross-device JWT revocation) |
| `POST /v2/auth/refresh` | Modified (`token_invalid_before` check, clears cookie on revoked token) |
| `POST /v2/auth/forgot` | Modified (`stripPassword` on hooks, requires `trust proxy` to be set — see audit fixes) |
| `POST /v2/auth/reset` | Modified (password rotation enforcement against `password_history`, JWT invalidation, `stripPassword` on hooks) |
| `GET /v2/auth/setup-status`, `GET /v2/auth/reset/:prid`, `GET /v2/users/me`, `GET /v2/apps`, `GET /v2/apps/:id` | Unchanged in this PR |

## Critical bug fix
**rights.js JWT revocation** — `validate_token_if_exists` was comparing `member.token_invalid_before` (unix seconds) against `decoded.iat * 1000` (treated as ms), so the inequality always evaluated false and stale Bearer tokens were never rejected. Removing `* 1000` makes both sides seconds.

Without this fix, "logout on Device A" left a ~15-minute window where Device B's cached access token still authenticated successfully against any v2 endpoint. The `/refresh` handler had the comparison correct, which masked the bug from page-refresh tests — only an active session with a cached access token exercised the broken path.

## New endpoint: `POST /v2/apps/create`
Mirrors `appsApi.createApp`: validates `name`/`type`/`timezone` (with optional `key`/`country`/`category`), generates `key` via sha1 of `crypto.randomBytes` when absent, inserts into `apps`, ensures the 6 `app_users<id>` indexes legacy creates, dispatches `/i/apps/create` plugin hook so per-app plugin collections get created. Catches duplicate-key (`11000`) → 409.

## New endpoint: `PATCH /v2/users/me`
Partial member update. Whitelisted fields (currently only `lang`); rejects unknown fields with `400 Unknown field(s): …`. Validates lang against `['en', 'tr', 'cs']` (mirrors `AVAILABLE_LOCALES` on the frontend). Returns the updated member.

## JWT cross-device revocation
- New `invalidateUserTokens(memberId)` helper writes `member.token_invalid_before = nowSec()`.
- Called from `/v2/auth/logout` and `/v2/auth/reset`.
- `/v2/auth/refresh` rejects with 401 + clears cookie when `decoded.iat < member.token_invalid_before`.
- `rights.js` Bearer branch performs the same check after JWT signature verification — this is the path that catches active sessions (no page refresh needed).

## Password rotation on `/v2/auth/reset`
- New `passwordMatchesHash(password, storedHash)` with try/catch around `argon2.verify` so a corrupted history entry can never lock a user out of reset.
- Candidates for the rotation check: `[member.password, ...member.password_history]` so first-time users are protected against reusing their current password.
- New `updateMemberPasswordWithHistory(id, newHash, oldHash, limit)` with `$push: { password_history: { $each: [oldHash], $slice: -limit } }`.
- `/reset` branches on `password_rotation > 0` between the history-aware and plain update.
- `verifyCredentials` refactored to delegate to `passwordMatchesHash`, keeping only the legacy→argon2 upgrade as a clearly-separated side effect.

## Setup hardening
- Added a distinct `username` field (was previously `username = email`).
- Strict username validation: 3-50 chars matching `[a-zA-Z0-9_.-]`.
- Email is trimmed before validation (was validating untrimmed, persisting trimmed).
- `nowSec()` helper used consistently in place of inline `Math.floor(Date.now()/1000)`.
- One-line comment on the empty permission matrix explaining `global_admin: true` bypasses it.
- `createDemoApp` field removed from `SetupRequest`/`SetupResponse` — was dead data on the wire.

## Audit fixes
- **Username matching is now case-insensitive at login** — both `username` and `email` arms in `verifyCredentials` use the same case-insensitive regex. Without this, a user registering as `Gabriel` couldn't log in with `gabriel` via the username arm.
- **`stripPassword` wraps every `plugins.callMethod`** that passes `req.body` or `member` — `loginFailed` (4 branches), `loginSuccessful`, `passwordRequest`, `passwordReset`. Prevents plugin handlers from accidentally persisting passwords.
- **`app.set('trust proxy', true)`** added to v2 app.ts. `/forgot` rate limiting was keying on the LB's internal IP, sharing one bucket across all clients.
- **`PATCH` added to `Access-Control-Allow-Methods`** in v2 CORS — required for the new `PATCH /v2/users/me`.

## File structure pass

`auth.ts` was ~800 lines of handlers and helpers interleaved. Split into focused modules:

```
core/api/v2/services/auth/
  brute-force.ts    preventBruteforce wrappers
  helpers.ts        stripPassword, escapeRegEx
  password.ts       isArgon2Hash, passwordMatchesHash, verifyCredentials, updateMemberPassword(WithHistory)
  reset-tokens.ts   password_reset CRUD + TTL constant
  responses.ts      apiError helper for v2 error shape
  tokens.ts         JWT signing, refresh cookie, invalidateUserTokens
  index.ts          barrel
core/api/v2/services/utils/
  time.ts           nowSec — generic, also used by apps.ts
core/api/v2/services/members.ts
  + countMembers, findMemberByEmail, findMemberById, insertMember, formatMember
```

`routes/auth.ts` is now route handlers + thin imports. Handlers alphabetized within the file.

## Code-quality refactor pass
- **`apiError(res, status, code, message)` helper** in `services/auth/responses.ts` — replaces ~25 occurrences of the 3-line `const body: ApiError = {…}; return res.status(N).json(body)` pattern with a single-line call.
- **`formatMember` unified** — `services/members.ts` owns the wire-format projection used by `GET/PATCH /v2/users/me` and `POST /v2/auth/setup`. Setup response gains the `permission` field (additive, non-breaking — `MemberPublic` types it as optional).
- **`APP_USERS_INDEX_SPECS`** — six identical `ensureIndex` calls in `apps.ts` collapsed into a forEach over a single source of truth.
- **`nowSec` moved** to `services/utils/time.ts` as a generic utility (no longer auth-scoped) and used directly by `apps.ts`.

## Testing
Manual end-to-end. Backend unit-test infrastructure for v2 (TypeScript) doesn't exist yet — Mocha has no TS loader configured. Filed as a follow-up. Manually verified:
- Cross-device logout: login on two browsers, logout on one, hit a v2 endpoint with the cached Bearer on the other → 400 "Token not valid". Specifically tested without page refresh to exercise the rights.js path.
- Setup with distinct username, format validation, both demo and own app paths.
- Password rotation: reset, attempt to reuse → `WEAK_PASSWORD`. Reset with new password, `password_history` populated. Reset with corrupted history entry — does not lock user out.
- Language persistence via `PATCH /v2/users/me` (including `400 Unknown field(s)` for disallowed keys, `400 Invalid lang code` for unknown locales).
- Brute-force: 11 wrong logins → `429 LOGIN_BLOCKED`. Successful login resets the counter.
- App creation creates the per-app indexes and fires the `/i/apps/create` plugin hook.

## Out of scope / follow-ups
- Demo-data populator (Phase 2 of app creation). Demo button currently creates an empty app.
- Automated test infrastructure for v2 TypeScript (Mocha currently has no TS loader; either `tsx`/`ts-node/register` setup or Vitest-for-backend is a separate decision).
- `processAppProps` and icon upload from legacy `appsApi.createApp` — skipped; can be added when needed.
- Scheduled cleanup of `password_reset` rows past TTL (currently lazy: only cleared on retry of an expired prid).
