### PR TITLE
[24.05] backport: security hardening — #7491 + #7532 + #7535

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## Version 24.05.50
+Security Fixes:
+- [data_migration] Constrain export/import paths to allowed directories; reject path-traversal in `target_path`, multipart filenames, and exportid (backport of #7491)
+- [errorlogs] Reject path-traversal in admin log file paths
+- [system-utility] Harden streamed responses with error handlers
+- [crashes] Add error handlers to crash report streamed responses
+- [exports] Add stream error handlers to export download
+- [reports] Add stream error handlers
+- [dashboards] Constrain public screenshot route paths and stream error handling
+- [star-rating] Constrain public feedback image route paths and stream error handling
+- [core] Add `common.resolvePathInBase` helper for safe path containment checks
+
 ## Version 24.05.49
 Fixes:
 - [alerts] Fixed alert jobs using system's timezone instead of application's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Version 24.05.50
 Security Fixes:
+- [star-rating] Close stored XSS in feedback widget logo upload/preview; restrict uploads to image MIME types and validate magic bytes (backport of #7532)
+- [star-rating] Defense-in-depth on image upload/serve routes
 - [data_migration] Constrain export/import paths to allowed directories; reject path-traversal in `target_path`, multipart filenames, and exportid (backport of #7491)
 - [errorlogs] Reject path-traversal in admin log file paths
 - [system-utility] Harden streamed responses with error handlers
@@ -7,7 +9,6 @@ Security Fixes:
 - [exports] Add stream error handlers to export download
 - [reports] Add stream error handlers
 - [dashboards] Constrain public screenshot route paths and stream error handling
-- [star-rating] Constrain public feedback image route paths and stream error handling
 - [core] Add `common.resolvePathInBase` helper for safe path containment checks
 
 ## Version 24.05.49

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 ## Version 24.05.50
-Security Fixes:
+Security Fixes (backport of #7535 — bug-bounty-style hardening pass):
+- [auth] Restrict `/login/token/:token` to login-purpose tokens; regenerate session id on token login to close fixation
+- [dashboards] Require auth + per-widget app permission on `/o/dashboards/test`; remove the unused endpoint
+- [dashboards] Identical response for missing/inaccessible dashboard (no enumeration)
+- [dbviewer] Block `$graphLookup` aggregation stage (cross-collection data exfiltration)
+- [redirect] Apply SSRF protection (`api/utils/ssrf-protection.js`) to `app.redirect_url` outbound requests
+- [tasks] Authorize `/i/tasks/{update,delete,name,edit}` per task ownership / app admin / global admin
+- [exports] Authorize `/o/export/download` by task ownership / app_id
+- [notes] Bind notes to permission-checked `app_id`; check edit permissions against the note's stored `app_id`
+- [notes] Enforce `saveNote` schema validation
+- [apps] Replace updateApp/createApp mass-assignment with explicit field allowlist
+- [event_groups] Whitelist updatable fields on create/update; scope reads by `app_id`
+- [app_users] Sanitize `user.picture` filename before deletion (path traversal)
+- [app_users] Scope export download/delete to caller's `app_id`; reject path-traversal in filenames
+- [app_users / logger / compliance-hub] Strip dangerous Mongo operators (`$where`, `$expr`, `$function`, `$accumulator`) from user-supplied queries
+- [push] Bind message create/test/update/one/remove/toggle to query-string `app_id` (cross-app push injection)
+- [alerts] Validate `alertConfig.selectedApps` against caller's permissions (cross-app metric exfiltration)
+- [data] Escape regex metacharacters in `sSearch` parameters (ReDoS)
+- [users] `/users/check/username` now requires global admin (parity with email check)
+- [cms / system / systemlogs] `/i/cms/save_entries`, `/o/system/plugins`, `/i/systemlogs` restricted to global admins
+- [auth] Replace OTP-equality recaptcha bypass with `twoFactorPassed` session flag
+- [auth] Generate new-member invite `prid` with `crypto.randomBytes` (replace predictable HMAC)
+- [output] Remove `noescape` query-string bypass on `returnOutput` (reflected-XSS via parameter)
+- [auth] Handle `req.session.regenerate` error in token login
+- [data] Return 404 (not 500) when `event_groups` lookup misses
+
+24.05-specific notes (some master fixes were not directly applicable):
+- C-1 (`$graphLookup`) and M-11 (dbviewer non-admin filter scope): master uses a `whiteListedAggregationStages` mechanism (added by SER-2122) and a `getBaseAppFilter` per-collection app-id mechanism that 24.05 does not have. C-1 is implemented as a minimal targeted block; M-11 is not applicable here. A broader 24.05 dbviewer hardening (porting SER-2122 + filter scope + M-11) is left for a separate change.
+- M-14 (`--disable-web-security`): the flag was never present in 24.05's puppeteer args, so the master fix is a no-op; only an explanatory comment was added.
+- L-7 (drop wildcard CORS from reports preview/pdf): intentionally **not** backported — the wildcard is needed for puppeteer PDF rendering against `data:` URL documents (sub-resource fetches). Same decision as on master where the L-7 fix was reverted.
+
+Earlier in this 24.05.50 release:
 - [star-rating] Close stored XSS in feedback widget logo upload/preview; restrict uploads to image MIME types and validate magic bytes (backport of #7532)
 - [star-rating] Defense-in-depth on image upload/serve routes
 - [data_migration] Constrain export/import paths to allowed directories; reject path-traversal in `target_path`, multipart filenames, and exportid (backport of #7491)

--- a/api/parts/data/exports.js
+++ b/api/parts/data/exports.js
@@ -207,7 +207,10 @@ exports.output = function(params, data, filename, type) {
     headers["Content-Disposition"] = "attachment;filename=" + encodeURIComponent(filename) + "." + type;
 
     if (type === "xlsx" || type === "xls") { //we have stream
-        params.res.writeHead(200, headers);
+        // Attach the stream error handler BEFORE writing headers so the
+        // !headersSent branch is reachable for errors that fire before
+        // the first chunk is piped. Once headers are out, the only safe
+        // recovery is to destroy the response.
         data.on("error", function(streamErr) {
             common.log("exports").e(streamErr);
             if (!params.res.headersSent) {
@@ -217,6 +220,7 @@ exports.output = function(params, data, filename, type) {
                 params.res.end();
             }
         });
+        params.res.writeHead(200, headers);
         data.pipe(params.res);
         //common.returnRaw(params, 200, new Buffer(data, 'binary'), headers);
     }

--- a/api/parts/data/exports.js
+++ b/api/parts/data/exports.js
@@ -208,6 +208,15 @@ exports.output = function(params, data, filename, type) {
 
     if (type === "xlsx" || type === "xls") { //we have stream
         params.res.writeHead(200, headers);
+        data.on("error", function(streamErr) {
+            common.log("exports").e(streamErr);
+            if (!params.res.headersSent) {
+                common.returnMessage(params, 500, "Export stream error");
+            }
+            else {
+                params.res.end();
+            }
+        });
         data.pipe(params.res);
         //common.returnRaw(params, 200, new Buffer(data, 'binary'), headers);
     }
@@ -400,6 +409,15 @@ exports.stream = function(params, stream, options) {
     else if (type === 'xlsx' || type === 'xls') {
         options.streamOptions.transform = transformFunction;
         var xc = new XLSXTransformStream();
+        xc.on("error", function(streamErr) {
+            common.log("exports").e(streamErr);
+            if (!params.res.headersSent) {
+                common.returnMessage(params, 500, "Export stream error");
+            }
+            else {
+                params.res.end();
+            }
+        });
         xc.pipe(params.res);
         if (listAtEnd === false) {
             xc.write(paramList);

--- a/api/parts/data/fetch.js
+++ b/api/parts/data/fetch.js
@@ -100,11 +100,21 @@ fetch.fetchEventData = function(collection, params) {
 * The return the event groups data by _id.
 * @param {Object} params - params object
 * @param {string} params._id - The id of the event group id.
+* @returns {boolean|undefined} false on validation failure
 **/
 fetch.fetchEventGroupById = function(params) {
     const COLLECTION_NAME = "event_groups";
-    const { qstring: { _id } } = params;
-    common.db.collection(COLLECTION_NAME).findOne({ _id }, function(error, result) {
+    // Coerce _id to a string to defeat NoSQL operator-injection. Always
+    // scope the lookup to params.app_id so an attacker who knows or
+    // enumerates an event-group _id from another tenant cannot read it
+    // back via this endpoint. validateRead ensures params.app_id is a
+    // tenant the caller is allowed on.
+    const _id = (params.qstring._id || "") + "";
+    if (!_id) {
+        common.returnMessage(params, 400, 'Missing parameter "_id"');
+        return false;
+    }
+    common.db.collection(COLLECTION_NAME).findOne({ _id, app_id: params.app_id + "" }, function(error, result) {
         if (error || !result) {
             common.returnMessage(params, 500, `error: ${error}`);
             return false;
@@ -157,7 +167,11 @@ fetch.fetchMergedEventGroups = function(params) {
 */
 fetch.getMergedEventGroups = function(params, event, options, callback) {
     const COLLECTION_NAME = "event_groups";
-    common.db.collection(COLLECTION_NAME).findOne({ _id: event }, function(error, result) {
+    // Same scoping rule as fetchEventGroupById — confine the lookup to
+    // params.app_id so a caller can't merge another tenant's event group
+    // by knowing/guessing its _id.
+    const eventId = (event || "") + "";
+    common.db.collection(COLLECTION_NAME).findOne({ _id: eventId, app_id: params.app_id + "" }, function(error, result) {
         if (error || !result) {
             common.returnMessage(params, 500, `error: ${error}`);
             return false;

--- a/api/parts/data/fetch.js
+++ b/api/parts/data/fetch.js
@@ -115,8 +115,16 @@ fetch.fetchEventGroupById = function(params) {
         return false;
     }
     common.db.collection(COLLECTION_NAME).findOne({ _id, app_id: params.app_id + "" }, function(error, result) {
-        if (error || !result) {
+        if (error) {
             common.returnMessage(params, 500, `error: ${error}`);
+            return false;
+        }
+        if (!result) {
+            // Distinguish "no such doc in this app's scope" (a normal client
+            // error / cross-tenant probe) from an actual server error. With
+            // app_id scoping introduced in H-17, the not-found case became
+            // common and returning 500 was misleading to callers.
+            common.returnMessage(params, 404, 'Event group not found');
             return false;
         }
         common.returnOutput(params, result);
@@ -172,8 +180,15 @@ fetch.getMergedEventGroups = function(params, event, options, callback) {
     // by knowing/guessing its _id.
     const eventId = (event || "") + "";
     common.db.collection(COLLECTION_NAME).findOne({ _id: eventId, app_id: params.app_id + "" }, function(error, result) {
-        if (error || !result) {
+        if (error) {
             common.returnMessage(params, 500, `error: ${error}`);
+            return false;
+        }
+        if (!result) {
+            // Same rationale as fetchEventGroupById — with app_id scoping in
+            // place, "not found" is a normal client error (often a probe
+            // for a foreign tenant's _id), not a server error.
+            common.returnMessage(params, 404, 'Event group not found');
             return false;
         }
         options = options || {};

--- a/api/parts/data/fetch.js
+++ b/api/parts/data/fetch.js
@@ -2072,7 +2072,13 @@ fetch.alljobs = async function(metric, params) {
     if (params.qstring.sSearch) {
         var rr;
         try {
-            rr = new RegExp(params.qstring.sSearch, "i");
+            // Cap input length and escape regex metacharacters before
+            // building the RegExp. A user-supplied raw pattern such as
+            // "^(a+)+$" can exhibit catastrophic backtracking and stall
+            // the worker (and Mongo CPU) across the whole jobs collection.
+            var raw = (params.qstring.sSearch + "").slice(0, 256);
+            var escaped = raw.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+            rr = new RegExp(escaped, "i");
             pipeline.unshift({
                 $match: { name: { $regex: rr } }
             });

--- a/api/parts/mgmt/app_users.js
+++ b/api/parts/mgmt/app_users.js
@@ -235,8 +235,18 @@ usersApi.delete = function(app_id, query, params, callback) {
                         //deleting userimages(if they exist);
                         if (res[0].picture) {
                             for (let i = 0;i < res[0].picture.length; i++) {
-                                //remove /userimages/ 
+                                //remove /userimages/
                                 let id = res[0].picture[i].substr(12, res[0].picture[i].length - 12);
+                                // The SDK populates user.picture; an attacker who controls a
+                                // device can set it to "/userimages/../../../etc/whatever".
+                                // path.resolve would then escape the userimages dir and the
+                                // server would unlink an arbitrary file when the user is
+                                // deleted. Strip to basename and reject anything that still
+                                // contains a separator after the strip.
+                                id = path.basename(id);
+                                if (!id || id === "." || id === ".." || id.indexOf("/") !== -1 || id.indexOf("\\") !== -1) {
+                                    continue;
+                                }
                                 var pp = path.resolve(__dirname, './../../../frontend/express/public/userimages/' + id);
                                 countlyFs.deleteFile("userimages", pp, {id: id}, function(err1) {
                                     if (err1) {

--- a/api/parts/mgmt/app_users.js
+++ b/api/parts/mgmt/app_users.js
@@ -833,12 +833,27 @@ var deleteMyExport = function(exportID) { //tries to delete packed file, exporte
 
 usersApi.deleteExport = function(filename, params, callback) {
     if (filename && filename !== '') {
+        // Reject anything containing path-traversal characters or separators.
+        // The legitimate filename shape is appUser_<24hex>_<uid> or
+        // appUser_<24hex>_HASH_<hex>; both should match a tight regex.
+        if (typeof filename !== 'string' || /[^A-Za-z0-9_.-]/.test(filename)) {
+            return callback('invalid filename', '');
+        }
         var base_name = filename.split('.');
         var name_parts = base_name[0].split('_');
 
-        //filename : appUsers_{appid}_{uid} vai appUsers_{appid}_HASH_{hash form uids}            
+        //filename : appUsers_{appid}_{uid} vai appUsers_{appid}_HASH_{hash form uids}
         if (name_parts[0] !== 'appUser') {
             callback('invalid filename', '');
+        }
+        // Cross-tenant guard: the export filename embeds the app_id at
+        // name_parts[1]. Until this commit, validateUserForWrite ran against
+        // params.qstring.app_id (which can be any app the caller has admin on)
+        // while the actual mutation/file deletion targeted name_parts[1] (a
+        // potentially DIFFERENT app). Require they match. global_admin keeps
+        // unrestricted access.
+        else if (!params.member.global_admin && (params.qstring.app_id + "") !== (name_parts[1] + "")) {
+            callback('Not allowed (export belongs to a different app)', '');
         }
         else {
             //remove archive

--- a/api/parts/mgmt/app_users.js
+++ b/api/parts/mgmt/app_users.js
@@ -121,6 +121,7 @@ usersApi.update = function(app_id, query, update, params, callback) {
         callback = params;
         params = {};
     }
+    common.stripUnsafeMongoOperators(query);
     plugins.dispatch("/drill/preprocess_query", {
         query: query
     });
@@ -177,6 +178,7 @@ usersApi.delete = function(app_id, query, params, callback) {
             query = {};
         }
     }
+    common.stripUnsafeMongoOperators(query);
     plugins.dispatch("/drill/preprocess_query", {
         query: query
     });
@@ -301,6 +303,7 @@ usersApi.search = function(app_id, query, project, sort, limit, skip, callback) 
             query = {};
         }
     }
+    common.stripUnsafeMongoOperators(query);
 
     plugins.dispatch("/drill/preprocess_query", {
         query: query
@@ -361,6 +364,7 @@ usersApi.count = function(app_id, query, callback) {
             query = {};
         }
     }
+    common.stripUnsafeMongoOperators(query);
 
     plugins.dispatch("/drill/preprocess_query", {
         query: query
@@ -1032,6 +1036,7 @@ usersApi.export = function(app_id, query, params, callback) {
         });
     }
 
+    common.stripUnsafeMongoOperators(query);
     plugins.dispatch("/drill/preprocess_query", {
         query: query
     });
@@ -1290,6 +1295,7 @@ usersApi.loyalty = function(params) {
     if (typeof query === "string") {
         try {
             query = JSON.parse(query);
+            common.stripUnsafeMongoOperators(query);
             plugins.dispatch("/drill/preprocess_query", {
                 query: query,
                 params
@@ -1298,6 +1304,9 @@ usersApi.loyalty = function(params) {
         catch (error) {
             query = {};
         }
+    }
+    else {
+        common.stripUnsafeMongoOperators(query);
     }
 
     if (cohorts) {

--- a/api/parts/mgmt/apps.js
+++ b/api/parts/mgmt/apps.js
@@ -364,8 +364,9 @@ appsApi.updateApp = function(params) {
             },
             // App admins are allowed to manage these app-level settings via
             // the regular update flow. SSRF protection on redirect_url is
-            // applied at request time (api/utils/ssrf-protection.js used in
-            // validateRedirect) — see plugins/hooks/api/ssrf-protection.js.
+            // applied at request time by validateRedirect in
+            // api/utils/requestProcessor.js, which uses the shared helper at
+            // api/utils/ssrf-protection.js.
             'redirect_url': {
                 'required': false,
                 'type': 'String'

--- a/api/parts/mgmt/apps.js
+++ b/api/parts/mgmt/apps.js
@@ -232,6 +232,18 @@ appsApi.createApp = async function(params) {
             'checksum_salt': {
                 'required': false,
                 'type': 'String'
+            },
+            'redirect_url': {
+                'required': false,
+                'type': 'String'
+            },
+            'app_domain': {
+                'required': false,
+                'type': 'String'
+            },
+            'description': {
+                'required': false,
+                'type': 'String'
             }
         },
         newApp = {};
@@ -242,11 +254,9 @@ appsApi.createApp = async function(params) {
         return false;
     }
 
-    for (let i in params.qstring.args) {
-        if (typeof newApp[i] === "undefined") {
-            newApp[i] = params.qstring.args[i];
-        }
-    }
+    // Previously a catch-all loop copied EVERY field from params.qstring.args
+    // into newApp. That let the caller pre-set fields like _id, seq, plugins.*
+    // on insert. We now drop the catch-all and rely on the schema above.
 
     processAppProps(newApp);
 
@@ -351,6 +361,22 @@ appsApi.updateApp = function(params) {
             'locked': {
                 'required': false,
                 'type': 'Boolean'
+            },
+            // App admins are allowed to manage these app-level settings via
+            // the regular update flow. SSRF protection on redirect_url is
+            // applied at request time (api/utils/ssrf-protection.js used in
+            // validateRedirect) — see plugins/hooks/api/ssrf-protection.js.
+            'redirect_url': {
+                'required': false,
+                'type': 'String'
+            },
+            'app_domain': {
+                'required': false,
+                'type': 'String'
+            },
+            'description': {
+                'required': false,
+                'type': 'String'
             }
         },
         updatedApp = {};
@@ -377,11 +403,17 @@ appsApi.updateApp = function(params) {
         return false;
     }
 
-    for (var i in params.qstring.args) {
-        if (typeof updatedApp[i] === "undefined" && i !== "app_id") {
-            updatedApp[i] = params.qstring.args[i];
-        }
-    }
+    // Previously this loop copied EVERY field from params.qstring.args back
+    // into updatedApp (excluding only "app_id"). That allowed an app admin to
+    // set arbitrary fields on the app document — owner, _id, seq, plugins.*,
+    // last_data, paused, created_at, etc. — bypassing per-flow validators
+    // (e.g. plugins.* should go through /i/apps/update/plugins/<name>; key
+    // and salt rotation should go through resetApp / dedicated flows).
+    //
+    // We now drop the catch-all and rely solely on the schema above. Any
+    // additional field a plugin needs the dashboard to set must be added to
+    // argProps explicitly (or, for plugin-namespaced settings, routed through
+    // /i/apps/update/plugins/<name>).
 
     if (Object.keys(updatedApp).length === 0) {
         common.returnMessage(params, 200, 'Nothing changed');

--- a/api/parts/mgmt/event_groups.js
+++ b/api/parts/mgmt/event_groups.js
@@ -46,7 +46,16 @@ const create = (params) => {
         return false;
     }
     const _id = `${ID_PREFIX}${crypto.createHash('md5').update(`${JSON.stringify(params.qstring.args.source_events)}${params.qstring.app_id}${Date.now()}`).digest('hex')}`;
-    common.db.collection(COLLECTION_NAME).insert({...params.qstring.args, _id}, (error, result) =>{
+    // Insert only the validated fields plus the server-side _id and app_id.
+    // The previous spread of params.qstring.args allowed callers to inject
+    // any field (including a forged app_id) into the inserted document.
+    const doc = {_id, app_id: params.qstring.app_id};
+    for (const field of ['name', 'source_events', 'description', 'display_map', 'status', 'order']) {
+        if (Object.prototype.hasOwnProperty.call(obj, field)) {
+            doc[field] = obj[field];
+        }
+    }
+    common.db.collection(COLLECTION_NAME).insert(doc, (error, result) =>{
         if (error) {
             common.returnMessage(params, 500, `error: ${error}`);
             return false;
@@ -58,13 +67,33 @@ const create = (params) => {
 };
 
 /**
+ * Whitelist of fields a caller may set/update on an event_group document.
+ * Anything else (notably _id, app_id) is stripped from $set.
+ */
+const UPDATABLE_FIELDS = ['name', 'source_events', 'description', 'display_map', 'status', 'order'];
+
+/**
  * Event Groups CRUD - The function updating which created `Event Groups` data by `_id`
- * @param {Object} params - 
+ * @param {Object} params -
+ * @returns {boolean|undefined} false on validation failure, otherwise undefined
  */
 const update = (params) => {
     if (params.qstring.args) {
         params.qstring.args = JSON.parse(params.qstring.args);
-        common.db.collection(COLLECTION_NAME).update({'_id': params.qstring.args._id}, {$set: params.qstring.args}, (error) =>{
+        // Strip args down to the whitelisted fields. Without this, args was
+        // passed as $set verbatim — letting an attacker rewrite app_id (move
+        // an event group across tenants) or set arbitrary unscoped fields.
+        const updateSet = {};
+        for (const field of UPDATABLE_FIELDS) {
+            if (Object.prototype.hasOwnProperty.call(params.qstring.args, field)) {
+                updateSet[field] = params.qstring.args[field];
+            }
+        }
+        if (Object.keys(updateSet).length === 0) {
+            common.returnMessage(params, 400, 'No updatable fields provided');
+            return false;
+        }
+        common.db.collection(COLLECTION_NAME).updateOne({'_id': params.qstring.args._id, app_id: params.qstring.app_id}, {$set: updateSet}, (error) =>{
             if (error) {
                 common.returnMessage(params, 500, `error: ${error}`);
                 return false;

--- a/api/parts/mgmt/users.js
+++ b/api/parts/mgmt/users.js
@@ -906,62 +906,62 @@ usersApi.saveNote = async function(params) {
     };
     const args = params.qstring.args;
     const noteValidation = common.validateArgs(args, argProps, true);
-    if (noteValidation) {
-        const note = {
-            app_id: args.app_id,
-            note: args.note,
-            ts: args.ts,
-            noteType: args.noteType,
-            emails: args.emails || [],
-            color: args.color,
-            category: args.category,
-            owner: params.member._id + "",
-            created_at: new Date().getTime(),
-            updated_at: new Date().getTime()
-        };
+    if (!noteValidation.result) {
+        common.returnMessage(params, 400, 'Invalid note: ' + (noteValidation.errors && noteValidation.errors.join('; ')));
+        return false;
+    }
 
-        if (args._id) {
-            const editPermission = await usersApi.checkNoteEditPermission(params);
-            if (!editPermission) {
-                common.returnMessage(params, 403, 'Not allow to edit note');
-            }
-            else {
-                delete note.created_at;
-                delete note.owner;
-                common.db.collection('notes').update({_id: common.db.ObjectID(args._id)}, {$set: note }, (err) => {
-                    if (err) {
-                        common.returnMessage(params, 503, 'Save note failed');
-                    }
-                    else {
-                        common.returnMessage(params, 200, 'Success');
-                    }
-                });
-            }
+    const note = {
+        app_id: args.app_id,
+        note: args.note,
+        ts: args.ts,
+        noteType: args.noteType,
+        emails: args.emails || [],
+        color: args.color,
+        category: args.category,
+        owner: params.member._id + "",
+        created_at: new Date().getTime(),
+        updated_at: new Date().getTime()
+    };
+
+    if (args._id) {
+        const editPermission = await usersApi.checkNoteEditPermission(params);
+        if (!editPermission) {
+            common.returnMessage(params, 403, 'Not allow to edit note');
         }
         else {
-            common.db.collection('notes').find({ "app_id": args.app_id }).sort({ "created_at": -1 }).limit(1).project({ "indicator": 1 }).toArray(function(err, res) {
+            delete note.created_at;
+            delete note.owner;
+            common.db.collection('notes').update({_id: common.db.ObjectID(args._id)}, {$set: note }, (err) => {
                 if (err) {
                     common.returnMessage(params, 503, 'Save note failed');
                 }
                 else {
-                    if (res && res.length) {
-                        note.indicator = countlyCommon.stringIncrement(res[0].indicator);
-                    }
-                    else {
-                        note.indicator = "A";
-                    }
-                    common.db.collection('notes').insert(note, (_err) => {
-                        if (_err) {
-                            common.returnMessage(params, 503, 'Insert Note failed.');
-                        }
-                        common.returnMessage(params, 200, 'Success');
-                    });
+                    common.returnMessage(params, 200, 'Success');
                 }
             });
         }
     }
     else {
-        common.returnMessage(params, 403, 'add notes failed');
+        common.db.collection('notes').find({ "app_id": args.app_id }).sort({ "created_at": -1 }).limit(1).project({ "indicator": 1 }).toArray(function(err, res) {
+            if (err) {
+                common.returnMessage(params, 503, 'Save note failed');
+            }
+            else {
+                if (res && res.length) {
+                    note.indicator = countlyCommon.stringIncrement(res[0].indicator);
+                }
+                else {
+                    note.indicator = "A";
+                }
+                common.db.collection('notes').insert(note, (_err) => {
+                    if (_err) {
+                        common.returnMessage(params, 503, 'Insert Note failed.');
+                    }
+                    common.returnMessage(params, 200, 'Success');
+                });
+            }
+        });
     }
     return true;
 };

--- a/api/parts/mgmt/users.js
+++ b/api/parts/mgmt/users.js
@@ -1097,8 +1097,14 @@ usersApi.fetchNotes = async function(params) {
     const orderByKey = {'3': 'noteType', '2': 'ts'};
     let sortBy = {};
     if (params.qstring.sSearch) {
+        // Cap input length and escape regex metacharacters before
+        // constructing the RegExp. Without this, a pattern like "^(a+)+$"
+        // can stall the worker (and the per-collection Mongo regex scan)
+        // for any caller with notes:read.
+        var rawSearch = (params.qstring.sSearch + "").slice(0, 256);
+        var escapedSearch = rawSearch.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
         /*eslint-disable */
-        query.note = {$regex: new RegExp(params.qstring.sSearch, "i")};
+        query.note = {$regex: new RegExp(escapedSearch, "i")};
         /*eslint-enable */
     }
     if (params.qstring.iSortCol_0 && params.qstring.iSortCol_0 !== '0') {

--- a/api/parts/mgmt/users.js
+++ b/api/parts/mgmt/users.js
@@ -862,7 +862,11 @@ usersApi.checkNoteEditPermission = async function(params) {
                         return reject(false);
                     }
                     const globalAdmin = params.member.global_admin;
-                    const isAppAdmin = hasAdminAccess(params.member, params.qstring.app_id);
+                    // Permission is checked against the NOTE's stored app_id, not the
+                    // app_id in the request's query string. Otherwise a user who is
+                    // app-admin of A can edit/delete notes that belong to B by passing
+                    // app_id=A in the qstring while targeting note_id=<B's note>.
+                    const isAppAdmin = hasAdminAccess(params.member, note.app_id + "");
                     const noteOwner = (note.owner + '' === params.member._id + '');
                     return resolve(noteOwner || (isAppAdmin && note.noteType === 'public') || (globalAdmin && note.noteType === 'public'));
                 }
@@ -911,8 +915,12 @@ usersApi.saveNote = async function(params) {
         return false;
     }
 
+    // Bind the note to the app_id we already permission-checked
+    // (params.qstring.app_id, against which validateCreate ran). Trusting
+    // args.app_id would let a user with create-rights on app A write notes
+    // attached to app B by passing args.app_id=B.
     const note = {
-        app_id: args.app_id,
+        app_id: params.qstring.app_id + "",
         note: args.note,
         ts: args.ts,
         noteType: args.noteType,
@@ -943,7 +951,7 @@ usersApi.saveNote = async function(params) {
         }
     }
     else {
-        common.db.collection('notes').find({ "app_id": args.app_id }).sort({ "created_at": -1 }).limit(1).project({ "indicator": 1 }).toArray(function(err, res) {
+        common.db.collection('notes').find({ "app_id": note.app_id }).sort({ "created_at": -1 }).limit(1).project({ "indicator": 1 }).toArray(function(err, res) {
             if (err) {
                 common.returnMessage(params, 503, 'Save note failed');
             }

--- a/api/parts/mgmt/users.js
+++ b/api/parts/mgmt/users.js
@@ -272,8 +272,16 @@ usersApi.createUser = async function(params) {
                     console.log('Error creating user: ', err);
                 }
                 if (member && member.length && !err) {
+                    // The previous derivation was sha512Hash(username + full_name, timestamp).
+                    // sha512Hash treats its second arg as a *boolean* addSalt flag (see
+                    // sha512Hash() below), so the actual HMAC key was Date.now() ms — a tiny
+                    // attacker-discoverable keyspace given an estimated send time. Combined
+                    // with attacker-knowable username/full_name, this enabled new-member
+                    // invite token recovery and account takeover before the legitimate user
+                    // clicked the link. Use crypto.randomBytes(32) instead — same approach
+                    // already used by the password-reset flow in frontend/express/libs/members.js.
                     var timestamp = Math.round(new Date().getTime() / 1000),
-                        prid = sha512Hash(member[0].username + member[0].full_name, timestamp);
+                        prid = crypto.randomBytes(32).toString('hex');
                     common.db.collection('password_reset').insert({"prid": prid, "user_id": member[0]._id, "timestamp": timestamp, "newInvite": true}, {safe: true}, function() {
                         mail.sendToNewMemberLink(member[0], prid);
                     });

--- a/api/utils/common.js
+++ b/api/utils/common.js
@@ -2577,6 +2577,58 @@ common.checkPromise = function(func, count, interval) {
     });
 };
 
+/**
+ * Recursively remove MongoDB operators that allow arbitrary JavaScript
+ * execution or comparison-bypass against trusted server state from a
+ * user-supplied query object. Strips:
+ *
+ *   $where        — evaluates a JS function on every doc; supports
+ *                   `while(true){}` DoS and timing-based exfiltration.
+ *   $expr         — evaluates aggregation expressions against the doc;
+ *                   can be chained with $function/$accumulator below.
+ *   $function     — Mongo 4.4+ server-side JS execution.
+ *   $accumulator  — server-side JS aggregation execution.
+ *
+ * Use this anywhere a request body / query string is passed straight
+ * into MongoDB find/update/delete/count/aggregate as the filter. It is
+ * a defence-in-depth helper, not a substitute for a strict allowlist
+ * of fields.
+ *
+ * @param {*} query - user-supplied query (any depth)
+ * @returns {*} the same query with the dangerous operators removed
+ */
+common.stripUnsafeMongoOperators = function(query) {
+    var BLOCKED = ["$where", "$expr", "$function", "$accumulator"];
+    /**
+     * Recursive walk that strips blocked operators in-place.
+     * @param {*} v - current node
+     * @returns {void}
+     */
+    function walk(v) {
+        if (!v || typeof v !== "object") {
+            return;
+        }
+        if (Array.isArray(v)) {
+            for (var ai = 0; ai < v.length; ai++) {
+                walk(v[ai]);
+            }
+            return;
+        }
+        for (var bi = 0; bi < BLOCKED.length; bi++) {
+            if (Object.prototype.hasOwnProperty.call(v, BLOCKED[bi])) {
+                delete v[BLOCKED[bi]];
+            }
+        }
+        for (var k in v) {
+            if (Object.prototype.hasOwnProperty.call(v, k)) {
+                walk(v[k]);
+            }
+        }
+    }
+    walk(query);
+    return query;
+};
+
 common.clearClashingQueryOperations = function(query) {
     var map = {};
     var field;

--- a/api/utils/common.js
+++ b/api/utils/common.js
@@ -14,7 +14,8 @@ var common = {},
     argon2 = require('argon2'),
     mongodb = require('mongodb'),
     getRandomValues = require('get-random-values'),
-    _ = require('lodash');
+    _ = require('lodash'),
+    path = require('path');
 
 var matchHtmlRegExp = /"|'|&(?!amp;|quot;|#39;|lt;|gt;|#46;|#36;)|<|>/;
 var matchLessHtmlRegExp = /[<>]/;
@@ -2595,9 +2596,9 @@ common.clearClashingQueryOperations = function(query) {
         }
     }
 
-    for (var path in map) {
-        if (map[path] > 1) {
-            badPaths.push(path);
+    for (var fieldPath in map) {
+        if (map[fieldPath] > 1) {
+            badPaths.push(fieldPath);
         }
     }
     if (badPaths.length > 0) {
@@ -3118,6 +3119,25 @@ common.sanitizeFilename = (filename, replacement = "") => {
         .replace(/[\/\?<>\\:\*\|"]/g, replacement)
         .replace(/^\.{1,2}$/, replacement)
         .replace(/^\.+/, replacement);
+};
+
+/**
+ * Resolve an input path under a base directory and reject path traversal.
+ * @param {string} basePath - base directory for allowed paths
+ * @param {string} inputPath - user-supplied path segment or relative path
+ * @returns {string|null} contained absolute path or null
+ */
+common.resolvePathInBase = (basePath, inputPath) => {
+    basePath = path.resolve(basePath + "");
+    inputPath = (inputPath + "").replace(/\\/g, "/");
+    while (inputPath.indexOf("/") === 0) {
+        inputPath = inputPath.substring(1);
+    }
+    let resolvedPath = path.resolve(basePath, inputPath);
+    if (resolvedPath === basePath || resolvedPath.indexOf(basePath + path.sep) === 0) {
+        return resolvedPath;
+    }
+    return null;
 };
 
 /**

--- a/api/utils/common.js
+++ b/api/utils/common.js
@@ -1638,9 +1638,18 @@ common.returnMessage = function(params, returnCode, message, heads, noResult = f
 * @param {object} heads - headers to add to the output
 */
 common.returnOutput = function(params, output, noescape, heads) {
-    if (params && params.qstring && params.qstring.noescape) {
-        noescape = params.qstring.noescape;
-    }
+    // The function previously honored params.qstring.noescape — letting any
+    // caller disable HTML-entity escaping on the API response by appending
+    // ?noescape=1 to the URL. The dashboard relies on returnOutput escaping
+    // attacker-controllable strings (crash names, segmentation values, etc)
+    // before rendering them with v-html. With ?noescape=1 honored at the
+    // qstring level, an attacker could craft a URL that, when loaded by an
+    // admin, returned unescaped JSON which then executed as script in
+    // v-html sinks (reflected XSS via parameter manipulation).
+    //
+    // Keep `noescape` as a function argument for internal callers that
+    // intentionally bypass escaping (binary, pre-escaped content); never
+    // accept it from the request.
     var escape = noescape ? undefined : function(k, v) {
         return escape_html_entities(k, v, true);
     };

--- a/api/utils/render.js
+++ b/api/utils/render.js
@@ -68,6 +68,11 @@ exports.renderView = function(options, cb) {
                     XDG_CONFIG_HOME: pathModule.resolve(__dirname, "../../.cache/chrome/tmp/.chromium"),
                     XDG_CACHE_HOME: pathModule.resolve(__dirname, "../../.cache/chrome/tmp/.chromium")
                 },
+                // --no-sandbox / --disable-setuid-sandbox: needed when running as root in containers.
+                // --ignore-certificate-errors: needed because the renderer fetches the local
+                //   dashboard at https://localhost which often has a self-signed certificate.
+                // Note: master 25.x temporarily added --disable-web-security here and PR #7535's
+                //   M-14 commit removed it; this 24.05 branch never had that flag, so M-14 is a no-op.
                 args: ['--no-sandbox', '--disable-setuid-sandbox', '--ignore-certificate-errors'],
                 ignoreHTTPSErrors: true,
                 userDataDir: pathModule.resolve(__dirname, "../../dump/chrome/" + Date.now())

--- a/api/utils/requestProcessor.js
+++ b/api/utils/requestProcessor.js
@@ -2158,9 +2158,12 @@ const processRequest = (params) => {
                     }, params);
                     break;
                 case 'plugins':
-                    validateUserForMgmtReadAPI(() => {
+                    // Listing installed plugins (paid/enterprise modules
+                    // included) is sensitive recon for attackers. Restrict
+                    // to global admins.
+                    validateUserForGlobalAdmin(params, () => {
                         common.returnOutput(params, plugins.getPlugins());
-                    }, params);
+                    });
                     break;
                 default:
                     if (!plugins.dispatch(apiPath, {
@@ -3122,7 +3125,12 @@ const processRequest = (params) => {
             case '/i/cms': {
                 switch (paths[3]) {
                 case 'save_entries':
-                    validateUserForWrite(params, countlyApi.mgmt.cms.saveEntries);
+                    // Restrict CMS cache writes to global admins. The CMS
+                    // entries seed help/onboarding content rendered to other
+                    // dashboard users; before this, validateUserForWrite (an
+                    // alias of validateUser) allowed any logged-in user to
+                    // pollute the cache.
+                    validateUserForGlobalAdmin(params, countlyApi.mgmt.cms.saveEntries);
                     break;
                 case 'clear':
                     validateUserForWrite(countlyApi.mgmt.cms.clearCache, params);

--- a/api/utils/requestProcessor.js
+++ b/api/utils/requestProcessor.js
@@ -2382,6 +2382,17 @@ const processRequest = (params) => {
                                 if (err) {
                                     common.returnMessage(params, 400, err);
                                 }
+                                else if (!data) {
+                                    common.returnMessage(params, 404, 'Export not found');
+                                }
+                                else if (!taskmanager.isAuthorizedFor(params.member, data)) {
+                                    // Without this check, validateRead only verifies the user has
+                                    // 'core:read' on the qstring app_id — which can be any app
+                                    // they have access to — while the long_tasks document itself
+                                    // (and its on-disk export) belongs to potentially a different
+                                    // app or another user's tenant scope. Cross-app data leak.
+                                    common.returnMessage(params, 403, 'Not allowed');
+                                }
                                 else {
                                     var filename = data.report_name;
                                     var type = filename.split(".");

--- a/api/utils/requestProcessor.js
+++ b/api/utils/requestProcessor.js
@@ -1797,6 +1797,15 @@ const processRequest = (params) => {
                                                 common.returnMessage(params, 400, "Export doesn't exist");
                                             }
                                             else {
+                                                stream.on("error", function(streamErr) {
+                                                    log.e(streamErr);
+                                                    if (!params.res.headersSent) {
+                                                        common.returnMessage(params, 500, "Export stream error");
+                                                    }
+                                                    else {
+                                                        params.res.end();
+                                                    }
+                                                });
                                                 params.res.writeHead(200, {
                                                     'Content-Type': 'application/x-gzip',
                                                     'Content-Length': size,
@@ -2357,6 +2366,15 @@ const processRequest = (params) => {
                                                     common.returnMessage(params, 400, "Export stream does not exist");
                                                 }
                                                 else {
+                                                    stream.on("error", function(streamErr) {
+                                                        log.e(streamErr);
+                                                        if (!params.res.headersSent) {
+                                                            common.returnMessage(params, 500, "Export stream error");
+                                                        }
+                                                        else {
+                                                            params.res.end();
+                                                        }
+                                                    });
                                                     headers = {};
                                                     headers["Content-Type"] = countlyApi.data.exports.getType(type);
                                                     headers["Content-Disposition"] = "attachment;filename=" + encodeURIComponent(filename);

--- a/api/utils/requestProcessor.js
+++ b/api/utils/requestProcessor.js
@@ -1791,8 +1791,29 @@ const processRequest = (params) => {
                  */
                 case 'download': {
                     if (paths[4] && paths[4] !== '') {
+                        // Reject filenames containing path separators / traversal
+                        // characters before any further parsing. The legitimate
+                        // shape is "appUser_<24hex>_<uid>(.json|.tar.gz)" or a
+                        // task-result id.
+                        if (typeof paths[4] !== 'string' || /[^A-Za-z0-9_.-]/.test(paths[4])) {
+                            common.returnMessage(params, 400, 'Invalid filename');
+                            return false;
+                        }
                         validateUserForRead(params, function() {
                             var filename = paths[4].split('.');
+                            // Cross-tenant guard: an appUser_<app_id>_<uid> export
+                            // belongs to <app_id>. validateUserForRead only verifies
+                            // the caller has read on params.qstring.app_id (which
+                            // can be any app they have access to), so without this
+                            // check, a member of app A could pull exports owned by
+                            // app B simply by guessing the filename.
+                            if (filename[0].startsWith("appUser_")) {
+                                var nameParts = filename[0].split('_');
+                                if (nameParts.length >= 2 && !params.member.global_admin && (params.qstring.app_id + "") !== (nameParts[1] + "")) {
+                                    common.returnMessage(params, 403, 'Not allowed (export belongs to a different app)');
+                                    return false;
+                                }
+                            }
                             new Promise(function(resolve) {
                                 if (filename[0].startsWith("appUser_")) {
                                     filename[0] = filename[0] + '.tar.gz';

--- a/api/utils/requestProcessor.js
+++ b/api/utils/requestProcessor.js
@@ -17,6 +17,7 @@ const log = require('./log.js')('core:api');
 const fs = require('fs');
 var countlyFs = require('./countlyFs.js');
 var path = require('path');
+var ssrfProtection = require('./ssrf-protection.js');
 const validateUserForWriteAPI = validateUser;
 const validateUserForDataReadAPI = validateRead;
 const validateUserForDataWriteAPI = validateUserForWrite;
@@ -3399,8 +3400,10 @@ function validateRedirect(ob) {
             newPath += "?";
         }
 
+        var fullUri = app.redirect_url + newPath + '&ip_address=' + params.ip_address;
+
         var opts = {
-            uri: app.redirect_url + newPath + '&ip_address=' + params.ip_address,
+            uri: fullUri,
             method: 'GET'
         };
 
@@ -3414,36 +3417,52 @@ function validateRedirect(ob) {
             }
         }
 
-        request(opts, function(error, response, body) {
-            var code = 400;
-            var message = "Redirect error. Tried to redirect to:" + app.redirect_url;
-
-            if (response && response.statusCode) {
-                code = response.statusCode;
-            }
-
-
-            if (response && response.body) {
-                try {
-                    var resp = JSON.parse(response.body);
-                    message = resp.result || resp;
+        // SSRF guard: validate the resolved URL against the shared block list
+        // (private/loopback/cloud-metadata) before issuing the request, and
+        // disable redirects in the underlying client. The redirect_url is set
+        // by app admins and would otherwise let any app-admin pivot the SDK
+        // ingestion stream into internal services or a proxy/harvest endpoint.
+        ssrfProtection.isUrlSafe(opts.uri).then(function(check) {
+            if (!check.safe) {
+                log.e("Redirect SSRF guard blocked %s: %s", opts.uri, check.error);
+                if (plugins.getConfig("api", params.app && params.app.plugins, true).safe || params.qstring?.safe_api_response) {
+                    common.returnMessage(params, 400, 'Redirect blocked by SSRF protection: ' + check.error);
                 }
-                catch (e) {
-                    if (response.result) {
-                        message = response.result;
+                return;
+            }
+            request(ssrfProtection.getSsrfSafeOptions(opts), function(error, response, body) {
+                var code = 400;
+                var message = "Redirect error. Tried to redirect to:" + app.redirect_url;
+
+                if (response && response.statusCode) {
+                    code = response.statusCode;
+                }
+
+
+                if (response && response.body) {
+                    try {
+                        var resp = JSON.parse(response.body);
+                        message = resp.result || resp;
                     }
-                    else {
-                        message = response.body;
+                    catch (e) {
+                        if (response.result) {
+                            message = response.result;
+                        }
+                        else {
+                            message = response.body;
+                        }
                     }
                 }
-            }
-            if (error) { //error
-                log.e("Redirect error", error, body, opts, app, params);
-            }
+                if (error) { //error
+                    log.e("Redirect error", error, body, opts, app, params);
+                }
 
-            if (plugins.getConfig("api", params.app && params.app.plugins, true).safe || params.qstring?.safe_api_response) {
-                common.returnMessage(params, code, message);
-            }
+                if (plugins.getConfig("api", params.app && params.app.plugins, true).safe || params.qstring?.safe_api_response) {
+                    common.returnMessage(params, code, message);
+                }
+            });
+        }).catch(function(e) {
+            log.e("Redirect SSRF guard error", e);
         });
         params.cancelRequest = "Redirected: " + app.redirect_url;
         params.waitForResponse = false;

--- a/api/utils/requestProcessor.js
+++ b/api/utils/requestProcessor.js
@@ -861,11 +861,26 @@ const processRequest = (params) => {
                 switch (paths[3]) {
                 case 'update':
                     validateUserForWrite(params, () => {
-                        taskmanager.rerunTask({
-                            db: common.db,
-                            id: params.qstring.task_id
-                        }, (err, res) => {
-                            common.returnMessage(params, 200, res);
+                        // Authorize: only the task's creator, an admin of the task's
+                        // app_id, or a global admin can rerun a task. Otherwise
+                        // rerunTask would replay the original request using the
+                        // creator's api_key (cross-tenant privilege escalation).
+                        taskmanager.loadIfAuthorized(common.db, params.qstring.task_id, params.member, (authErr) => {
+                            if (authErr === 'forbidden') {
+                                return common.returnMessage(params, 403, 'Not allowed');
+                            }
+                            if (authErr === 'not_found') {
+                                return common.returnMessage(params, 404, 'Task not found');
+                            }
+                            if (authErr) {
+                                return common.returnMessage(params, 500, 'Server error');
+                            }
+                            taskmanager.rerunTask({
+                                db: common.db,
+                                id: params.qstring.task_id
+                            }, (err, res) => {
+                                common.returnMessage(params, 200, res);
+                            });
                         });
                     });
                     break;
@@ -882,47 +897,80 @@ const processRequest = (params) => {
                     break;
                 case 'delete':
                     validateUserForWrite(params, () => {
-                        taskmanager.deleteResult({
-                            db: common.db,
-                            id: params.qstring.task_id
-                        }, (err, task) => {
-                            plugins.dispatch("/systemlogs", {params: params, action: "task_manager_task_deleted", data: task});
-                            common.returnMessage(params, 200, "Success");
+                        taskmanager.loadIfAuthorized(common.db, params.qstring.task_id, params.member, (authErr) => {
+                            if (authErr === 'forbidden') {
+                                return common.returnMessage(params, 403, 'Not allowed');
+                            }
+                            if (authErr === 'not_found') {
+                                return common.returnMessage(params, 404, 'Task not found');
+                            }
+                            if (authErr) {
+                                return common.returnMessage(params, 500, 'Server error');
+                            }
+                            taskmanager.deleteResult({
+                                db: common.db,
+                                id: params.qstring.task_id
+                            }, (err, task) => {
+                                plugins.dispatch("/systemlogs", {params: params, action: "task_manager_task_deleted", data: task});
+                                common.returnMessage(params, 200, "Success");
+                            });
                         });
                     });
                     break;
                 case 'name':
                     validateUserForWrite(params, () => {
-                        taskmanager.nameResult({
-                            db: common.db,
-                            id: params.qstring.task_id,
-                            name: params.qstring.name
-                        }, () => {
-                            common.returnMessage(params, 200, "Success");
+                        taskmanager.loadIfAuthorized(common.db, params.qstring.task_id, params.member, (authErr) => {
+                            if (authErr === 'forbidden') {
+                                return common.returnMessage(params, 403, 'Not allowed');
+                            }
+                            if (authErr === 'not_found') {
+                                return common.returnMessage(params, 404, 'Task not found');
+                            }
+                            if (authErr) {
+                                return common.returnMessage(params, 500, 'Server error');
+                            }
+                            taskmanager.nameResult({
+                                db: common.db,
+                                id: params.qstring.task_id,
+                                name: params.qstring.name
+                            }, () => {
+                                common.returnMessage(params, 200, "Success");
+                            });
                         });
                     });
                     break;
                 case 'edit':
                     validateUserForWrite(params, () => {
-                        const data = {
-                            "report_name": params.qstring.report_name,
-                            "report_desc": params.qstring.report_desc,
-                            "global": params.qstring.global + "" === 'true',
-                            "autoRefresh": params.qstring.autoRefresh + "" === 'true',
-                            "period_desc": params.qstring.period_desc
-                        };
-                        taskmanager.editTask({
-                            db: common.db,
-                            data: data,
-                            id: params.qstring.task_id
-                        }, (err, d) => {
-                            if (err) {
-                                common.returnMessage(params, 503, "Error");
+                        taskmanager.loadIfAuthorized(common.db, params.qstring.task_id, params.member, (authErr) => {
+                            if (authErr === 'forbidden') {
+                                return common.returnMessage(params, 403, 'Not allowed');
                             }
-                            else {
-                                common.returnMessage(params, 200, "Success");
+                            if (authErr === 'not_found') {
+                                return common.returnMessage(params, 404, 'Task not found');
                             }
-                            plugins.dispatch("/systemlogs", {params: params, action: "task_manager_task_updated", data: d});
+                            if (authErr) {
+                                return common.returnMessage(params, 500, 'Server error');
+                            }
+                            const data = {
+                                "report_name": params.qstring.report_name,
+                                "report_desc": params.qstring.report_desc,
+                                "global": params.qstring.global + "" === 'true',
+                                "autoRefresh": params.qstring.autoRefresh + "" === 'true',
+                                "period_desc": params.qstring.period_desc
+                            };
+                            taskmanager.editTask({
+                                db: common.db,
+                                data: data,
+                                id: params.qstring.task_id
+                            }, (err, d) => {
+                                if (err) {
+                                    common.returnMessage(params, 503, "Error");
+                                }
+                                else {
+                                    common.returnMessage(params, 200, "Success");
+                                }
+                                plugins.dispatch("/systemlogs", {params: params, action: "task_manager_task_updated", data: d});
+                            });
                         });
                     });
                     break;

--- a/api/utils/ssrf-protection.js
+++ b/api/utils/ssrf-protection.js
@@ -1,0 +1,224 @@
+/**
+ * @module api/utils/ssrf-protection
+ * @description SSRF (Server-Side Request Forgery) protection utilities
+ * shared by the core API (validateRedirect for app.redirect_url) and
+ * the Hooks plugin's HTTPEffect.
+ *
+ * Provides IP blocklist checking, DNS-level validation, and URL safety
+ * verification to prevent requests to internal/private network addresses,
+ * cloud metadata endpoints, and other dangerous targets.
+ *
+ * Uses ipaddr.js for robust IP address parsing and range classification,
+ * covering all RFC-defined private, reserved, loopback, link-local,
+ * multicast, carrier-grade NAT, and documentation ranges for both
+ * IPv4 and IPv6 (including IPv4-mapped IPv6 and NAT64).
+ *
+ *  - URL parse time validation with DNS (isUrlSafe)
+ *  - Protocol restriction (only http/https)
+ *  - Redirects disabled (followRedirect: false via getSsrfSafeOptions)
+ *  - Revalidation after template expansion (when doing request in http effect)
+ */
+
+'use strict';
+
+const dns = require('dns');
+const net = require('net');
+const { URL } = require('url');
+const ipaddr = require('ipaddr.js');
+
+/**
+ * Allowed URL protocols for outbound requests.
+ */
+const ALLOWED_PROTOCOLS = new Set(['http:', 'https:']);
+
+/**
+ * Hostnames known to serve cloud metadata / internal services.
+ * Checked as exact match (case-insensitive).
+ */
+const BLOCKED_HOSTNAMES = new Set([
+    'metadata.google.internal',
+    'metadata.goog',
+    'metadata.google.com',
+    'kubernetes.default.svc',
+    'kubernetes.default',
+    'kubernetes',
+]);
+
+/**
+ * Check whether an IP address (v4 or v6) is private/reserved/internal.
+ *
+ * Uses ipaddr.js range() classification. Only 'unicast' addresses are
+ * considered safe. All other ranges are blocked:
+ *  - unspecified  (0.0.0.0/8, ::)
+ *  - loopback     (127.0.0.0/8, ::1)
+ *  - private      (10/8, 172.16/12, 192.168/16)
+ *  - linkLocal    (169.254/16, fe80::/10)
+ *  - multicast    (224/4, ff00::/8)
+ *  - broadcast    (255.255.255.255)
+ *  - reserved     (192.0.0/24, 192.0.2/24, 192.88.99/24, 198.18/15,
+ *                  198.51.100/24, 203.0.113/24, 240/4, 2001:db8::/32)
+ *  - carrierGradeNat (100.64/10)
+ *  - uniqueLocal  (fc00::/7)
+ *  - ipv4Mapped   (::ffff:0:0/96 — unwrapped and re-checked as IPv4)
+ *  - rfc6052      (64:ff9b::/96 NAT64)
+ *  - discard      (100::/64)
+ *
+ * @param {string} ip - IP address string
+ * @returns {boolean} true if the IP should be blocked
+ */
+function isBlockedIP(ip) {
+    let parsed;
+    try {
+        parsed = ipaddr.parse(ip);
+    }
+    catch (e) {
+        // Unparseable IP — block to be safe
+        return true;
+    }
+
+    const range = parsed.range();
+
+    // IPv4-mapped IPv6 (::ffff:x.x.x.x): unwrap and check the inner IPv4
+    if (range === 'ipv4Mapped' && parsed.isIPv4MappedAddress()) {
+        return parsed.toIPv4Address().range() !== 'unicast';
+    }
+
+    return range !== 'unicast';
+}
+
+/**
+ * Check whether a hostname is a known dangerous internal service.
+ *
+ * @param {string} hostname - The hostname to check (will be lowercased)
+ * @returns {boolean} true if the hostname should be blocked
+ */
+function isBlockedHostname(hostname) {
+    const lower = hostname.toLowerCase();
+
+    // Exact match against known dangerous hosts
+    if (BLOCKED_HOSTNAMES.has(lower)) {
+        return true;
+    }
+
+    // Block "localhost" and variants
+    if (lower === 'localhost' || lower.endsWith('.localhost')) {
+        return true;
+    }
+
+    // Block .internal TLD (used by GCP metadata and internal services)
+    if (lower.endsWith('.internal')) {
+        return true;
+    }
+
+    return false;
+}
+
+/**
+ * Strip IPv6 brackets from a hostname if present.
+ * new URL('http://[::1]/').hostname returns '[::1]' with brackets,
+ * but net.isIP() and our IP checkers expect '::1' without brackets.
+ *
+ * @param {string} hostname - hostname possibly wrapped in brackets
+ * @returns {string} hostname with brackets stripped if it was a bracketed IPv6
+ */
+function stripIPv6Brackets(hostname) {
+    if (hostname.startsWith('[') && hostname.endsWith(']')) {
+        return hostname.slice(1, -1);
+    }
+    return hostname;
+}
+
+/**
+ * Validate a URL string for SSRF safety.
+ *
+ * @param {string} urlString - The URL to validate
+ */
+async function isUrlSafe(urlString) {
+    // Must be a non-empty string
+    if (!urlString || typeof urlString !== 'string') {
+        return { safe: false, error: 'URL must be a non-empty string' };
+    }
+
+    // Parse the URL
+    let parsed;
+    try {
+        parsed = new URL(urlString);
+    }
+    catch (e) {
+        return { safe: false, error: 'Invalid URL: ' + e.message };
+    }
+
+    // Protocol restriction
+    if (!ALLOWED_PROTOCOLS.has(parsed.protocol)) {
+        return { safe: false, error: `Protocol "${parsed.protocol}" is not allowed. Only http and https are permitted.` };
+    }
+
+    // Block credentials in URL (user:pass@host)
+    if (parsed.username || parsed.password) {
+        return { safe: false, error: 'URLs with embedded credentials are not allowed' };
+    }
+
+    const hostname = parsed.hostname;
+
+    // Check against blocked hostnames
+    if (isBlockedHostname(hostname)) {
+        return { safe: false, error: `Hostname "${hostname}" is blocked` };
+    }
+
+    // Strip IPv6 brackets for IP checks (URL parser returns [::1], net.isIP expects ::1)
+    const bareHostname = stripIPv6Brackets(hostname);
+
+    // If hostname is an IP literal, check it directly
+    if (net.isIP(bareHostname)) {
+        if (isBlockedIP(bareHostname)) {
+            return { safe: false, error: `IP address "${bareHostname}" is in a private/reserved range` };
+        }
+        // IP is public — OK at parse time
+        return { safe: true, error: null };
+    }
+
+    // Hostname is a domain name — resolve it to check the IP
+    try {
+        const address = await new Promise((resolve, reject) => {
+            dns.lookup(hostname, (err, addr) => {
+                if (err) {
+                    reject(err);
+                }
+                else {
+                    resolve(addr);
+                }
+            });
+        });
+
+        if (isBlockedIP(address)) {
+            return { safe: false, error: `Hostname "${hostname}" resolves to private/reserved IP "${address}"` };
+        }
+    }
+    catch (e) {
+        return { safe: false, error: `DNS resolution failed for "${hostname}": ${e.message}` };
+    }
+
+    return { safe: true, error: null };
+}
+
+/**
+ * Build got-compatible request options with SSRF protection baked in.
+ *
+ * Disables redirects to prevent redirect-based SSRF bypasses.
+ *
+ * @param {object} requestOptions - base request options (uri, timeout, headers, etc.)
+ * @returns {object} the same options object with SSRF settings injected
+ */
+function getSsrfSafeOptions(requestOptions) {
+    const options = Object.assign({}, requestOptions);
+
+    // Disable redirects entirely — prevents redirect-based SSRF bypasses
+    options.followRedirect = false;
+
+    return options;
+}
+
+module.exports = {
+    isUrlSafe,
+    getSsrfSafeOptions,
+};

--- a/api/utils/taskmanager.js
+++ b/api/utils/taskmanager.js
@@ -15,6 +15,76 @@ var plugins = require('../../plugins/pluginManager.js');
 const log = require('./log.js')('core:taskmanager');
 
 /**
+ * Authorize a member to act on a long_tasks document.
+ *
+ * A task is operatable only by:
+ *   - global admins,
+ *   - the member who created it (task.creator === member._id),
+ *   - app-admins of the task's app_id (when task.app_id is set).
+ *
+ * The /i/tasks/{update,delete,name,edit} endpoints used to be reachable
+ * by any logged-in user (validateUserForWrite is just validateUser),
+ * which made it possible to rerun, rename, edit, or delete tasks
+ * belonging to other users / apps. rerunTask in particular replays the
+ * original request using the creator's api_key, which is a cross-tenant
+ * privilege escalation.
+ *
+ * @param {object} member - params.member from request context
+ * @param {object} task - long_tasks document
+ * @returns {boolean} true if the member is allowed to operate on this task
+ */
+taskmanager.isAuthorizedFor = function(member, task) {
+    if (!member || !task) {
+        return false;
+    }
+    if (member.global_admin) {
+        return true;
+    }
+    if (task.creator && (task.creator + "") === (member._id + "")) {
+        return true;
+    }
+    if (task.app_id) {
+        try {
+            // Lazy require to avoid a circular dependency: rights.js requires
+            // common.js which is required at the top of this module.
+            var rights = require('./rights.js');
+            if (rights.hasAdminAccess(member, task.app_id + "")) {
+                return true;
+            }
+        }
+        catch (e) {
+            log.e("Failed to load rights.js for task auth check", e);
+        }
+    }
+    return false;
+};
+
+/**
+ * Load a task by id, then call cb(err, task) only if `member` is authorized
+ * for it. If unauthorized, cb is called with err === 'forbidden'.
+ *
+ * @param {object} db - database connection
+ * @param {string} id - task id
+ * @param {object} member - params.member
+ * @param {function} cb - cb(err, task)
+ */
+taskmanager.loadIfAuthorized = function(db, id, member, cb) {
+    db = db || common.db;
+    db.collection("long_tasks").findOne({_id: id}, function(err, task) {
+        if (err) {
+            return cb(err);
+        }
+        if (!task) {
+            return cb('not_found');
+        }
+        if (!taskmanager.isAuthorizedFor(member, task)) {
+            return cb('forbidden');
+        }
+        cb(null, task);
+    });
+};
+
+/**
 * Monitors DB query or some other potentially long task and switches to long task manager if it exceeds threshold
 * @param {object} options - options for the task
 * @param {object} options.db - database connection

--- a/frontend/express/app.js
+++ b/frontend/express/app.js
@@ -477,6 +477,15 @@ Promise.all([plugins.dbConnection(countlyConfig), plugins.dbConnection("countly_
                             res.sendFile(__dirname + '/public/images/default_app_icon.png');
                         }
                         else {
+                            stream.on('error', function(streamErr) {
+                                log.e(streamErr);
+                                if (!res.headersSent) {
+                                    res.sendFile(__dirname + '/public/images/default_app_icon.png');
+                                }
+                                else {
+                                    res.end();
+                                }
+                            });
                             res.writeHead(200, {
                                 'Accept-Ranges': 'bytes',
                                 'Cache-Control': 'public, max-age=31536000',
@@ -516,6 +525,15 @@ Promise.all([plugins.dbConnection(countlyConfig), plugins.dbConnection("countly_
                             res.sendFile(__dirname + '/public/images/default_member_icon.png');
                         }
                         else {
+                            stream.on('error', function(streamErr) {
+                                log.e(streamErr);
+                                if (!res.headersSent) {
+                                    res.sendFile(__dirname + '/public/images/default_member_icon.png');
+                                }
+                                else {
+                                    res.end();
+                                }
+                            });
                             res.writeHead(200, {
                                 'Accept-Ranges': 'bytes',
                                 'Cache-Control': 'public, max-age=31536000',
@@ -547,6 +565,13 @@ Promise.all([plugins.dbConnection(countlyConfig), plugins.dbConnection("countly_
                 if (err2 || !stream) {
                     return res.send(false);
                 }
+                stream.on('error', function(streamErr) {
+                    log.e(streamErr);
+                    if (!res.headersSent) {
+                        return res.send(false);
+                    }
+                    res.end();
+                });
 
                 res.writeHead(200, {
                     'Accept-Ranges': 'bytes',

--- a/frontend/express/app.js
+++ b/frontend/express/app.js
@@ -60,6 +60,25 @@ var versionInfo = require('./version.info'),
     { validateCreate } = require('../../api/utils/rights.js'),
     tracker = require('../../api/parts/mgmt/tracker.js');
 
+/**
+ * Resolve a request path under a static base directory.
+ * @param {string} baseDir - base static directory
+ * @param {string} requestPath - user-supplied request path
+ * @returns {string|null} contained path or null
+ */
+function safeStaticPath(baseDir, requestPath) {
+    baseDir = path.resolve(baseDir);
+    requestPath = (requestPath + "").replace(/\\/g, "/");
+    while (requestPath.indexOf("/") === 0) {
+        requestPath = requestPath.substring(1);
+    }
+    var resolvedPath = path.resolve(baseDir, requestPath);
+    if (resolvedPath === baseDir || resolvedPath.indexOf(baseDir + path.sep) === 0) {
+        return resolvedPath;
+    }
+    return null;
+}
+
 console.log("Starting Countly", "version", versionInfo.version, "package", pack.version);
 
 var COUNTLY_NAMED_TYPE = "Countly Lite v" + COUNTLY_VERSION;
@@ -462,12 +481,17 @@ Promise.all([plugins.dbConnection(countlyConfig), plugins.dbConnection("countly_
             res.sendFile(__dirname + '/public/images/default_app_icon.png');
         }
         else {
-            countlyFs.getStats("appimages", __dirname + '/public/appimages/' + req.params[0], {id: req.params[0]}, function(err, stats) {
+            var appImagePath = safeStaticPath(__dirname + '/public/appimages', req.params[0]);
+            if (!appImagePath) {
+                res.sendFile(__dirname + '/public/images/default_app_icon.png');
+                return;
+            }
+            countlyFs.getStats("appimages", appImagePath, {id: req.params[0]}, function(err, stats) {
                 if (err || !stats || !stats.size) {
                     res.sendFile(__dirname + '/public/images/default_app_icon.png');
                 }
                 else {
-                    countlyFs.getStream("appimages", __dirname + '/public/appimages/' + req.params[0], {id: req.params[0]}, function(err2, stream) {
+                    countlyFs.getStream("appimages", appImagePath, {id: req.params[0]}, function(err2, stream) {
                         if (err2 || !stream) {
                             res.sendFile(__dirname + '/public/images/default_app_icon.png');
                         }
@@ -496,12 +520,17 @@ Promise.all([plugins.dbConnection(countlyConfig), plugins.dbConnection("countly_
             res.sendFile(__dirname + '/public/images/default_member_icon.png');
         }
         else {
-            countlyFs.getStats("memberimages", __dirname + '/public/' + req.path, {id: req.params[0]}, function(err, stats) {
+            var memberImagePath = safeStaticPath(__dirname + '/public/memberimages', req.params[0]);
+            if (!memberImagePath) {
+                res.sendFile(__dirname + '/public/images/default_member_icon.png');
+                return;
+            }
+            countlyFs.getStats("memberimages", memberImagePath, {id: req.params[0]}, function(err, stats) {
                 if (err || !stats || !stats.size) {
                     res.sendFile(__dirname + '/public/images/default_member_icon.png');
                 }
                 else {
-                    countlyFs.getStream("memberimages", __dirname + '/public/' + req.path, {id: req.params[0]}, function(err2, stream) {
+                    countlyFs.getStream("memberimages", memberImagePath, {id: req.params[0]}, function(err2, stream) {
                         if (err2 || !stream) {
                             res.sendFile(__dirname + '/public/images/default_member_icon.png');
                         }
@@ -524,12 +553,16 @@ Promise.all([plugins.dbConnection(countlyConfig), plugins.dbConnection("countly_
     });
 
     app.get(countlyConfig.path + "*/screenshots/*", function(req, res) {
-        countlyFs.getStats("screenshots", __dirname + '/public/' + req.path, {id: "core"}, function(err, stats) {
+        var screenshotPath = safeStaticPath(__dirname + '/public', req.path);
+        if (!screenshotPath) {
+            return res.send(false);
+        }
+        countlyFs.getStats("screenshots", screenshotPath, {id: "core"}, function(err, stats) {
             if (err || !stats || !stats.size) {
                 return res.send(false);
             }
 
-            countlyFs.getStream("screenshots", __dirname + '/public/' + req.path, {id: "core"}, function(err2, stream) {
+            countlyFs.getStream("screenshots", screenshotPath, {id: "core"}, function(err2, stream) {
                 if (err2 || !stream) {
                     return res.send(false);
                 }

--- a/frontend/express/app.js
+++ b/frontend/express/app.js
@@ -1832,7 +1832,10 @@ Promise.all([plugins.dbConnection(countlyConfig), plugins.dbConnection("countly_
     });
 
     app.post(countlyConfig.path + '/users/check/username', function(req, res) {
-        if (!req.session.uid || !req.body.username) {
+        // Symmetric with /users/check/email above: only global admins can
+        // probe whether a username exists. Without this gate any logged-in
+        // user could enumerate dashboard usernames.
+        if (!req.session.uid || !isGlobalAdmin(req) || !req.body.username) {
             res.send(false);
             return false;
         }

--- a/frontend/express/app.js
+++ b/frontend/express/app.js
@@ -60,25 +60,6 @@ var versionInfo = require('./version.info'),
     { validateCreate } = require('../../api/utils/rights.js'),
     tracker = require('../../api/parts/mgmt/tracker.js');
 
-/**
- * Resolve a request path under a static base directory.
- * @param {string} baseDir - base static directory
- * @param {string} requestPath - user-supplied request path
- * @returns {string|null} contained path or null
- */
-function safeStaticPath(baseDir, requestPath) {
-    baseDir = path.resolve(baseDir);
-    requestPath = (requestPath + "").replace(/\\/g, "/");
-    while (requestPath.indexOf("/") === 0) {
-        requestPath = requestPath.substring(1);
-    }
-    var resolvedPath = path.resolve(baseDir, requestPath);
-    if (resolvedPath === baseDir || resolvedPath.indexOf(baseDir + path.sep) === 0) {
-        return resolvedPath;
-    }
-    return null;
-}
-
 console.log("Starting Countly", "version", versionInfo.version, "package", pack.version);
 
 var COUNTLY_NAMED_TYPE = "Countly Lite v" + COUNTLY_VERSION;
@@ -481,7 +462,7 @@ Promise.all([plugins.dbConnection(countlyConfig), plugins.dbConnection("countly_
             res.sendFile(__dirname + '/public/images/default_app_icon.png');
         }
         else {
-            var appImagePath = safeStaticPath(__dirname + '/public/appimages', req.params[0]);
+            var appImagePath = common.resolvePathInBase(__dirname + '/public/appimages', req.params[0]);
             if (!appImagePath) {
                 res.sendFile(__dirname + '/public/images/default_app_icon.png');
                 return;
@@ -520,7 +501,7 @@ Promise.all([plugins.dbConnection(countlyConfig), plugins.dbConnection("countly_
             res.sendFile(__dirname + '/public/images/default_member_icon.png');
         }
         else {
-            var memberImagePath = safeStaticPath(__dirname + '/public/memberimages', req.params[0]);
+            var memberImagePath = common.resolvePathInBase(__dirname + '/public/memberimages', req.params[0]);
             if (!memberImagePath) {
                 res.sendFile(__dirname + '/public/images/default_member_icon.png');
                 return;
@@ -553,7 +534,7 @@ Promise.all([plugins.dbConnection(countlyConfig), plugins.dbConnection("countly_
     });
 
     app.get(countlyConfig.path + "*/screenshots/*", function(req, res) {
-        var screenshotPath = safeStaticPath(__dirname + '/public', req.path);
+        var screenshotPath = common.resolvePathInBase(__dirname + '/public', req.path);
         if (!screenshotPath) {
             return res.send(false);
         }

--- a/frontend/express/app.js
+++ b/frontend/express/app.js
@@ -493,7 +493,8 @@ Promise.all([plugins.dbConnection(countlyConfig), plugins.dbConnection("countly_
                                 'Date': new Date().toUTCString(),
                                 'Last-Modified': stats.mtime.toUTCString(),
                                 'Content-Type': 'image/png',
-                                'Content-Length': stats.size
+                                'Content-Length': stats.size,
+                                'X-Content-Type-Options': 'nosniff'
                             });
                             stream.pipe(res);
                         }
@@ -541,7 +542,8 @@ Promise.all([plugins.dbConnection(countlyConfig), plugins.dbConnection("countly_
                                 'Date': new Date().toUTCString(),
                                 'Last-Modified': stats.mtime.toUTCString(),
                                 'Content-Type': 'image/png',
-                                'Content-Length': stats.size
+                                'Content-Length': stats.size,
+                                'X-Content-Type-Options': 'nosniff'
                             });
                             stream.pipe(res);
                         }
@@ -580,7 +582,8 @@ Promise.all([plugins.dbConnection(countlyConfig), plugins.dbConnection("countly_
                     'Date': new Date().toUTCString(),
                     'Last-Modified': stats.mtime.toUTCString(),
                     'Content-Type': 'image/png',
-                    'Content-Length': stats.size
+                    'Content-Length': stats.size,
+                    'X-Content-Type-Options': 'nosniff'
                 });
                 stream.pipe(res);
             });

--- a/frontend/express/libs/members.js
+++ b/frontend/express/libs/members.js
@@ -487,6 +487,20 @@ membersUtility.loginWithToken = function(req, callback) {
                 return callback(undefined);
             }
 
+            // Only allow tokens whose purpose is explicitly "log this member in".
+            //   - "LoggedInAuth"   — legitimate session tokens (set by setLoggedInVariables;
+            //                        mail.sendTimeBanWarning).
+            //   - "LoginAuthToken" — short-lived (TTL=300, multi:false) tokens used by the
+            //                        server-side Puppeteer renderer to authenticate the
+            //                        headless Chrome session at /login/token/:token.
+            // Any other purpose — including arbitrary purposes settable via /i/token/create
+            // by a global admin — MUST NOT be redeemable here.
+            var allowedLoginPurposes = ["LoggedInAuth", "LoginAuthToken"];
+            if (allowedLoginPurposes.indexOf(valid.purpose) === -1) {
+                plugins.callMethod("tokenLoginFailed", {req: req, data: {token: token, token_owner: valid.owner, reason: "wrong_purpose"}});
+                return callback(undefined);
+            }
+
             membersUtility.db.collection('members').findOne({"_id": membersUtility.db.ObjectID(valid.owner)}, function(err, member) {
                 if (err || !member) {
                     plugins.callMethod("tokenLoginFailed", {req: req, data: {token: token, token_owner: valid.owner}});
@@ -495,12 +509,20 @@ membersUtility.loginWithToken = function(req, callback) {
                 else {
                     plugins.callMethod("tokenLoginSuccessful", {req: req, data: {username: member.username}});
 
-                    if (valid.temporary) {
-                        req.session.temporary_token = true;
-                    }
-                    setLoggedInVariables(req, member, membersUtility.db, function() {
-                        req.session.settings = member.settings;
-                        callback(member);
+                    // Regenerate the session id before binding the new identity to it.
+                    // Without this, an attacker who knows a valid token can fixate the
+                    // victim's session id by getting them to GET /login/token/:token —
+                    // the victim's pre-attack session id then becomes the authenticated
+                    // session. The password login flow above (line ~329) already does
+                    // this; the token flow was missing it.
+                    req.session.regenerate(function() {
+                        if (valid.temporary) {
+                            req.session.temporary_token = true;
+                        }
+                        setLoggedInVariables(req, member, membersUtility.db, function() {
+                            req.session.settings = member.settings;
+                            callback(member);
+                        });
                     });
                 }
             });

--- a/frontend/express/libs/members.js
+++ b/frontend/express/libs/members.js
@@ -515,7 +515,17 @@ membersUtility.loginWithToken = function(req, callback) {
                     // the victim's pre-attack session id then becomes the authenticated
                     // session. The password login flow above (line ~329) already does
                     // this; the token flow was missing it.
-                    req.session.regenerate(function() {
+                    //
+                    // If regenerate fails (e.g. session store error), abort the login
+                    // rather than fall through to setLoggedInVariables on the existing
+                    // (pre-auth) session id — silently continuing would re-introduce
+                    // the fixation primitive this commit closes.
+                    req.session.regenerate(function(regenErr) {
+                        if (regenErr) {
+                            console.log("Session regenerate failed during token login", regenErr);
+                            plugins.callMethod("tokenLoginFailed", {req: req, data: {token: token, token_owner: valid.owner, reason: "session_regenerate_failed"}});
+                            return callback(undefined);
+                        }
                         if (valid.temporary) {
                             req.session.temporary_token = true;
                         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "grunt-contrib-uglify": "5.2.2",
         "hpagent": "^1.2.0",
         "icanhazip": "^1.0.3",
+        "ipaddr.js": "^2.3.0",
         "jimp": "1.6.0",
         "json2csv": "5.0.7",
         "jsonwebtoken": "^9.0.1",
@@ -7834,12 +7835,12 @@
       }
     },
     "node_modules/ipaddr.js": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
+      "integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.10"
+        "node": ">= 10"
       }
     },
     "node_modules/is-absolute": {
@@ -10873,6 +10874,15 @@
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
       },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-addr/node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.10"
       }

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "grunt-contrib-uglify": "5.2.2",
     "hpagent": "^1.2.0",
     "icanhazip": "^1.0.3",
+    "ipaddr.js": "^2.3.0",
     "jimp": "1.6.0",
     "json2csv": "5.0.7",
     "jsonwebtoken": "^9.0.1",

--- a/plugins/alerts/api/api.js
+++ b/plugins/alerts/api/api.js
@@ -5,7 +5,7 @@ var Promise = require("bluebird");
 const JOB = require('../../../api/parts/jobs');
 const utils = require('./parts/utils.js');
 const _ = require('lodash');
-const { validateCreate, validateRead, validateUpdate } = require('../../../api/utils/rights.js');
+const { validateCreate, validateRead, validateUpdate, hasCreateRight } = require('../../../api/utils/rights.js');
 const FEATURE_NAME = 'alerts';
 const commonLib = require("./parts/common-lib.js");
 const moment = require('moment-timezone');
@@ -214,6 +214,22 @@ function getScheduleTextExpression(period, offset) {
                 if (!(common.validateArgs(alertConfig, checkProps))) {
                     common.returnMessage(params, 200, 'Not enough args');
                     return true;
+                }
+
+                // Cross-app guard: every entry of selectedApps must be an
+                // app the caller is allowed to create alerts on. Without
+                // this, a user with alerts:create on app A could submit
+                // selectedApps=[B] and have the alert evaluator emit B's
+                // metric values to attacker-controlled emails listed in
+                // alertValues.
+                if (Array.isArray(alertConfig.selectedApps) && alertConfig.selectedApps.length > 0 && !params.member.global_admin) {
+                    var unauthorized = alertConfig.selectedApps.filter(function(aid) {
+                        return !hasCreateRight(FEATURE_NAME, aid + "", params.member);
+                    });
+                    if (unauthorized.length > 0) {
+                        common.returnMessage(params, 403, 'No alerts:create permission on apps: ' + unauthorized.join(', '));
+                        return true;
+                    }
                 }
                 if (alertConfig._id) {
                     const id = alertConfig._id;

--- a/plugins/compliance-hub/api/api.js
+++ b/plugins/compliance-hub/api/api.js
@@ -148,6 +148,11 @@ const FEATURE_NAME = 'compliance_hub';
                         query = {};
                     }
                 }
+                common.stripUnsafeMongoOperators(query);
+                // Force scope to the request's app_id even though this lookup
+                // is in app_users<app_id>; defense-in-depth in case a future
+                // refactor changes the collection.
+                query.app_id = params.app_id.toString();
                 common.db.collection("app_users" + params.qstring.app_id).findOne(query, function(err, res) {
                     common.returnOutput(params, res?.consent || {});
                 });
@@ -169,6 +174,7 @@ const FEATURE_NAME = 'compliance_hub';
                         query = {};
                     }
                 }
+                common.stripUnsafeMongoOperators(query);
                 query.app_id = params.app_id.toString();
                 common.db.collection("consent_history").countDocuments(query, function(err, total) {
                     if (err) {
@@ -187,6 +193,7 @@ const FEATURE_NAME = 'compliance_hub';
                                 params.qstring.query = {};
                             }
                         }
+                        common.stripUnsafeMongoOperators(params.qstring.query);
 
                         if (params.qstring.sSearch && params.qstring.sSearch !== "") {
                             try {

--- a/plugins/crashes/api/api.js
+++ b/plugins/crashes/api/api.js
@@ -1253,6 +1253,15 @@ plugins.setConfigs("crashes", {
                             'Content-Disposition': "attachment;filename=" + encodeURIComponent(params.qstring.crash_id) + "_bin.dmp"
                         });
                         let stream = new Duplex();
+                        stream.on("error", function(streamErr) {
+                            log.e(streamErr);
+                            if (!params.res.headersSent) {
+                                common.returnMessage(params, 500, "Binary stream error");
+                            }
+                            else {
+                                params.res.end();
+                            }
+                        });
                         stream.push(buf);
                         stream.push(null);
                         stream.pipe(params.res);

--- a/plugins/crashes/api/api.js
+++ b/plugins/crashes/api/api.js
@@ -1247,11 +1247,9 @@ plugins.setConfigs("crashes", {
                     }
                     if (params.res.writeHead) {
                         var buf = Buffer.from(crash.binary_crash_dump, 'base64');
-                        params.res.writeHead(200, {
-                            'Content-Type': 'application/octet-stream',
-                            'Content-Length': buf.byteLength,
-                            'Content-Disposition': "attachment;filename=" + encodeURIComponent(params.qstring.crash_id) + "_bin.dmp"
-                        });
+                        // Construct the stream and attach the error handler
+                        // BEFORE writeHead so the !headersSent branch is
+                        // reachable for errors that fire before piping.
                         let stream = new Duplex();
                         stream.on("error", function(streamErr) {
                             log.e(streamErr);
@@ -1261,6 +1259,11 @@ plugins.setConfigs("crashes", {
                             else {
                                 params.res.end();
                             }
+                        });
+                        params.res.writeHead(200, {
+                            'Content-Type': 'application/octet-stream',
+                            'Content-Length': buf.byteLength,
+                            'Content-Disposition': "attachment;filename=" + encodeURIComponent(params.qstring.crash_id) + "_bin.dmp"
                         });
                         stream.push(buf);
                         stream.push(null);

--- a/plugins/dashboards/api/api.js
+++ b/plugins/dashboards/api/api.js
@@ -353,18 +353,52 @@ plugins.setConfigs("dashboards", {
     });
 
     plugins.register("/o/dashboards/test", function(ob) {
-        var params = ob.params,
-            widgets = [];
+        var params = ob.params;
 
-        try {
-            widgets = JSON.parse(params.qstring.widgets);
-        }
-        catch (ex) {
-            //Error
-        }
+        validateUser(params, function() {
+            var widgets = [];
+            try {
+                widgets = JSON.parse(params.qstring.widgets);
+            }
+            catch (ex) {
+                //Error
+            }
 
-        customDashboards.fetchAllWidgetsData(params, widgets, function(data) {
-            common.returnOutput(params, data);
+            if (!Array.isArray(widgets)) {
+                widgets = [];
+            }
+
+            // Reject widgets referencing apps the requesting user does not have
+            // access to. Without this, the endpoint (which previously had no
+            // auth at all) could be used to read analytics from arbitrary apps.
+            var allowed = {};
+            if (params.member && params.member.global_admin) {
+                // Global admins skip the per-app restriction below.
+                allowed = null;
+            }
+            else if (params.member) {
+                var userApps = getUserApps(params.member) || [];
+                for (var i = 0; i < userApps.length; i++) {
+                    allowed[userApps[i] + ""] = true;
+                }
+            }
+
+            if (allowed) {
+                for (var w = 0; w < widgets.length; w++) {
+                    if (Array.isArray(widgets[w].apps)) {
+                        widgets[w].apps = widgets[w].apps.filter(function(a) {
+                            return allowed[a + ""];
+                        });
+                    }
+                    else {
+                        widgets[w].apps = [];
+                    }
+                }
+            }
+
+            customDashboards.fetchAllWidgetsData(params, widgets, function(data) {
+                common.returnOutput(params, data);
+            });
         });
 
         return true;

--- a/plugins/dashboards/api/api.js
+++ b/plugins/dashboards/api/api.js
@@ -354,58 +354,6 @@ plugins.setConfigs("dashboards", {
         return true;
     });
 
-    plugins.register("/o/dashboards/test", function(ob) {
-        var params = ob.params;
-
-        validateUser(params, function() {
-            var widgets = [];
-            try {
-                widgets = JSON.parse(params.qstring.widgets);
-            }
-            catch (ex) {
-                //Error
-            }
-
-            if (!Array.isArray(widgets)) {
-                widgets = [];
-            }
-
-            // Reject widgets referencing apps the requesting user does not have
-            // access to. Without this, the endpoint (which previously had no
-            // auth at all) could be used to read analytics from arbitrary apps.
-            var allowed = {};
-            if (params.member && params.member.global_admin) {
-                // Global admins skip the per-app restriction below.
-                allowed = null;
-            }
-            else if (params.member) {
-                var userApps = getUserApps(params.member) || [];
-                for (var i = 0; i < userApps.length; i++) {
-                    allowed[userApps[i] + ""] = true;
-                }
-            }
-
-            if (allowed) {
-                for (var w = 0; w < widgets.length; w++) {
-                    if (Array.isArray(widgets[w].apps)) {
-                        widgets[w].apps = widgets[w].apps.filter(function(a) {
-                            return allowed[a + ""];
-                        });
-                    }
-                    else {
-                        widgets[w].apps = [];
-                    }
-                }
-            }
-
-            customDashboards.fetchAllWidgetsData(params, widgets, function(data) {
-                common.returnOutput(params, data);
-            });
-        });
-
-        return true;
-    });
-
     /**
      * @api {get} /o/dashboards/all Get all dashboards
      * @apiName GetAllDashboards

--- a/plugins/dashboards/api/api.js
+++ b/plugins/dashboards/api/api.js
@@ -121,7 +121,14 @@ plugins.setConfigs("dashboards", {
                     memberId = member._id + "";
 
                 common.db.collection("dashboards").findOne({_id: common.db.ObjectID(dashboardId)}, function(err, dashboard) {
-                    if (!err && dashboard) {
+                    if (err || !dashboard) {
+                        // Return the same response shape as the access-denied
+                        // branch below so an attacker can't distinguish
+                        // "exists but no access" from "doesn't exist".
+                        // Without this, dashboard IDs were enumerable.
+                        return common.returnOutput(params, {error: true, dashboard_access_denied: true});
+                    }
+                    {
                         async.parallel([
                             hasViewAccessToDashboard.bind(null, params.member, dashboard),
                             hasEditAccessToDashboard.bind(null, params.member, dashboard),
@@ -197,9 +204,6 @@ plugins.setConfigs("dashboards", {
                                 common.returnOutput(params, output);
                             });
                         });
-                    }
-                    else {
-                        common.returnMessage(params, 404, "Dashboard does not exist");
                     }
 
                     /**

--- a/plugins/dashboards/api/api.js
+++ b/plugins/dashboards/api/api.js
@@ -128,83 +128,81 @@ plugins.setConfigs("dashboards", {
                         // Without this, dashboard IDs were enumerable.
                         return common.returnOutput(params, {error: true, dashboard_access_denied: true});
                     }
-                    {
-                        async.parallel([
-                            hasViewAccessToDashboard.bind(null, params.member, dashboard),
-                            hasEditAccessToDashboard.bind(null, params.member, dashboard),
-                            fetchMembersData.bind(null, [dashboard.owner_id], [])
-                        ], function(er, res) {
-                            var hasViewAccess = res[0];
-                            var hasEditAccess = res[1];
-                            var ownerData = res[2];
+                    async.parallel([
+                        hasViewAccessToDashboard.bind(null, params.member, dashboard),
+                        hasEditAccessToDashboard.bind(null, params.member, dashboard),
+                        fetchMembersData.bind(null, [dashboard.owner_id], [])
+                    ], function(er, res) {
+                        var hasViewAccess = res[0];
+                        var hasEditAccess = res[1];
+                        var ownerData = res[2];
 
-                            if (er || !hasViewAccess) {
-                                return common.returnOutput(params, {error: true, dashboard_access_denied: true});
-                            }
+                        if (er || !hasViewAccess) {
+                            return common.returnOutput(params, {error: true, dashboard_access_denied: true});
+                        }
 
-                            if (dashboard.owner_id === memberId || member.global_admin) {
-                                dashboard.is_owner = true;
-                            }
+                        if (dashboard.owner_id === memberId || member.global_admin) {
+                            dashboard.is_owner = true;
+                        }
 
-                            if (hasEditAccess) {
-                                dashboard.is_editable = true;
-                            }
-                            else {
-                                dashboard.is_editable = false;
-                            }
+                        if (hasEditAccess) {
+                            dashboard.is_editable = true;
+                        }
+                        else {
+                            dashboard.is_editable = false;
+                        }
 
-                            if (ownerData && ownerData.length) {
-                                dashboard.owner = ownerData[0];
-                            }
+                        if (ownerData && ownerData.length) {
+                            dashboard.owner = ownerData[0];
+                        }
 
-                            var parallelTasks = [
-                                fetchDashboardWidgets.bind(null)
-                            ];
+                        var parallelTasks = [
+                            fetchDashboardWidgets.bind(null)
+                        ];
 
-                            if (!dashboard.share_with) {
-                                if (dashboard.shared_with_edit && dashboard.shared_with_edit.length ||
-                                    dashboard.shared_with_view && dashboard.shared_with_view.length ||
-                                    dashboard.shared_email_edit && dashboard.shared_email_edit.length ||
-                                    dashboard.shared_email_view && dashboard.shared_email_view.length ||
-                                    dashboard.shared_user_groups_edit && dashboard.shared_user_groups_edit.length ||
-                                    dashboard.shared_user_groups_view && dashboard.shared_user_groups_view.length) {
-                                    dashboard.share_with = "selected-users";
-                                }
-                                else {
-                                    dashboard.share_with = "none";
-                                }
-                            }
-
-                            if (dashboard.refreshRate) {
-                                dashboard.refreshRate = dashboard.refreshRate / 60; //Convert to minutes
-                                dashboard.use_refresh_rate = true;
-                            }
-
-                            if (canSeeDashboardShares(params.member, dashboard)) {
-                                parallelTasks.push(fetchSharedUsersInfo.bind(null, dashboard));
+                        if (!dashboard.share_with) {
+                            if (dashboard.shared_with_edit && dashboard.shared_with_edit.length ||
+                                dashboard.shared_with_view && dashboard.shared_with_view.length ||
+                                dashboard.shared_email_edit && dashboard.shared_email_edit.length ||
+                                dashboard.shared_email_view && dashboard.shared_email_view.length ||
+                                dashboard.shared_user_groups_edit && dashboard.shared_user_groups_edit.length ||
+                                dashboard.shared_user_groups_view && dashboard.shared_user_groups_view.length) {
+                                dashboard.share_with = "selected-users";
                             }
                             else {
-                                delete dashboard.shared_with_edit;
-                                delete dashboard.shared_with_view;
-                                delete dashboard.shared_email_view;
-                                delete dashboard.shared_email_edit;
-                                delete dashboard.shared_user_groups_edit;
-                                delete dashboard.shared_user_groups_view;
+                                dashboard.share_with = "none";
+                            }
+                        }
+
+                        if (dashboard.refreshRate) {
+                            dashboard.refreshRate = dashboard.refreshRate / 60; //Convert to minutes
+                            dashboard.use_refresh_rate = true;
+                        }
+
+                        if (canSeeDashboardShares(params.member, dashboard)) {
+                            parallelTasks.push(fetchSharedUsersInfo.bind(null, dashboard));
+                        }
+                        else {
+                            delete dashboard.shared_with_edit;
+                            delete dashboard.shared_with_view;
+                            delete dashboard.shared_email_view;
+                            delete dashboard.shared_email_edit;
+                            delete dashboard.shared_user_groups_edit;
+                            delete dashboard.shared_user_groups_view;
+                        }
+
+                        async.parallel(parallelTasks, function(error, result) {
+                            if (error) {
+                                common.returnMessage(params, 401, 'Error while fetching dashboard widget data.');
+                                return true;
                             }
 
-                            async.parallel(parallelTasks, function(error, result) {
-                                if (error) {
-                                    common.returnMessage(params, 401, 'Error while fetching dashboard widget data.');
-                                    return true;
-                                }
+                            var output = dashboard;
+                            output = Object.assign(output, result[0]);
 
-                                var output = dashboard;
-                                output = Object.assign(output, result[0]);
-
-                                common.returnOutput(params, output);
-                            });
+                            common.returnOutput(params, output);
                         });
-                    }
+                    });
 
                     /**
                      * Function to fetch dashboard widgets

--- a/plugins/dashboards/frontend/app.js
+++ b/plugins/dashboards/frontend/app.js
@@ -52,7 +52,8 @@ var log = common.log('dashboards:frontend');
                         'Date': new Date().toUTCString(),
                         'Last-Modified': stats.mtime.toUTCString(),
                         'Content-Type': 'image/png',
-                        'Content-Length': stats.size
+                        'Content-Length': stats.size,
+                        'X-Content-Type-Options': 'nosniff'
                     });
                     stream.pipe(res);
                 });

--- a/plugins/dashboards/frontend/app.js
+++ b/plugins/dashboards/frontend/app.js
@@ -4,6 +4,7 @@ var countlyConfig = require('../../../frontend/express/config', 'dont-enclose');
 var countlyFs = require('../../../api/utils/countlyFs.js');
 var common = require('../../../api/utils/common.js');
 var path = require('path');
+var log = common.log('dashboards:frontend');
 
 (function(plugin) {
     plugin.init = function(/*app, countlyDb*/) {
@@ -36,6 +37,13 @@ var path = require('path');
                     if (err2 || !stream) {
                         return res.send(false);
                     }
+                    stream.on('error', function(streamErr) {
+                        log.e(streamErr);
+                        if (!res.headersSent) {
+                            return res.send(false);
+                        }
+                        res.end();
+                    });
 
                     res.writeHead(200, {
                         'Accept-Ranges': 'bytes',

--- a/plugins/dashboards/frontend/app.js
+++ b/plugins/dashboards/frontend/app.js
@@ -2,6 +2,26 @@ var plugins = require('../../pluginManager.js');
 var exported = {};
 var countlyConfig = require('../../../frontend/express/config', 'dont-enclose');
 var countlyFs = require('../../../api/utils/countlyFs.js');
+var path = require('path');
+
+/**
+ * Resolve a request path under a static base directory.
+ * @param {string} baseDir - base static directory
+ * @param {string} requestPath - user-supplied request path
+ * @returns {string|null} contained path or null
+ */
+function safeStaticPath(baseDir, requestPath) {
+    baseDir = path.resolve(baseDir);
+    requestPath = (requestPath + "").replace(/\\/g, "/");
+    while (requestPath.indexOf("/") === 0) {
+        requestPath = requestPath.substring(1);
+    }
+    var resolvedPath = path.resolve(baseDir, requestPath);
+    if (resolvedPath === baseDir || resolvedPath.indexOf(baseDir + path.sep) === 0) {
+        return resolvedPath;
+    }
+    return null;
+}
 
 (function(plugin) {
     plugin.init = function(/*app, countlyDb*/) {
@@ -14,20 +34,23 @@ var countlyFs = require('../../../api/utils/countlyFs.js');
 
     plugin.staticPaths = function(app/*, countlyDb*/) {
         app.get(countlyConfig.path + "/dashboards/images/screenshots/*", function(req, res) {
-            var requestPath = req.path;
-            var reqArray = requestPath.split("/");
-            var fileName = "";
-            if (reqArray && reqArray.length) {
-                reqArray[0] += "/frontend/public";
-                fileName = reqArray[reqArray.length - 1];
+            if (!req || !req.params) {
+                return res.send(false);
             }
-            requestPath = reqArray.join("/");
-            countlyFs.getStats("screenshots", __dirname + '/../../../plugins/' + requestPath, {id: "dashboards/" + fileName}, function(err, stats) {
+            var fileName = "";
+            if (req.params && req.params[0]) {
+                fileName = req.params[0];
+            }
+            var requestPath = safeStaticPath(__dirname + '/public/images/screenshots', fileName);
+            if (!requestPath) {
+                return res.send(false);
+            }
+            countlyFs.getStats("screenshots", requestPath, {id: "dashboards/" + fileName}, function(err, stats) {
                 if (err || !stats || !stats.size) {
                     return res.send(false);
                 }
 
-                countlyFs.getStream("screenshots", __dirname + '/../../../plugins/' + requestPath, {id: "dashboards/" + fileName}, function(err2, stream) {
+                countlyFs.getStream("screenshots", requestPath, {id: "dashboards/" + fileName}, function(err2, stream) {
                     if (err2 || !stream) {
                         return res.send(false);
                     }

--- a/plugins/dashboards/frontend/app.js
+++ b/plugins/dashboards/frontend/app.js
@@ -2,26 +2,8 @@ var plugins = require('../../pluginManager.js');
 var exported = {};
 var countlyConfig = require('../../../frontend/express/config', 'dont-enclose');
 var countlyFs = require('../../../api/utils/countlyFs.js');
+var common = require('../../../api/utils/common.js');
 var path = require('path');
-
-/**
- * Resolve a request path under a static base directory.
- * @param {string} baseDir - base static directory
- * @param {string} requestPath - user-supplied request path
- * @returns {string|null} contained path or null
- */
-function safeStaticPath(baseDir, requestPath) {
-    baseDir = path.resolve(baseDir);
-    requestPath = (requestPath + "").replace(/\\/g, "/");
-    while (requestPath.indexOf("/") === 0) {
-        requestPath = requestPath.substring(1);
-    }
-    var resolvedPath = path.resolve(baseDir, requestPath);
-    if (resolvedPath === baseDir || resolvedPath.indexOf(baseDir + path.sep) === 0) {
-        return resolvedPath;
-    }
-    return null;
-}
 
 (function(plugin) {
     plugin.init = function(/*app, countlyDb*/) {
@@ -41,7 +23,7 @@ function safeStaticPath(baseDir, requestPath) {
             if (req.params && req.params[0]) {
                 fileName = req.params[0];
             }
-            var requestPath = safeStaticPath(__dirname + '/public/images/screenshots', fileName);
+            var requestPath = common.resolvePathInBase(path.resolve(__dirname, './public/images/screenshots'), fileName);
             if (!requestPath) {
                 return res.send(false);
             }

--- a/plugins/data_migration/api/api.js
+++ b/plugins/data_migration/api/api.js
@@ -237,9 +237,19 @@ function trim_ending_slashes(address) {
                 data_migrator.import_data(params.files.import_file, params, logpath, log, foldername);
             }
             else if (params.qstring.existing_file) {
+                var importBasePath = path.resolve(__dirname, './../import');
+                var existingFileInput = (params.qstring.existing_file + "").trim();
+                var resolvedExistingFilePath = null;
 
-                if (fs.existsSync(params.qstring.existing_file)) {
-                    var fname = path.basename(params.qstring.existing_file);//path to file
+                if (safeDataMigrationId(existingFileInput)) {
+                    resolvedExistingFilePath = common.resolvePathInBase(importBasePath, existingFileInput + '.tar.gz');
+                }
+                else if (existingFileInput.endsWith('.tar.gz') && common.sanitizeFilename(existingFileInput) === existingFileInput) {
+                    resolvedExistingFilePath = common.resolvePathInBase(importBasePath, existingFileInput);
+                }
+
+                if (resolvedExistingFilePath && fs.existsSync(resolvedExistingFilePath)) {
+                    var fname = path.basename(resolvedExistingFilePath);//path to file
                     fname = fname.split(".");
                     foldername = fname[0];
 
@@ -250,7 +260,7 @@ function trim_ending_slashes(address) {
                         logpath = path.resolve(__dirname, '../../../log/dm-import_' + foldername + '.log');
                         common.returnMessage(params, 200, "data-migration.import-started");
                         data_migrator = new migration_helper();
-                        data_migrator.importExistingData(params.qstring.existing_file, params, logpath, log, foldername);
+                        data_migrator.importExistingData(resolvedExistingFilePath, params, logpath, log, foldername);
                     }
                 }
                 else {

--- a/plugins/data_migration/api/api.js
+++ b/plugins/data_migration/api/api.js
@@ -22,6 +22,39 @@ var authorize = require('../../../api/utils/authorizer.js'); //for token
 
 const request = require('countly-request')(plugins.getConfig("security"));
 const FEATURE_NAME = 'data_migration';
+
+/**
+ * Validate a data migration id before using it as a path segment.
+ * @param {string} exportid - export or import id
+ * @returns {string|null} safe id or null
+ */
+function safeDataMigrationId(exportid) {
+    exportid = exportid + "";
+    if (exportid && common.sanitizeFilename(exportid) === exportid) {
+        return exportid;
+    }
+    return null;
+}
+
+/**
+ * Resolve a filename under a base path after filename validation.
+ * @param {string} basePath - base directory
+ * @param {string} filename - filename to resolve under base directory
+ * @returns {string|null} contained path or null
+ */
+function safePathIn(basePath, filename) {
+    filename = filename + "";
+    if (!filename || common.sanitizeFilename(filename) !== filename) {
+        return null;
+    }
+    basePath = path.resolve(basePath);
+    var resolvedPath = path.resolve(basePath, filename);
+    if (resolvedPath.indexOf(basePath + path.sep) === 0) {
+        return resolvedPath;
+    }
+    return null;
+}
+
 /**
 *Function to delete all exported files in export folder
 * @returns {Promise} Promise
@@ -295,7 +328,12 @@ function trim_ending_slashes(address) {
         }
         validateDelete(params, FEATURE_NAME, function() {
             if (params.qstring.exportid) {
-                common.db.collection("data_migrations").findOne({_id: params.qstring.exportid}, function(err, res) {
+                var exportid = safeDataMigrationId(params.qstring.exportid);
+                if (!exportid) {
+                    common.returnMessage(ob.params, 400, "data-migration.invalid-exportid");
+                    return;
+                }
+                common.db.collection("data_migrations").findOne({_id: exportid}, function(err, res) {
                     if (err) {
                         common.returnMessage(params, 404, err);
                     }
@@ -303,17 +341,22 @@ function trim_ending_slashes(address) {
                         if (res) {
                             var data_migrator = new migration_helper(common.db);
 
-                            data_migrator.clean_up_data('export', params.qstring.exportid, true).then(function() {
-                                if (fs.existsSync(path.resolve(__dirname, './../../../log/' + res.log))) {
+                            data_migrator.clean_up_data('export', exportid, true).then(function() {
+                                var logPath = res.log ? safePathIn(path.resolve(__dirname, './../../../log'), res.log) : null;
+                                if (res.log && !logPath) {
+                                    common.returnMessage(ob.params, 401, "data-migration.unable-to-delete-log-file");
+                                    return;
+                                }
+                                if (logPath && fs.existsSync(logPath)) {
                                     try {
-                                        fs.unlinkSync(path.resolve(__dirname, './../../../log/' + res.log));
+                                        fs.unlinkSync(logPath);
                                     }
                                     catch (err1) {
                                         log.e(err1);
                                         common.returnMessage(ob.params, 401, "data-migration.unable-to-delete-log-file"); return;
                                     }
                                 }
-                                common.db.collection("data_migrations").remove({_id: params.qstring.exportid}, function(err1) {
+                                common.db.collection("data_migrations").remove({_id: exportid}, function(err1) {
                                     if (err1) {
                                         common.returnMessage(params, 404, err1);
                                     }
@@ -354,12 +397,18 @@ function trim_ending_slashes(address) {
         }
         validateDelete(params, FEATURE_NAME, function() {
             if (params.qstring.exportid && params.qstring.exportid !== '') {
+                var exportid = safeDataMigrationId(params.qstring.exportid);
+                if (!exportid) {
+                    common.returnMessage(ob.params, 400, 'data-migration.invalid-exportid');
+                    return;
+                }
                 var data_migrator = new migration_helper(common.db);
-                data_migrator.clean_up_data('import', params.qstring.exportid, true).then(function() {
+                data_migrator.clean_up_data('import', exportid, true).then(function() {
                     //delete log file
-                    if (fs.existsSync(path.resolve(__dirname, './../../../log/dm-import_' + params.qstring.exportid + '.log'))) {
+                    var importLogPath = safePathIn(path.resolve(__dirname, './../../../log'), 'dm-import_' + exportid + '.log');
+                    if (importLogPath && fs.existsSync(importLogPath)) {
                         try {
-                            fs.unlinkSync(path.resolve(__dirname, './../../../log/dm-import_' + params.qstring.exportid + '.log'));
+                            fs.unlinkSync(importLogPath);
                         }
                         catch (err) {
                             log.e(err);
@@ -367,7 +416,10 @@ function trim_ending_slashes(address) {
                     }
                     //delete info file
                     try {
-                        fs.unlinkSync(path.resolve(__dirname, './../import/' + params.qstring.exportid + '.json'));
+                        var importInfoPath = safePathIn(path.resolve(__dirname, './../import'), exportid + '.json');
+                        if (importInfoPath) {
+                            fs.unlinkSync(importInfoPath);
+                        }
                     }
                     catch (err) {
                         log.e(err);

--- a/plugins/data_migration/api/api.js
+++ b/plugins/data_migration/api/api.js
@@ -411,7 +411,7 @@ function trim_ending_slashes(address) {
                     //delete info file
                     try {
                         var importInfoPath = common.resolvePathInBase(path.resolve(__dirname, './../import'), exportid + '.json');
-                        if (importInfoPath) {
+                        if (importInfoPath && fs.existsSync(importInfoPath)) {
                             fs.unlinkSync(importInfoPath);
                         }
                     }

--- a/plugins/data_migration/api/api.js
+++ b/plugins/data_migration/api/api.js
@@ -37,25 +37,6 @@ function safeDataMigrationId(exportid) {
 }
 
 /**
- * Resolve a filename under a base path after filename validation.
- * @param {string} basePath - base directory
- * @param {string} filename - filename to resolve under base directory
- * @returns {string|null} contained path or null
- */
-function safePathIn(basePath, filename) {
-    filename = filename + "";
-    if (!filename || common.sanitizeFilename(filename) !== filename) {
-        return null;
-    }
-    basePath = path.resolve(basePath);
-    var resolvedPath = path.resolve(basePath, filename);
-    if (resolvedPath.indexOf(basePath + path.sep) === 0) {
-        return resolvedPath;
-    }
-    return null;
-}
-
-/**
 *Function to delete all exported files in export folder
 * @returns {Promise} Promise
 */
@@ -342,7 +323,10 @@ function trim_ending_slashes(address) {
                             var data_migrator = new migration_helper(common.db);
 
                             data_migrator.clean_up_data('export', exportid, true).then(function() {
-                                var logPath = res.log ? safePathIn(path.resolve(__dirname, './../../../log'), res.log) : null;
+                                var logPath = null;
+                                if (res.log && common.sanitizeFilename(res.log) === (res.log + "")) {
+                                    logPath = common.resolvePathInBase(path.resolve(__dirname, './../../../log'), res.log);
+                                }
                                 if (res.log && !logPath) {
                                     common.returnMessage(ob.params, 401, "data-migration.unable-to-delete-log-file");
                                     return;
@@ -405,7 +389,7 @@ function trim_ending_slashes(address) {
                 var data_migrator = new migration_helper(common.db);
                 data_migrator.clean_up_data('import', exportid, true).then(function() {
                     //delete log file
-                    var importLogPath = safePathIn(path.resolve(__dirname, './../../../log'), 'dm-import_' + exportid + '.log');
+                    var importLogPath = common.resolvePathInBase(path.resolve(__dirname, './../../../log'), 'dm-import_' + exportid + '.log');
                     if (importLogPath && fs.existsSync(importLogPath)) {
                         try {
                             fs.unlinkSync(importLogPath);
@@ -416,7 +400,7 @@ function trim_ending_slashes(address) {
                     }
                     //delete info file
                     try {
-                        var importInfoPath = safePathIn(path.resolve(__dirname, './../import'), exportid + '.json');
+                        var importInfoPath = common.resolvePathInBase(path.resolve(__dirname, './../import'), exportid + '.json');
                         if (importInfoPath) {
                             fs.unlinkSync(importInfoPath);
                         }

--- a/plugins/data_migration/api/api.js
+++ b/plugins/data_migration/api/api.js
@@ -338,7 +338,9 @@ function trim_ending_slashes(address) {
                                     logPath = common.resolvePathInBase(path.resolve(__dirname, './../../../log'), res.log);
                                 }
                                 if (res.log && !logPath) {
-                                    common.returnMessage(ob.params, 401, "data-migration.unable-to-delete-log-file");
+                                    // 400: the stored log filename failed
+                                    // sanitization/containment (bad input).
+                                    common.returnMessage(ob.params, 400, "data-migration.unable-to-delete-log-file");
                                     return;
                                 }
                                 if (logPath && fs.existsSync(logPath)) {
@@ -347,7 +349,8 @@ function trim_ending_slashes(address) {
                                     }
                                     catch (err1) {
                                         log.e(err1);
-                                        common.returnMessage(ob.params, 401, "data-migration.unable-to-delete-log-file"); return;
+                                        // 500: actual server-side fs error.
+                                        common.returnMessage(ob.params, 500, "data-migration.unable-to-delete-log-file"); return;
                                     }
                                 }
                                 common.db.collection("data_migrations").remove({_id: exportid}, function(err1) {

--- a/plugins/data_migration/api/data_migration_helper.js
+++ b/plugins/data_migration/api/data_migration_helper.js
@@ -36,18 +36,6 @@ module.exports = function(my_db) {
         }
         return null;
     };
-    var safePathIn = function(basePath, filename) {
-        filename = filename + "";
-        if (!filename || common.sanitizeFilename(filename) !== filename) {
-            return null;
-        }
-        basePath = path.resolve(basePath);
-        var resolvedPath = path.resolve(basePath, filename);
-        if (resolvedPath.indexOf(basePath + path.sep) === 0) {
-            return resolvedPath;
-        }
-        return null;
-    };
     var create_con_strings = function() {
         var dbargs = [];
         var db_params = plugins.getDbConnectionParams('countly');
@@ -238,7 +226,7 @@ module.exports = function(my_db) {
                     return;
                 }
                 if (remove_archive) {
-                    var archivePath = safePathIn(baseFolder, my_exportid + '.tar.gz');
+                    var archivePath = common.resolvePathInBase(baseFolder, my_exportid + '.tar.gz');
                     if (archivePath && fs.existsSync(archivePath)) {
                         try {
                             fs.unlinkSync(archivePath);
@@ -250,7 +238,7 @@ module.exports = function(my_db) {
                 }
                 //cleans up default(if exist), then special
                 new Promise(function(resolve0, reject0) {
-                    var dataPath = safePathIn(baseFolder, my_exportid);
+                    var dataPath = common.resolvePathInBase(baseFolder, my_exportid);
                     if (dataPath && fs.existsSync(dataPath)) {
                         //removes default folder if exists
                         fse.remove(dataPath, err => {
@@ -283,7 +271,7 @@ module.exports = function(my_db) {
                                         }
                                     }
                                     var my_dir = path.dirname(res.export_path);
-                                    var exportPath = my_dir ? safePathIn(my_dir, my_exportid) : null;
+                                    var exportPath = my_dir ? common.resolvePathInBase(my_dir, my_exportid) : null;
                                     if (exportPath && fs.existsSync(exportPath)) {
                                         fse.remove(exportPath, err1 => {
                                             if (err1) {
@@ -299,7 +287,7 @@ module.exports = function(my_db) {
                                     }
                                 }
                                 else {
-                                    var defaultPath = safePathIn(baseFolder, my_exportid);
+                                    var defaultPath = common.resolvePathInBase(baseFolder, my_exportid);
                                     if (defaultPath && fs.existsSync(defaultPath)) {
                                         fse.remove(defaultPath, err1 => {
                                             if (err1) {
@@ -324,7 +312,7 @@ module.exports = function(my_db) {
                                 var data = fs.readFileSync(infofile);
                                 var mydata = JSON.parse(data);
                                 if (mydata && mydata.my_folder) {
-                                    var importPath = safePathIn(mydata.my_folder, my_exportid);
+                                    var importPath = common.resolvePathInBase(mydata.my_folder, my_exportid);
                                     if (!importPath) {
                                         reject(Error('data-migration.invalid-exportid'));
                                         return;

--- a/plugins/data_migration/api/data_migration_helper.js
+++ b/plugins/data_migration/api/data_migration_helper.js
@@ -29,6 +29,25 @@ module.exports = function(my_db) {
     var log = common.log('datamigration:api');
 
     var self = this;
+    var safeDataMigrationId = function(my_exportid) {
+        my_exportid = my_exportid + "";
+        if (my_exportid && common.sanitizeFilename(my_exportid) === my_exportid) {
+            return my_exportid;
+        }
+        return null;
+    };
+    var safePathIn = function(basePath, filename) {
+        filename = filename + "";
+        if (!filename || common.sanitizeFilename(filename) !== filename) {
+            return null;
+        }
+        basePath = path.resolve(basePath);
+        var resolvedPath = path.resolve(basePath, filename);
+        if (resolvedPath.indexOf(basePath + path.sep) === 0) {
+            return resolvedPath;
+        }
+        return null;
+    };
     var create_con_strings = function() {
         var dbargs = [];
         var db_params = plugins.getDbConnectionParams('countly');
@@ -211,11 +230,18 @@ module.exports = function(my_db) {
 
     this.clean_up_data = function(folder, my_exportid, remove_archive) {
         return new Promise(function(resolve, reject) {
-            if (my_exportid !== "") {
+            my_exportid = safeDataMigrationId(my_exportid);
+            if (my_exportid) {
+                var baseFolder = path.resolve(__dirname, './../' + folder);
+                if (['import', 'export'].indexOf(folder) === -1) {
+                    reject(Error('data-migration.invalid-exportid'));
+                    return;
+                }
                 if (remove_archive) {
-                    if (fs.existsSync(path.resolve(__dirname, './../' + folder + '/' + common.sanitizeFilename(my_exportid) + '.tar.gz'))) {
+                    var archivePath = safePathIn(baseFolder, my_exportid + '.tar.gz');
+                    if (archivePath && fs.existsSync(archivePath)) {
                         try {
-                            fs.unlinkSync(path.resolve(__dirname, './../' + folder + '/' + common.sanitizeFilename(my_exportid) + '.tar.gz'));
+                            fs.unlinkSync(archivePath);
                         }
                         catch (err) {
                             log.e(err);
@@ -224,9 +250,10 @@ module.exports = function(my_db) {
                 }
                 //cleans up default(if exist), then special
                 new Promise(function(resolve0, reject0) {
-                    if (fs.existsSync(path.resolve(__dirname, './../' + folder + '/' + my_exportid))) {
+                    var dataPath = safePathIn(baseFolder, my_exportid);
+                    if (dataPath && fs.existsSync(dataPath)) {
                         //removes default folder if exists
-                        fse.remove(path.resolve(__dirname, './../' + folder + '/' + my_exportid), err => {
+                        fse.remove(dataPath, err => {
                             if (err) {
                                 reject0(Error('data-migration.unable-to-remove-directory'));
                             }
@@ -256,8 +283,9 @@ module.exports = function(my_db) {
                                         }
                                     }
                                     var my_dir = path.dirname(res.export_path);
-                                    if (my_dir && fs.existsSync(my_dir + '/' + my_exportid)) {
-                                        fse.remove(my_dir + '/' + my_exportid, err1 => {
+                                    var exportPath = my_dir ? safePathIn(my_dir, my_exportid) : null;
+                                    if (exportPath && fs.existsSync(exportPath)) {
+                                        fse.remove(exportPath, err1 => {
                                             if (err1) {
                                                 reject(Error('data-migration.unable-to-remove-directory'));
                                             }
@@ -271,8 +299,9 @@ module.exports = function(my_db) {
                                     }
                                 }
                                 else {
-                                    if (fs.existsSync(path.resolve(__dirname, './../' + folder + '/' + my_exportid))) {
-                                        fse.remove(path.resolve(__dirname, './../' + folder + '/' + my_exportid), err1 => {
+                                    var defaultPath = safePathIn(baseFolder, my_exportid);
+                                    if (defaultPath && fs.existsSync(defaultPath)) {
+                                        fse.remove(defaultPath, err1 => {
                                             if (err1) {
                                                 reject(Error('data-migration.unable-to-remove-directory'));
                                             }
@@ -295,7 +324,12 @@ module.exports = function(my_db) {
                                 var data = fs.readFileSync(infofile);
                                 var mydata = JSON.parse(data);
                                 if (mydata && mydata.my_folder) {
-                                    fse.remove(mydata.my_folder + "/" + my_exportid, err => {
+                                    var importPath = safePathIn(mydata.my_folder, my_exportid);
+                                    if (!importPath) {
+                                        reject(Error('data-migration.invalid-exportid'));
+                                        return;
+                                    }
+                                    fse.remove(importPath, err => {
                                         if (err) {
                                             reject(Error('data-migration.unable-to-remove-directory'));
                                         }

--- a/plugins/data_migration/api/data_migration_helper.js
+++ b/plugins/data_migration/api/data_migration_helper.js
@@ -220,11 +220,11 @@ module.exports = function(my_db) {
         return new Promise(function(resolve, reject) {
             my_exportid = safeDataMigrationId(my_exportid);
             if (my_exportid) {
-                var baseFolder = path.resolve(__dirname, './../' + folder);
                 if (['import', 'export'].indexOf(folder) === -1) {
-                    reject(Error('data-migration.invalid-exportid'));
+                    reject(Error('data-migration.invalid-folder'));
                     return;
                 }
+                var baseFolder = path.resolve(__dirname, './../' + folder);
                 if (remove_archive) {
                     var archivePath = common.resolvePathInBase(baseFolder, my_exportid + '.tar.gz');
                     if (archivePath && fs.existsSync(archivePath)) {

--- a/plugins/data_migration/api/data_migration_helper.js
+++ b/plugins/data_migration/api/data_migration_helper.js
@@ -264,6 +264,15 @@ module.exports = function(my_db) {
                                 if (res && res.export_path && res.export_path !== '') {
                                     if (remove_archive) {
                                         try {
+                                            // KNOWN LIMITATION: res.export_path comes from the
+                                            // user-supplied target_path during export
+                                            // (data_migration_helper.js ~1224). The directory
+                                            // portion isn't currently containment-checked.
+                                            // Proper fix is to validate target_path at write
+                                            // time (will be addressed alongside the broader
+                                            // target_path hardening). Subdirectory removal a
+                                            // few lines below uses common.resolvePathInBase
+                                            // for defense-in-depth.
                                             fs.unlinkSync(res.export_path);
                                         }
                                         catch (err1) {

--- a/plugins/data_migration/frontend/app.js
+++ b/plugins/data_migration/frontend/app.js
@@ -2,6 +2,39 @@ var pluginOb = {},
     countlyConfig = require("../../../frontend/express/config");
 const fs = require('fs');
 const path = require('path');
+const common = require('../../../api/utils/common.js');
+
+/**
+ * Validate a filename before using it as a path segment.
+ * @param {string} filename - filename
+ * @returns {string|null} safe filename or null
+ */
+function safeFilename(filename) {
+    filename = filename + "";
+    if (filename && common.sanitizeFilename(filename) === filename) {
+        return filename;
+    }
+    return null;
+}
+
+/**
+ * Resolve a filename under a base path after filename validation.
+ * @param {string} basePath - base directory
+ * @param {string} filename - filename to resolve under base directory
+ * @returns {string|null} contained path or null
+ */
+function safePathIn(basePath, filename) {
+    filename = safeFilename(filename);
+    if (!filename) {
+        return null;
+    }
+    basePath = path.resolve(basePath);
+    var resolvedPath = path.resolve(basePath, filename);
+    if (resolvedPath.indexOf(basePath + path.sep) === 0) {
+        return resolvedPath;
+    }
+    return null;
+}
 
 (function(plugin) {
     plugin.init = function(app, countlyDb) {
@@ -9,9 +42,14 @@ const path = require('path');
             if (req.session && req.session.gadm) {
                 //asked by query id
                 if (req.query && req.query.id) {
-                    countlyDb.collection("data_migrations").findOne({_id: req.query.id}, function(err, data) {
-                        if (!err) {
-                            var myfile = path.resolve(__dirname, './../export/' + req.query.id + '.tar.gz');
+                    var exportid = safeFilename(req.query.id);
+                    if (!exportid) {
+                        res.status(400).send('Invalid export file');
+                        return;
+                    }
+                    countlyDb.collection("data_migrations").findOne({_id: exportid}, function(err, data) {
+                        if (!err && data) {
+                            var myfile = safePathIn(path.resolve(__dirname, './../export'), exportid + '.tar.gz');
                             if (data.export_path && data.export_path !== '') {
                                 myfile = data.export_path;
                             }
@@ -25,9 +63,14 @@ const path = require('path');
                     });
                 }
                 if (req.query && req.query.logfile) {
-                    if (fs.existsSync(path.resolve(__dirname, '../../../log/' + req.query.logfile))) {
+                    var logFilePath = safePathIn(path.resolve(__dirname, '../../../log'), req.query.logfile);
+                    if (!logFilePath) {
+                        res.status(400).send('Invalid log file');
+                        return;
+                    }
+                    if (fs.existsSync(logFilePath)) {
                         res.set('Content-Type', 'text/plain');
-                        res.download(path.resolve(__dirname, '../../../log/' + req.query.logfile), req.query.logfile);
+                        res.download(logFilePath, req.query.logfile);
                         return;
                     }
 

--- a/plugins/data_migration/frontend/app.js
+++ b/plugins/data_migration/frontend/app.js
@@ -32,7 +32,12 @@ function safeFilename(filename) {
                         if (!err && data) {
                             var myfile = common.resolvePathInBase(path.resolve(__dirname, './../export'), exportid + '.tar.gz');
                             if (data.export_path && data.export_path !== '') {
-                                myfile = data.export_path;
+                                var customExportPath = path.resolve(data.export_path + "");
+                                if (path.basename(customExportPath) !== exportid + '.tar.gz') {
+                                    res.status(400).send('Invalid export file');
+                                    return;
+                                }
+                                myfile = customExportPath;
                             }
                             if (fs.existsSync(myfile)) {
                                 res.set('Content-Type', 'application/x-gzip');
@@ -40,6 +45,14 @@ function safeFilename(filename) {
                                 return;
                             }
 
+                        }
+                        else if (err) {
+                            res.status(500).send('Error loading export file');
+                            return;
+                        }
+                        else {
+                            res.status(404).send('Export file not found');
+                            return;
                         }
                     });
                 }

--- a/plugins/data_migration/frontend/app.js
+++ b/plugins/data_migration/frontend/app.js
@@ -37,6 +37,13 @@ function safeFilename(filename) {
                                     res.status(400).send('Invalid export file');
                                     return;
                                 }
+                                // KNOWN LIMITATION: customExportPath is trusted as a filesystem path
+                                // beyond the basename check. Its directory portion ultimately comes from
+                                // the user-supplied params.qstring.target_path during the export flow
+                                // (data_migration_helper.js ~1224). The proper fix is at write time —
+                                // contain target_path to an allowed base directory there. Until that
+                                // upstream fix lands, an attacker with data_migration create rights who
+                                // exploits the target_path issue can read back the file they wrote.
                                 myfile = customExportPath;
                             }
                             if (fs.existsSync(myfile)) {

--- a/plugins/data_migration/frontend/app.js
+++ b/plugins/data_migration/frontend/app.js
@@ -17,25 +17,6 @@ function safeFilename(filename) {
     return null;
 }
 
-/**
- * Resolve a filename under a base path after filename validation.
- * @param {string} basePath - base directory
- * @param {string} filename - filename to resolve under base directory
- * @returns {string|null} contained path or null
- */
-function safePathIn(basePath, filename) {
-    filename = safeFilename(filename);
-    if (!filename) {
-        return null;
-    }
-    basePath = path.resolve(basePath);
-    var resolvedPath = path.resolve(basePath, filename);
-    if (resolvedPath.indexOf(basePath + path.sep) === 0) {
-        return resolvedPath;
-    }
-    return null;
-}
-
 (function(plugin) {
     plugin.init = function(app, countlyDb) {
         app.get(countlyConfig.path + '/data-migration/download', function(req, res) {
@@ -49,7 +30,7 @@ function safePathIn(basePath, filename) {
                     }
                     countlyDb.collection("data_migrations").findOne({_id: exportid}, function(err, data) {
                         if (!err && data) {
-                            var myfile = safePathIn(path.resolve(__dirname, './../export'), exportid + '.tar.gz');
+                            var myfile = common.resolvePathInBase(path.resolve(__dirname, './../export'), exportid + '.tar.gz');
                             if (data.export_path && data.export_path !== '') {
                                 myfile = data.export_path;
                             }
@@ -63,7 +44,7 @@ function safePathIn(basePath, filename) {
                     });
                 }
                 if (req.query && req.query.logfile) {
-                    var logFilePath = safePathIn(path.resolve(__dirname, '../../../log'), req.query.logfile);
+                    var logFilePath = safeFilename(req.query.logfile) ? common.resolvePathInBase(path.resolve(__dirname, '../../../log'), req.query.logfile) : null;
                     if (!logFilePath) {
                         res.status(400).send('Invalid log file');
                         return;

--- a/plugins/data_migration/tests/index.js
+++ b/plugins/data_migration/tests/index.js
@@ -956,9 +956,15 @@ describe("Testing data migration plugin", function() {
 
         it("Call import process", function(done) {
             tt = "b18e10498ec0f41a85bb8155ccd4a209819319a3";
-            var dir = path.resolve(__dirname, './' + tt + '.tar.gz');
+            var sourcePath = path.resolve(__dirname, './' + tt + '.tar.gz');
+            var importDir = path.resolve(__dirname, './../import');
+            var importPath = path.resolve(importDir, './' + tt + '.tar.gz');
+            if (!fs.existsSync(importDir)) {
+                fs.mkdirSync(importDir, 484);
+            }
+            fs.copyFileSync(sourcePath, importPath);
             request
-                .post('/i/datamigration/import?ts=000000&existing_file=' + dir)
+                .post('/i/datamigration/import?ts=000000&existing_file=' + tt)
                 .set('countly-token', mytoken)
                 .expect(200)
                 .end(function(err, res) {

--- a/plugins/data_migration/tests/index.js
+++ b/plugins/data_migration/tests/index.js
@@ -852,6 +852,26 @@ describe("Testing data migration plugin", function() {
                     }
                 });
         });
+        it("rejects path traversal in import delete exportid", function(done) {
+            var traversalTarget = "/tmp/countly_data_migration_path_traversal_test";
+            var traversalExportId = "../../../../../../../../.." + traversalTarget;
+
+            fs.writeFileSync(traversalTarget, "test");
+            request
+                .post('/i/datamigration/delete_import?exportid=' + encodeURIComponent(traversalExportId) + '&api_key=' + API_KEY_ADMIN + '&app_id=' + APP_ID)
+                .expect(400)
+                .end(function(err) {
+                    if (err) {
+                        fse.removeSync(traversalTarget);
+                        return done(err);
+                    }
+                    if (!fs.existsSync(traversalTarget)) {
+                        return done("Traversal target was deleted");
+                    }
+                    fse.removeSync(traversalTarget);
+                    done();
+                });
+        });
         it("delete import request ", function(done) {
             request
                 .post('/i/datamigration/delete_import?exportid=b18e10498ec0f41a85bb8155ccd4a209819319a3' + '&api_key=' + API_KEY_ADMIN + '&app_id=' + APP_ID)

--- a/plugins/data_migration/tests/index.js
+++ b/plugins/data_migration/tests/index.js
@@ -7,6 +7,7 @@ var path = require("path");
 var fs = require("fs"),
     readline = require('readline'),
     stream = require('stream');
+var os = require('os');
 var cp = require('child_process'); //call process
 const exec = cp.exec; //for calling command line
 const fse = require('fs-extra'); // delete folders
@@ -853,7 +854,7 @@ describe("Testing data migration plugin", function() {
                 });
         });
         it("rejects path traversal in import delete exportid", function(done) {
-            var traversalTarget = "/tmp/countly_data_migration_path_traversal_test";
+            var traversalTarget = path.join(os.tmpdir(), "countly_data_migration_path_traversal_test_" + Date.now());
             var traversalExportId = "../../../../../../../../.." + traversalTarget;
 
             fs.writeFileSync(traversalTarget, "test");

--- a/plugins/dbviewer/api/api.js
+++ b/plugins/dbviewer/api/api.js
@@ -327,6 +327,22 @@ var spawn = require('child_process').spawn,
                 common.returnMessage(params, 500, "The aggregation pipeline must be of the type array");
             }
             else {
+                // Reject $graphLookup. Its `from:` lets a user pull joined
+                // documents from any other collection in the same DB,
+                // bypassing the per-collection access check
+                // (dbUserHasAccessToCollection) and getBaseAppFilter — the
+                // base filter only applies to the source pipeline. The
+                // members/auth_tokens redaction below only fires when the
+                // source collection is one of those, not when those docs
+                // come in via the join. (Master 25.x has a broader
+                // aggregation-stage whitelist; this is the minimal 24.05
+                // backport of the same intent — see PR #7535 commit C-1.)
+                for (var stageIdx = 0; stageIdx < aggregation.length; stageIdx++) {
+                    if (aggregation[stageIdx] && Object.prototype.hasOwnProperty.call(aggregation[stageIdx], "$graphLookup")) {
+                        common.returnMessage(params, 400, "Aggregation stage \"$graphLookup\" is not allowed");
+                        return;
+                    }
+                }
                 var addProjectionAt = 0;
                 if (aggregation[0] && aggregation[0].$match) {
                     while (aggregation.length > addProjectionAt && aggregation[addProjectionAt].$match) {

--- a/plugins/errorlogs/api/api.js
+++ b/plugins/errorlogs/api/api.js
@@ -43,8 +43,14 @@ const readFromEnd = (file, size) => {
 };
 
 (function() {
-    var logs = {api: "../../../log/countly-api.log", dashboard: "../../../log/countly-dashboard.log"};
-    var dir = path.resolve(__dirname, '');
+    var logs = {api: "countly-api.log", dashboard: "countly-dashboard.log"};
+    var logDirectory = path.resolve(__dirname, "../../../log");
+    var getLogPath = function(logFileName) {
+        if (!logFileName || common.sanitizeFilename(logFileName) !== logFileName) {
+            return null;
+        }
+        return common.resolvePathInBase(logDirectory, logFileName);
+    };
     //write api call
     plugins.register("/o/errorlogs", function(ob) {
         //get parameters
@@ -53,7 +59,7 @@ const readFromEnd = (file, size) => {
         var bytes = obParams.qstring.bytes ? parseInt(obParams.qstring.bytes) : 0;
 
         validate(obParams, function(params) {
-            walk(dir + "/../../../log", function(errList, logfiles) {
+            walk(logDirectory, function(errList, logfiles) {
                 if (errList) {
                     console.error(errList);
                 }
@@ -61,9 +67,14 @@ const readFromEnd = (file, size) => {
                     logs = logfiles;
                 }
                 if (params.qstring.log && logs[params.qstring.log]) {
+                    var selectedLogPath = getLogPath(logs[params.qstring.log]);
+                    if (!selectedLogPath) {
+                        common.returnOutput(params, "");
+                        return;
+                    }
                     if (params.qstring.download) {
                         if (bytes === 0) {
-                            fs.readFile(dir + "/" + logs[params.qstring.log], 'utf8', function(err, data) {
+                            fs.readFile(selectedLogPath, 'utf8', function(err, data) {
                                 if (err) {
                                     data = "";
                                 }
@@ -71,7 +82,7 @@ const readFromEnd = (file, size) => {
                             });
                         }
                         else {
-                            readFromEnd(dir + "/" + logs[params.qstring.log], bytes)
+                            readFromEnd(selectedLogPath, bytes)
                                 .then(function(data) {
                                     common.returnRaw(params, 200, data, {'Content-Type': 'plain/text; charset=utf-8', 'Content-disposition': 'attachment; filename=countly-' + params.qstring.log + '.log'});
                                 }).catch(function() {
@@ -83,7 +94,7 @@ const readFromEnd = (file, size) => {
                     }
                     else {
                         if (bytes === 0) {
-                            fs.readFile(dir + "/" + logs[params.qstring.log], 'utf8', function(err, data) {
+                            fs.readFile(selectedLogPath, 'utf8', function(err, data) {
                                 if (err) {
                                     data = "";
                                 }
@@ -91,7 +102,7 @@ const readFromEnd = (file, size) => {
                             });
                         }
                         else {
-                            readFromEnd(dir + "/" + logs[params.qstring.log], bytes)
+                            readFromEnd(selectedLogPath, bytes)
                                 .then(function(data) {
                                     common.returnOutput(params, data);
                                 }).catch(function() {
@@ -105,8 +116,13 @@ const readFromEnd = (file, size) => {
                 else {
                     var readLog = function(key, done) {
                         var finished = false;
+                        var logPath = getLogPath(logs[key]);
+                        if (!logPath) {
+                            done(null, {key: key, val: ""});
+                            return;
+                        }
                         if (bytes === 0) {
-                            fs.readFile(dir + "/" + logs[key], 'utf8', function(err, data) {
+                            fs.readFile(logPath, 'utf8', function(err, data) {
                                 if (err) {
                                     data = "";
                                 }
@@ -114,7 +130,7 @@ const readFromEnd = (file, size) => {
                             });
                         }
                         else {
-                            readFromEnd(dir + "/" + logs[key], bytes)
+                            readFromEnd(logPath, bytes)
                                 .then(function(data) {
                                     if (!finished) {
                                         finished = true;
@@ -147,7 +163,7 @@ const readFromEnd = (file, size) => {
         var validate = ob.validateUserForGlobalAdmin; //user validation
 
         validate(obParams, function(params) {
-            walk(dir + "/../../../log", function(errList, logfiles) {
+            walk(logDirectory, function(errList, logfiles) {
                 if (errList) {
                     console.error(errList);
                 }
@@ -155,8 +171,13 @@ const readFromEnd = (file, size) => {
                     logs = logfiles;
                 }
                 if (params.qstring.log && logs[params.qstring.log]) {
+                    var selectedLogPath = getLogPath(logs[params.qstring.log]);
+                    if (!selectedLogPath) {
+                        common.returnMessage(params, 200, "Invalid log file");
+                        return;
+                    }
                     plugins.dispatch("/systemlogs", {params: params, action: "errologs_clear", data: {log: params.qstring.log}});
-                    fs.truncate(dir + "/" + logs[params.qstring.log], 0, function(err) {
+                    fs.truncate(selectedLogPath, 0, function(err) {
                         if (err) {
                             common.returnMessage(params, 200, err);
                         }
@@ -182,7 +203,7 @@ const readFromEnd = (file, size) => {
             }
             list.forEach(function(file) {
                 if (file && file.startsWith("countly-") && file.endsWith(".log")) {
-                    results[file.replace("countly-", "").replace(".log", "")] = '../../../log/' + file;
+                    results[file.replace("countly-", "").replace(".log", "")] = file;
                     if (!--pending) {
                         done(null, results);
                     }

--- a/plugins/logger/api/api.js
+++ b/plugins/logger/api/api.js
@@ -332,6 +332,10 @@ plugins.setConfigs("logger", {
                     filter = {};
                 }
             }
+            // Reject Mongo $where / $expr / $function / $accumulator in
+            // user-supplied filter — they enable server-side JS execution
+            // (DoS, blind-timing exfiltration).
+            common.stripUnsafeMongoOperators(filter);
 
             validateRead(params, FEATURE_NAME, function(parameters) {
                 common.db.collection('logs' + parameters.app_id).find(filter).limit(1000).toArray(function(err, items) {

--- a/plugins/push/api/api-message.js
+++ b/plugins/push/api/api-message.js
@@ -8,14 +8,30 @@ const { Message, Result, Creds, State, Status, platforms, Audience, ValidationEr
 
 /**
  * Validate data & construct message out of it, throw in case of error
- * 
+ *
  * @param {object} args plain object to construct Message from
  * @param {boolean} draft true if we need to skip checking data for validity
+ * @param {object} [params=null] request params object — when supplied, the
+ *                  body's "app" field is required to match params.qstring.app_id
+ *                  (cross-app guard).
  * @returns {PostMessageOptions} Message instance in case validation passed, array of error messages otherwise
  * @throws {ValidationError} in case of error
  * @apiUse PushMessageBody
  */
-async function validate(args, draft = false) {
+async function validate(args, draft = false, params = null) {
+    // Cross-app guard. The body's "app" field selects which app's push
+    // credentials are used and which app's user base is targeted.
+    // validateCreate / validateRead etc. only check the caller's
+    // permission against params.qstring.app_id, so without this check a
+    // user with push:create on app A could submit args.app = <victim_B>
+    // and send arbitrary push notifications through app B's signed
+    // APNS/FCM credentials. Force the body's app to match the
+    // permission-checked qstring.app_id.
+    if (params && params.qstring && params.qstring.app_id) {
+        if (args && args.app && (args.app + "") !== (params.qstring.app_id + "")) {
+            throw new ValidationError('args.app does not match request app_id');
+        }
+    }
     let msg;
     if (draft) {
         let data = common.validateArgs(args, {
@@ -148,7 +164,7 @@ async function validate(args, draft = false) {
  * @apiUse PushError
  */
 module.exports.test = async params => {
-    let msg = await validate(params.qstring),
+    let msg = await validate(params.qstring, false, params),
         cfg = params.app.plugins && params.app.plugins.push || {},
         test_uids = cfg && cfg.test && cfg.test.uids ? cfg.test.uids.split(',') : undefined,
         test_cohorts = cfg && cfg.test && cfg.test.cohorts ? cfg.test.cohorts.split(',') : undefined,
@@ -252,7 +268,7 @@ module.exports.test = async params => {
  * @apiUse PushError
  */
 module.exports.create = async params => {
-    let msg = await validate(params.qstring, params.qstring.status === Status.Draft),
+    let msg = await validate(params.qstring, params.qstring.status === Status.Draft, params),
         demo = params.qstring.demo === undefined ? params.qstring.args ? params.qstring.args.demo : false : params.qstring.demo;
     msg._id = common.db.ObjectID();
     msg.info.created = msg.info.updated = new Date();
@@ -304,7 +320,7 @@ module.exports.create = async params => {
  * @apiUse PushError
  */
 module.exports.update = async params => {
-    let msg = await validate(params.qstring, params.qstring.status === Status.Draft);
+    let msg = await validate(params.qstring, params.qstring.status === Status.Draft, params);
     msg.info.updated = new Date();
     msg.info.updatedBy = params.member._id;
     msg.info.updatedByName = params.member.full_name;
@@ -395,7 +411,15 @@ module.exports.remove = async params => {
         return true;
     }
 
-    let msg = await Message.findOne({_id: data.obj._id, state: {$bitsAllClear: State.Deleted}});
+    // Cross-app guard. Without scoping the lookup by app, a member with
+    // push:delete on app A could pass _id of a message belonging to app B
+    // and delete it. Bind to params.qstring.app_id (which validateDelete
+    // already permission-checked).
+    let findFilter = {_id: data.obj._id, state: {$bitsAllClear: State.Deleted}};
+    if (params.qstring.app_id) {
+        findFilter.app = common.db.ObjectID(params.qstring.app_id + "");
+    }
+    let msg = await Message.findOne(findFilter);
     if (!msg) {
         common.returnMessage(params, 404, {errors: ['Message not found']}, null, true);
         return true;
@@ -473,7 +497,12 @@ module.exports.toggle = async params => {
         return true;
     }
 
-    let msg = await Message.findOne(data._id);
+    // Scope by app — same cross-app guard as in remove() / one().
+    let toggleFilter = {_id: data._id};
+    if (params.qstring.app_id) {
+        toggleFilter.app = common.db.ObjectID(params.qstring.app_id + "");
+    }
+    let msg = await Message.findOne(toggleFilter);
     if (!msg) {
         common.returnMessage(params, 404, {errors: ['Message not found']}, null, true);
         return true;
@@ -705,7 +734,13 @@ module.exports.one = async params => {
         return true;
     }
 
-    let msg = await Message.findOne(data._id);
+    // Scope by app so a user with push:read on app A can't read a message
+    // belonging to app B by guessing its _id.
+    let oneFilter = {_id: data._id};
+    if (params.qstring.app_id) {
+        oneFilter.app = common.db.ObjectID(params.qstring.app_id + "");
+    }
+    let msg = await Message.findOne(oneFilter);
     if (!msg) {
         common.returnMessage(params, 404, {errors: ['Message not found']}, null, true);
         return true;

--- a/plugins/recaptcha/frontend/app.js
+++ b/plugins/recaptcha/frontend/app.js
@@ -23,7 +23,16 @@ plugins.setConfigs("recaptcha", {
         });
         app.post(countlyConfig.path + '/login', function(req, res, next) {
             if (req.session.fails && plugins.getConfig("recaptcha").enable && plugins.getConfig("recaptcha").site_key !== "" && plugins.getConfig("recaptcha").secret_key !== "") {
-                if (req.body && req.body.auth_code && req.body.auth_code === req.session.otp) { //if coming from two-factor and if it is matching the auth code in session skip captcha
+                // Skip captcha when the user already completed 2FA in this
+                // session. Previously this branch checked
+                // req.body.auth_code === req.session.otp, but the 2FA plugin
+                // used to write session.otp BEFORE verifying the code — so
+                // any successful 2FA login left a session in which any
+                // subsequent /login with the same auth_code value would
+                // bypass captcha against arbitrary other usernames.
+                // The 2FA plugin now sets req.session.twoFactorPassed = true
+                // ONLY after GA.check succeeds; we use that flag here.
+                if (req.session.twoFactorPassed) {
                     next();
                 }
                 else {

--- a/plugins/star-rating/api/api.js
+++ b/plugins/star-rating/api/api.js
@@ -5,8 +5,9 @@ var exported = {},
     log = common.log('star-rating:api'),
     countlyCommon = require('../../../api/lib/countly.common.js'),
     plugins = require('../../pluginManager.js'),
-    { validateCreate, validateRead, validateUpdate, validateDelete } = require('../../../api/utils/rights.js'),
-    countlyFs = require('../../../api/utils/countlyFs.js');
+    { validateCreate, validateRead, validateUpdate, validateDelete, validateGlobalAdmin, validateAppAdmin } = require('../../../api/utils/rights.js'),
+    countlyFs = require('../../../api/utils/countlyFs.js'),
+    imageUtils = require('./image-utils.js');
 var fetch = require('../../../api/parts/data/fetch.js');
 var ejs = require("ejs"),
     fs = require('fs'),
@@ -371,7 +372,6 @@ function uploadFile(myfile, id, callback) {
     function uploadFeedbackFile(myname, myfile) {
         return new Promise(function(resolve, reject) {
             var tmp_path = myfile.path;
-            var type = myfile.type;
             if (myfile.size > 1.5 * 1024 * 1024) {
                 fs.unlink(tmp_path, function() {});
                 reject(Error("feedback.image-error"));
@@ -380,27 +380,33 @@ function uploadFile(myfile, id, callback) {
                 fs.readFile(tmp_path, (err, data) => {
                     if (err) {
                         reject(Error("feedback.imagee-error"));
+                        return;
                     }
-                    //convert file to data
-                    if (data) {
-                        try {
-                            var data_uri_prefix = "data:" + type + ";base64,";
-                            var buf = Buffer.from(data);
-                            var image = buf.toString('base64');
-                            image = data_uri_prefix + image;
-                            countlyFs.gridfs.saveData("feedback", myname, image, {id: myname, writeMode: "overwrite"}, function(err2) {
-                                fs.unlink(tmp_path, function() {});
-                                if (err2) {
-                                    return reject(err2);
-                                }
-                                resolve();
-                            });
-                        }
-                        catch (SyntaxError) {
-                            reject(Error("feedback.imagee-error"));
-                        }
+                    if (!data) {
+                        reject(Error("feedback.imagee-error"));
+                        return;
                     }
-                    else {
+                    var buf = Buffer.from(data);
+                    // Detect MIME from the actual bytes; never trust myfile.type.
+                    // Anything that isn't a recognized safe raster image is rejected.
+                    var detectedType = imageUtils.sniffImageType(buf);
+                    if (!detectedType) {
+                        fs.unlink(tmp_path, function() {});
+                        reject(Error("feedback.imagef-error"));
+                        return;
+                    }
+                    try {
+                        var data_uri_prefix = "data:" + detectedType + ";base64,";
+                        var image = data_uri_prefix + buf.toString('base64');
+                        countlyFs.gridfs.saveData("feedback", myname, image, {id: myname, writeMode: "overwrite"}, function(err2) {
+                            fs.unlink(tmp_path, function() {});
+                            if (err2) {
+                                return reject(err2);
+                            }
+                            resolve();
+                        });
+                    }
+                    catch (SyntaxError) {
                         reject(Error("feedback.imagee-error"));
                     }
                 });
@@ -430,37 +436,60 @@ function uploadFile(myfile, id, callback) {
      * }
     */
     plugins.register("/i/feedback/upload", function(ob) {
-        // do not respond if this isn't feedback fetch request 
+        // do not respond if this isn't feedback fetch request
         // or surveys plugin enabled
         if (surveysEnabled) {
             return false;
         }
 
         var params = ob.params;
-        validateUpdate(params, "global_plugins", function() {
-            var images = ["feedback_logo"];
-            var flag = 0;
-            if (params.files) {
-                for (let i = 0; i < images.length; i++) {
-                    if (params.files[images[i]]) {
-                        flag = 1;
-                        uploadFeedbackFile(images[i], params.files[images[i]]).then(function() {
-                            common.returnOutput(params, {"result": "Success"});
-                        }, function(err) {
-                            common.returnMessage(params, 400, err.message);
-                        });
-                        break;
-                    }
-                }
-                if (flag === 0) {
-                    uploadFeedbackFile(params.qstring.name, params.files.file).then(function() {
-                        common.returnOutput(params, {"result": "Success"});
-                    }, function(err) {
-                        common.returnMessage(params, 400, err.message);
-                    });
-                }
-            }
-        });
+        if (!params.files) {
+            common.returnMessage(params, 400, "feedback.imagee-error");
+            return true;
+        }
+
+        // Two upload modes:
+        //   1. Global feedback logo: file posted under field "feedback_logo",
+        //      stored under id "feedback_logo". Modifies a global plugin
+        //      setting and therefore requires actual global admin.
+        //   2. Per-app feedback logo: file posted under field "file" with
+        //      ?name=feedback_logo<24-char-hex-app-id>. The target app id is
+        //      decoded from the name itself, NOT taken from qstring.app_id,
+        //      so an admin of one app can't plant a logo for another app.
+        //
+        // Any other name shape is rejected.
+        var globalUpload = !!params.files.feedback_logo;
+        var fileObj = globalUpload ? params.files.feedback_logo : params.files.file;
+        var requestedName = globalUpload ? "feedback_logo" : (params.qstring && params.qstring.name);
+
+        var parsed = imageUtils.parseFeedbackLogoName(requestedName);
+        if (!parsed.valid || !fileObj) {
+            common.returnMessage(params, 400, "feedback.invalid-name");
+            return true;
+        }
+
+        /**
+         * Run the actual file upload after auth has passed.
+         * @returns {void}
+         */
+        function performUpload() {
+            uploadFeedbackFile(requestedName, fileObj).then(function() {
+                common.returnOutput(params, {"result": "Success"});
+            }, function(err) {
+                common.returnMessage(params, 400, err.message);
+            });
+        }
+
+        if (parsed.isGlobal) {
+            validateGlobalAdmin(params, performUpload);
+        }
+        else {
+            // Pin app_id to the value embedded in the upload name so the
+            // app-admin check can't be satisfied with admin rights on a
+            // different app.
+            params.qstring.app_id = parsed.appId;
+            validateAppAdmin(params, performUpload);
+        }
         return true;
     });
     /*

--- a/plugins/star-rating/api/api.js
+++ b/plugins/star-rating/api/api.js
@@ -287,16 +287,17 @@ function uploadFile(myfile, id, callback) {
             try {
                 var pp = path.resolve(__dirname, './../images/' + id + "." + detectedExt);
                 countlyFs.saveData("star-rating", pp, data, { id: "" + id + "." + detectedExt, writeMode: "overwrite" }, function(err3) {
+                    fs.unlink(tmp_path, function() { });
                     if (err3) {
                         callback("Failed to upload image");
                     }
                     else {
-                        fs.unlink(tmp_path, function() { });
                         callback(true, id + "." + detectedExt);
                     }
                 });
             }
             catch (SyntaxError) {
+                fs.unlink(tmp_path, function() { });
                 callback("Failed to upload image");
             }
         });
@@ -377,11 +378,8 @@ function uploadFile(myfile, id, callback) {
             }
             else {
                 fs.readFile(tmp_path, (err, data) => {
-                    if (err) {
-                        reject(Error("feedback.imagee-error"));
-                        return;
-                    }
-                    if (!data) {
+                    if (err || !data) {
+                        fs.unlink(tmp_path, function() {});
                         reject(Error("feedback.imagee-error"));
                         return;
                     }
@@ -406,6 +404,7 @@ function uploadFile(myfile, id, callback) {
                         });
                     }
                     catch (SyntaxError) {
+                        fs.unlink(tmp_path, function() {});
                         reject(Error("feedback.imagee-error"));
                     }
                 });
@@ -463,7 +462,11 @@ function uploadFile(myfile, id, callback) {
 
         var parsed = imageUtils.parseFeedbackLogoName(requestedName);
         if (!parsed.valid || !fileObj) {
-            common.returnMessage(params, 400, "feedback.invalid-name");
+            // Reuse the existing localized "invalid format" key rather than
+            // adding a new key that would need translating across 25+ locale
+            // files. From the user's perspective both conditions (bad name
+            // shape, missing file) are "your upload was malformed, try again".
+            common.returnMessage(params, 400, "feedback.imagef-error");
             return true;
         }
 

--- a/plugins/star-rating/api/api.js
+++ b/plugins/star-rating/api/api.js
@@ -244,6 +244,16 @@ function create_upload_dir(callback) {
     });
 }
 
+// Map sniffed image MIME → file extension to use on disk. Determines
+// the saved filename and the URL component returned to the caller.
+// Restricted to png/jpeg/gif to preserve the original /i/feedback/logo
+// contract (no widening to webp here).
+var SNIFFED_TYPE_TO_EXT = {
+    "image/png": "png",
+    "image/jpeg": "jpg",
+    "image/gif": "gif"
+};
+
 /**
 * Used for file upload
 * @param {object} myfile - file object(if empty - returns)
@@ -256,48 +266,37 @@ function uploadFile(myfile, id, callback) {
         return;
     }
     var tmp_path = myfile.path;
-    var type = myfile.type;
-    myfile.name = myfile.name || "png";
-    if (type !== "image/png" && type !== "image/gif" && type !== "image/jpeg") {
-        fs.unlink(tmp_path, function() { });
-        callback("Invalid image format. Must be png or jpeg");
-        return;
-    }
-
-    var allowedExtensions = ["gif", "jpeg", "jpg", "png"];
-    var ext = myfile.name.split(".");
-    ext = ext[ext.length - 1];
-
-    if (allowedExtensions.indexOf(ext) === -1) {
-        callback("Invalid file extension. Must be .png, .jpg, .gif or .jpeg");
-        return;
-    }
 
     create_upload_dir(function() {
         fs.readFile(tmp_path, (err, data) => {
-            if (err) {
+            if (err || !data) {
+                fs.unlink(tmp_path, function() { });
                 callback("Failed to upload image");
                 return;
             }
-            //convert file to data
-            if (data) {
-                try {
-                    var pp = path.resolve(__dirname, './../images/' + id + "." + ext);
-                    countlyFs.saveData("star-rating", pp, data, { id: "" + id + "." + ext, writeMode: "overwrite" }, function(err3) {
-                        if (err3) {
-                            callback("Failed to upload image");
-                        }
-                        else {
-                            fs.unlink(tmp_path, function() { });
-                            callback(true, id + "." + ext);
-                        }
-                    });
-                }
-                catch (SyntaxError) {
-                    callback("Failed to upload image");
-                }
+            // Detect format from magic bytes; never trust myfile.type or
+            // myfile.name. Anything not in the allowlist (png/jpeg/gif)
+            // is rejected.
+            var detectedType = imageUtils.sniffImageType(data);
+            var detectedExt = detectedType && SNIFFED_TYPE_TO_EXT[detectedType];
+            if (!detectedExt) {
+                fs.unlink(tmp_path, function() { });
+                callback("Invalid image format. Must be png, jpeg, or gif");
+                return;
             }
-            else {
+            try {
+                var pp = path.resolve(__dirname, './../images/' + id + "." + detectedExt);
+                countlyFs.saveData("star-rating", pp, data, { id: "" + id + "." + detectedExt, writeMode: "overwrite" }, function(err3) {
+                    if (err3) {
+                        callback("Failed to upload image");
+                    }
+                    else {
+                        fs.unlink(tmp_path, function() { });
+                        callback(true, id + "." + detectedExt);
+                    }
+                });
+            }
+            catch (SyntaxError) {
                 callback("Failed to upload image");
             }
         });

--- a/plugins/star-rating/api/image-utils.js
+++ b/plugins/star-rating/api/image-utils.js
@@ -1,0 +1,59 @@
+/**
+ * Detect image MIME type by inspecting magic bytes. Does NOT trust
+ * any client-supplied or stored MIME string. Returns one of the
+ * allowlisted image MIME types, or null if the buffer is not a
+ * recognized safe image format.
+ * @param {Buffer} buf - file content
+ * @returns {string|null} MIME type or null if not a recognized image
+ */
+function sniffImageType(buf) {
+    if (!buf || buf.length < 12) {
+        return null;
+    }
+    // PNG: 89 50 4E 47 0D 0A 1A 0A
+    if (buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4E && buf[3] === 0x47
+        && buf[4] === 0x0D && buf[5] === 0x0A && buf[6] === 0x1A && buf[7] === 0x0A) {
+        return 'image/png';
+    }
+    // JPEG: FF D8 FF
+    if (buf[0] === 0xFF && buf[1] === 0xD8 && buf[2] === 0xFF) {
+        return 'image/jpeg';
+    }
+    // GIF87a / GIF89a: 47 49 46 38 (37|39) 61
+    if (buf[0] === 0x47 && buf[1] === 0x49 && buf[2] === 0x46 && buf[3] === 0x38
+        && (buf[4] === 0x37 || buf[4] === 0x39) && buf[5] === 0x61) {
+        return 'image/gif';
+    }
+    // WebP: "RIFF" .... "WEBP"
+    if (buf[0] === 0x52 && buf[1] === 0x49 && buf[2] === 0x46 && buf[3] === 0x46
+        && buf[8] === 0x57 && buf[9] === 0x45 && buf[10] === 0x42 && buf[11] === 0x50) {
+        return 'image/webp';
+    }
+    return null;
+}
+
+// Allowed feedback logo names: the literal global "feedback_logo" or
+// "feedback_logo<24-char-hex-app-id>" for per-app logos.
+var FEEDBACK_LOGO_NAME_RE = /^feedback_logo([a-f0-9]{24})?$/;
+
+/**
+ * Validate a feedback logo name and, if it's a per-app logo, return
+ * the app id encoded in it.
+ * @param {string} name - candidate name
+ * @returns {object} parse result with `valid`, `isGlobal`, and `appId` fields
+ */
+function parseFeedbackLogoName(name) {
+    if (typeof name !== 'string') {
+        return {valid: false, isGlobal: false, appId: null};
+    }
+    var m = FEEDBACK_LOGO_NAME_RE.exec(name);
+    if (!m) {
+        return {valid: false, isGlobal: false, appId: null};
+    }
+    return {valid: true, isGlobal: !m[1], appId: m[1] || null};
+}
+
+module.exports = {
+    sniffImageType: sniffImageType,
+    parseFeedbackLogoName: parseFeedbackLogoName
+};

--- a/plugins/star-rating/frontend/app.js
+++ b/plugins/star-rating/frontend/app.js
@@ -1,9 +1,15 @@
 var exported = {},
     countlyFs = require('../../../api/utils/countlyFs.js'),
     countlyConfig = require("../../../frontend/express/config"),
-    common = require('../../../api/utils/common.js');
+    common = require('../../../api/utils/common.js'),
+    imageUtils = require('../api/image-utils.js');
 var path = require('path');
 var log = common.log('star-rating:frontend');
+
+// Names accepted on the preview route. Tighter than the upload-side
+// validator so even legacy data with unexpected ids can't be reached
+// via path component shenanigans (no path separators, no dots).
+var PREVIEW_NAME_RE = /^[a-zA-Z0-9_-]{1,64}$/;
 
 (function(plugin) {
     plugin.init = function(app) {
@@ -22,23 +28,43 @@ var log = common.log('star-rating:frontend');
         // keep this for backward compatability
         app.get(countlyConfig.path + '/feedback', renderPopup);
         app.get(countlyConfig.path + '/feedback/preview/*', function(req, res/*, next*/) {
-            if (!req.params || !req.params[0] || req.params[0] === '') {
+            if (!req.params || !req.params[0] || req.params[0] === '' || !PREVIEW_NAME_RE.test(req.params[0])) {
                 res.sendFile(__dirname + '/public/images/default_app_icon.png');
             }
             else {
                 countlyFs.gridfs.getDataById("feedback", req.params[0], function(err, data) {
                     if (err || !data) {
                         res.sendFile(__dirname + '/public/images/default_app_icon.png');
+                        return;
                     }
-                    else {
-                        var dd = data.split(',');
-                        var img = Buffer.from(dd[1], 'base64');
-                        res.writeHead(200, {
-                            'Content-Type': dd = dd[0].substr(5, dd[0].length - 12),
-                            'Content-Length': img.length
-                        });
-                        res.end(img);
+                    var commaIdx = data.indexOf(',');
+                    if (commaIdx === -1) {
+                        res.sendFile(__dirname + '/public/images/default_app_icon.png');
+                        return;
                     }
+                    var img;
+                    try {
+                        img = Buffer.from(data.slice(commaIdx + 1), 'base64');
+                    }
+                    catch (e) {
+                        res.sendFile(__dirname + '/public/images/default_app_icon.png');
+                        return;
+                    }
+                    // Re-derive Content-Type from sniffed bytes. Never trust
+                    // the MIME embedded in the stored data URI.
+                    var safeType = imageUtils.sniffImageType(img);
+                    if (!safeType) {
+                        res.sendFile(__dirname + '/public/images/default_app_icon.png');
+                        return;
+                    }
+                    res.writeHead(200, {
+                        'Content-Type': safeType,
+                        'Content-Length': img.length,
+                        'X-Content-Type-Options': 'nosniff',
+                        'Content-Security-Policy': "sandbox; default-src 'none'",
+                        'Content-Disposition': 'inline'
+                    });
+                    res.end(img);
                 });
             }
         });

--- a/plugins/star-rating/frontend/app.js
+++ b/plugins/star-rating/frontend/app.js
@@ -3,6 +3,7 @@ var exported = {},
     countlyConfig = require("../../../frontend/express/config"),
     common = require('../../../api/utils/common.js');
 var path = require('path');
+var log = common.log('star-rating:frontend');
 
 (function(plugin) {
     plugin.init = function(app) {
@@ -57,6 +58,15 @@ var path = require('path');
                             res.sendFile(path.resolve(__dirname + './../../../frontend/express/public/images/default_app_icon.png'));
                         }
                         else {
+                            stream.on('error', function(error) {
+                                log.e(error);
+                                if (!res.headersSent) {
+                                    res.sendFile(path.resolve(__dirname + './../../../frontend/express/public/images/default_app_icon.png'));
+                                }
+                                else {
+                                    res.end();
+                                }
+                            });
                             res.writeHead(200, {
                                 'Accept-Ranges': 'bytes',
                                 'Cache-Control': 'public, max-age=31536000',

--- a/plugins/star-rating/frontend/app.js
+++ b/plugins/star-rating/frontend/app.js
@@ -1,26 +1,8 @@
 var exported = {},
     countlyFs = require('../../../api/utils/countlyFs.js'),
-    countlyConfig = require("../../../frontend/express/config");
+    countlyConfig = require("../../../frontend/express/config"),
+    common = require('../../../api/utils/common.js');
 var path = require('path');
-
-/**
- * Resolve a request path under a static base directory.
- * @param {string} baseDir - base static directory
- * @param {string} requestPath - user-supplied request path
- * @returns {string|null} contained path or null
- */
-function safeStaticPath(baseDir, requestPath) {
-    baseDir = path.resolve(baseDir);
-    requestPath = (requestPath + "").replace(/\\/g, "/");
-    while (requestPath.indexOf("/") === 0) {
-        requestPath = requestPath.substring(1);
-    }
-    var resolvedPath = path.resolve(baseDir, requestPath);
-    if (resolvedPath === baseDir || resolvedPath.indexOf(baseDir + path.sep) === 0) {
-        return resolvedPath;
-    }
-    return null;
-}
 
 (function(plugin) {
     plugin.init = function(app) {
@@ -60,7 +42,7 @@ function safeStaticPath(baseDir, requestPath) {
             }
         });
         app.get(countlyConfig.path + '/star-rating/images/*', function(req, res) {
-            var imagePath = safeStaticPath(path.resolve(__dirname, './../images'), req.params[0]);
+            var imagePath = common.resolvePathInBase(path.resolve(__dirname, './../images'), req.params[0]);
             if (!imagePath) {
                 res.sendFile(path.resolve(__dirname + './../../../frontend/express/public/images/default_app_icon.png'));
                 return;

--- a/plugins/star-rating/frontend/app.js
+++ b/plugins/star-rating/frontend/app.js
@@ -2,6 +2,26 @@ var exported = {},
     countlyFs = require('../../../api/utils/countlyFs.js'),
     countlyConfig = require("../../../frontend/express/config");
 var path = require('path');
+
+/**
+ * Resolve a request path under a static base directory.
+ * @param {string} baseDir - base static directory
+ * @param {string} requestPath - user-supplied request path
+ * @returns {string|null} contained path or null
+ */
+function safeStaticPath(baseDir, requestPath) {
+    baseDir = path.resolve(baseDir);
+    requestPath = (requestPath + "").replace(/\\/g, "/");
+    while (requestPath.indexOf("/") === 0) {
+        requestPath = requestPath.substring(1);
+    }
+    var resolvedPath = path.resolve(baseDir, requestPath);
+    if (resolvedPath === baseDir || resolvedPath.indexOf(baseDir + path.sep) === 0) {
+        return resolvedPath;
+    }
+    return null;
+}
+
 (function(plugin) {
     plugin.init = function(app) {
 
@@ -40,12 +60,17 @@ var path = require('path');
             }
         });
         app.get(countlyConfig.path + '/star-rating/images/*', function(req, res) {
-            countlyFs.getStats("star-rating", path.resolve(__dirname, './../images/' + req.params[0]), {id: "" + req.params[0]}, function(statsErr, stats) {
+            var imagePath = safeStaticPath(path.resolve(__dirname, './../images'), req.params[0]);
+            if (!imagePath) {
+                res.sendFile(path.resolve(__dirname + './../../../frontend/express/public/images/default_app_icon.png'));
+                return;
+            }
+            countlyFs.getStats("star-rating", imagePath, {id: "" + req.params[0]}, function(statsErr, stats) {
                 if (statsErr || !stats || !stats.size) {
                     res.sendFile(path.resolve(__dirname + './../../../frontend/express/public/images/default_app_icon.png'));
                 }
                 else {
-                    countlyFs.getStream("star-rating", path.resolve(__dirname, './../images/' + req.params[0]), {id: "" + req.params[0]}, function(streamErr, stream) {
+                    countlyFs.getStream("star-rating", imagePath, {id: "" + req.params[0]}, function(streamErr, stream) {
                         if (streamErr || !stream) {
                             res.sendFile(path.resolve(__dirname + './../../../frontend/express/public/images/default_app_icon.png'));
                         }

--- a/plugins/star-rating/frontend/app.js
+++ b/plugins/star-rating/frontend/app.js
@@ -103,7 +103,10 @@ var PREVIEW_NAME_RE = /^[a-zA-Z0-9_-]{1,64}$/;
                                 'Server': 'nginx/1.10.3 (Ubuntu)',
                                 'X-Powered-By': 'Express',
                                 'Content-Type': 'image/png',
-                                'Content-Length': stats.size
+                                'Content-Length': stats.size,
+                                'X-Content-Type-Options': 'nosniff',
+                                'Content-Security-Policy': "sandbox; default-src 'none'",
+                                'Content-Disposition': 'inline'
                             });
                             stream.pipe(res);
                         }

--- a/plugins/star-rating/frontend/app.js
+++ b/plugins/star-rating/frontend/app.js
@@ -11,6 +11,16 @@ var log = common.log('star-rating:frontend');
 // via path component shenanigans (no path separators, no dots).
 var PREVIEW_NAME_RE = /^[a-zA-Z0-9_-]{1,64}$/;
 
+// File extension → response Content-Type for /star-rating/images/*.
+// Upload side restricts saved files to png/jpg/gif; .jpeg kept for any
+// legacy data uploaded before that restriction was tightened.
+var STAR_RATING_EXT_TO_MIME = {
+    "png": "image/png",
+    "jpg": "image/jpeg",
+    "jpeg": "image/jpeg",
+    "gif": "image/gif"
+};
+
 (function(plugin) {
     plugin.init = function(app) {
 
@@ -74,6 +84,16 @@ var PREVIEW_NAME_RE = /^[a-zA-Z0-9_-]{1,64}$/;
                 res.sendFile(path.resolve(__dirname + './../../../frontend/express/public/images/default_app_icon.png'));
                 return;
             }
+            // Derive Content-Type from the requested filename extension.
+            // Upload side guarantees the saved extension matches the
+            // sniffed format; this just ensures the response Content-Type
+            // matches the actual bytes (rather than always claiming png).
+            var pathExt = (req.params[0].split(".").pop() || "").toLowerCase();
+            var responseMime = STAR_RATING_EXT_TO_MIME[pathExt];
+            if (!responseMime) {
+                res.sendFile(path.resolve(__dirname + './../../../frontend/express/public/images/default_app_icon.png'));
+                return;
+            }
             countlyFs.getStats("star-rating", imagePath, {id: "" + req.params[0]}, function(statsErr, stats) {
                 if (statsErr || !stats || !stats.size) {
                     res.sendFile(path.resolve(__dirname + './../../../frontend/express/public/images/default_app_icon.png'));
@@ -102,7 +122,7 @@ var PREVIEW_NAME_RE = /^[a-zA-Z0-9_-]{1,64}$/;
                                 'Last-Modified': stats.mtime.toUTCString(),
                                 'Server': 'nginx/1.10.3 (Ubuntu)',
                                 'X-Powered-By': 'Express',
-                                'Content-Type': 'image/png',
+                                'Content-Type': responseMime,
                                 'Content-Length': stats.size,
                                 'X-Content-Type-Options': 'nosniff',
                                 'Content-Security-Policy': "sandbox; default-src 'none'",

--- a/plugins/system-utility/api/api.js
+++ b/plugins/system-utility/api/api.js
@@ -212,6 +212,15 @@ function stopWithTimeout(type, fromTimeout = false) {
                             "Content-Type": "plain/text; charset=utf-8",
                             "Content-Disposition": "attachment; filename=profiler.tar"
                         });
+                        tarStream.on("error", (streamErr) => {
+                            log.e(streamErr);
+                            if (!params.res.headersSent) {
+                                common.returnMessage(params, 500, "Profiler archive stream error");
+                            }
+                            else {
+                                params.res.end();
+                            }
+                        });
                         tarStream.on("end", () => params.res.end());
                         tarStream.pipe(params.res);
                     }

--- a/plugins/system-utility/api/api.js
+++ b/plugins/system-utility/api/api.js
@@ -208,10 +208,9 @@ function stopWithTimeout(type, fromTimeout = false) {
                         common.returnMessage(params, 404, "Profiler files couldn't be found");
                     }
                     else {
-                        params.res.writeHead(200, {
-                            "Content-Type": "plain/text; charset=utf-8",
-                            "Content-Disposition": "attachment; filename=profiler.tar"
-                        });
+                        // Attach error/end handlers BEFORE writeHead so the
+                        // !headersSent branch is reachable for errors that
+                        // fire before the first chunk is piped.
                         tarStream.on("error", (streamErr) => {
                             log.e(streamErr);
                             if (!params.res.headersSent) {
@@ -222,6 +221,10 @@ function stopWithTimeout(type, fromTimeout = false) {
                             }
                         });
                         tarStream.on("end", () => params.res.end());
+                        params.res.writeHead(200, {
+                            "Content-Type": "plain/text; charset=utf-8",
+                            "Content-Disposition": "attachment; filename=profiler.tar"
+                        });
                         tarStream.pipe(params.res);
                     }
                 }

--- a/plugins/systemlogs/api/api.js
+++ b/plugins/systemlogs/api/api.js
@@ -2,7 +2,7 @@ var pluginOb = {},
     common = require('../../../api/utils/common.js'),
     countlyCommon = require('../../../api/lib/countly.common.js'),
     plugins = require('../../pluginManager.js'),
-    { validateGlobalAdmin, validateUser } = require('../../../api/utils/rights.js');
+    { validateGlobalAdmin } = require('../../../api/utils/rights.js');
 
 //const FEATURE_NAME = 'systemlogs';
 plugins.setConfigs("systemlogs", {
@@ -188,7 +188,13 @@ plugins.setConfigs("systemlogs", {
 
     plugins.register("/i/systemlogs", function(ob) {
         var params = ob.params;
-        validateUser(params, function() {
+        // Restrict /i/systemlogs to global admins. Previously gated only by
+        // validateUser, so any authenticated dashboard user (incl. read-only)
+        // could write arbitrary action+data into the systemlogs collection
+        // — useful for forging "app_deleted"/"user_deleted" entries to mask
+        // real attacker activity, or for socially engineering admins via
+        // attacker-controlled JSON rendered in the System Logs UI.
+        validateGlobalAdmin(params, function() {
             if (typeof params.qstring.data === "string") {
                 try {
                     params.qstring.data = JSON.parse(params.qstring.data);

--- a/plugins/two-factor-auth/frontend/app.js
+++ b/plugins/two-factor-auth/frontend/app.js
@@ -194,8 +194,18 @@ function generateQRCode(username, secret, callback) {
                         try {
                             const secretToken = member.two_factor_auth && member.two_factor_auth.secret_token ? apiUtils.decrypt(member.two_factor_auth.secret_token) : req.body.secret_token;
 
-                            req.session.otp = req.body.auth_code;
+                            // NOTE: do NOT write req.session.otp here. The
+                            // recaptcha plugin used to skip its check when
+                            // req.body.auth_code === req.session.otp; setting
+                            // it BEFORE verification let an attacker who once
+                            // performed any 2FA login subsequently brute-force
+                            // other accounts using the same auth_code value
+                            // and bypass recaptcha. Instead we set
+                            // req.session.twoFactorPassed = true ONLY after
+                            // GA.check succeeds, and the recaptcha plugin
+                            // looks at that flag.
                             if (GA.check(req.body.auth_code, secretToken)) {
+                                req.session.twoFactorPassed = true;
                                 if (req.body.secret_token) {
                                     countlyDb.collection("members").findAndModify(
                                         {_id: member._id},

--- a/test/unit-tests/star-rating.image-utils.js
+++ b/test/unit-tests/star-rating.image-utils.js
@@ -1,0 +1,186 @@
+var should = require("should");
+var imageUtils = require("../../plugins/star-rating/api/image-utils.js");
+
+// Build a buffer of length `size` whose first bytes are `prefix`.
+function bufWith(prefix, size) {
+    var b = Buffer.alloc(size || Math.max(prefix.length, 12));
+    for (var i = 0; i < prefix.length; i++) {
+        b[i] = prefix[i];
+    }
+    return b;
+}
+
+describe("star-rating image-utils", function() {
+
+    describe("sniffImageType", function() {
+        it("recognizes PNG signature", function(done) {
+            var buf = bufWith([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]);
+            should(imageUtils.sniffImageType(buf)).equal("image/png");
+            done();
+        });
+
+        it("recognizes JPEG signature (FF D8 FF)", function(done) {
+            var buf = bufWith([0xFF, 0xD8, 0xFF, 0xE0]);
+            should(imageUtils.sniffImageType(buf)).equal("image/jpeg");
+            done();
+        });
+
+        it("recognizes GIF87a", function(done) {
+            // 'GIF87a' = 47 49 46 38 37 61
+            var buf = bufWith([0x47, 0x49, 0x46, 0x38, 0x37, 0x61]);
+            should(imageUtils.sniffImageType(buf)).equal("image/gif");
+            done();
+        });
+
+        it("recognizes GIF89a", function(done) {
+            var buf = bufWith([0x47, 0x49, 0x46, 0x38, 0x39, 0x61]);
+            should(imageUtils.sniffImageType(buf)).equal("image/gif");
+            done();
+        });
+
+        it("recognizes WebP (RIFF....WEBP)", function(done) {
+            var buf = bufWith([
+                0x52, 0x49, 0x46, 0x46, // RIFF
+                0x00, 0x00, 0x00, 0x00, // size placeholder
+                0x57, 0x45, 0x42, 0x50 // WEBP
+            ]);
+            should(imageUtils.sniffImageType(buf)).equal("image/webp");
+            done();
+        });
+
+        it("rejects HTML payloads", function(done) {
+            var html = Buffer.from("<!DOCTYPE html><html><body><script>alert(1)</script></body></html>", "utf8");
+            should(imageUtils.sniffImageType(html)).be.null();
+            done();
+        });
+
+        it("rejects SVG payloads (XML-based, not in allowlist)", function(done) {
+            var svg = Buffer.from('<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>', "utf8");
+            should(imageUtils.sniffImageType(svg)).be.null();
+            done();
+        });
+
+        it("rejects plain text", function(done) {
+            var txt = Buffer.from("just some text content here padding padding", "utf8");
+            should(imageUtils.sniffImageType(txt)).be.null();
+            done();
+        });
+
+        it("rejects empty buffer", function(done) {
+            should(imageUtils.sniffImageType(Buffer.alloc(0))).be.null();
+            done();
+        });
+
+        it("rejects buffer shorter than 12 bytes", function(done) {
+            should(imageUtils.sniffImageType(Buffer.from([0x89, 0x50, 0x4E, 0x47]))).be.null();
+            done();
+        });
+
+        it("rejects null / undefined input", function(done) {
+            should(imageUtils.sniffImageType(null)).be.null();
+            should(imageUtils.sniffImageType(undefined)).be.null();
+            done();
+        });
+
+        it("rejects PNG signature with corrupted byte", function(done) {
+            // Same as PNG but byte[7] flipped
+            var buf = bufWith([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x00]);
+            should(imageUtils.sniffImageType(buf)).be.null();
+            done();
+        });
+
+        it("rejects RIFF without WEBP marker (e.g. WAV file)", function(done) {
+            var buf = bufWith([
+                0x52, 0x49, 0x46, 0x46, // RIFF
+                0x00, 0x00, 0x00, 0x00,
+                0x57, 0x41, 0x56, 0x45 // WAVE - audio, not image
+            ]);
+            should(imageUtils.sniffImageType(buf)).be.null();
+            done();
+        });
+
+        it("rejects GIF8 followed by wrong version byte", function(done) {
+            // 47 49 46 38 38 61 — '8' is not 7 or 9, so not a real GIF
+            var buf = bufWith([0x47, 0x49, 0x46, 0x38, 0x38, 0x61]);
+            should(imageUtils.sniffImageType(buf)).be.null();
+            done();
+        });
+
+        it("does not sniff payload past the header", function(done) {
+            // Real GIF89a header followed by HTML — must still classify as gif
+            // and rely on Content-Type + nosniff + CSP to neutralize the trailing bytes.
+            var head = [0x47, 0x49, 0x46, 0x38, 0x39, 0x61];
+            var trailer = Buffer.from("<html><script>alert(1)</script></html>", "utf8");
+            var buf = Buffer.concat([Buffer.from(head), Buffer.alloc(20), trailer]);
+            should(imageUtils.sniffImageType(buf)).equal("image/gif");
+            done();
+        });
+    });
+
+    describe("parseFeedbackLogoName", function() {
+        it("accepts the literal global feedback_logo", function(done) {
+            var p = imageUtils.parseFeedbackLogoName("feedback_logo");
+            p.valid.should.be.true();
+            p.isGlobal.should.be.true();
+            should(p.appId).be.null();
+            done();
+        });
+
+        it("accepts feedback_logo<24-hex-app-id> as per-app", function(done) {
+            var appId = "0123456789abcdef01234567";
+            var p = imageUtils.parseFeedbackLogoName("feedback_logo" + appId);
+            p.valid.should.be.true();
+            p.isGlobal.should.be.false();
+            p.appId.should.equal(appId);
+            done();
+        });
+
+        it("rejects names with non-hex characters in the app id slot", function(done) {
+            var p = imageUtils.parseFeedbackLogoName("feedback_logoZZZZZZZZZZZZZZZZZZZZZZZZ");
+            p.valid.should.be.false();
+            done();
+        });
+
+        it("rejects uppercase hex in the app id slot", function(done) {
+            // App ids are always lowercase hex; uppercase hints at attacker fuzzing
+            var p = imageUtils.parseFeedbackLogoName("feedback_logoABCDEF0123456789ABCDEF01");
+            p.valid.should.be.false();
+            done();
+        });
+
+        it("rejects shorter or longer hex tails", function(done) {
+            imageUtils.parseFeedbackLogoName("feedback_logo0123").valid.should.be.false();
+            imageUtils.parseFeedbackLogoName("feedback_logo0123456789abcdef0123456789").valid.should.be.false();
+            done();
+        });
+
+        it("rejects path-traversal style names", function(done) {
+            imageUtils.parseFeedbackLogoName("../../etc/passwd").valid.should.be.false();
+            imageUtils.parseFeedbackLogoName("feedback_logo/../foo").valid.should.be.false();
+            done();
+        });
+
+        it("rejects HTML-bearing names", function(done) {
+            imageUtils.parseFeedbackLogoName("evil.html").valid.should.be.false();
+            imageUtils.parseFeedbackLogoName("<script>").valid.should.be.false();
+            done();
+        });
+
+        it("rejects empty / non-string input", function(done) {
+            imageUtils.parseFeedbackLogoName("").valid.should.be.false();
+            imageUtils.parseFeedbackLogoName(null).valid.should.be.false();
+            imageUtils.parseFeedbackLogoName(undefined).valid.should.be.false();
+            imageUtils.parseFeedbackLogoName(123).valid.should.be.false();
+            imageUtils.parseFeedbackLogoName({}).valid.should.be.false();
+            done();
+        });
+
+        it("rejects names with extra prefix or suffix", function(done) {
+            imageUtils.parseFeedbackLogoName("Xfeedback_logo").valid.should.be.false();
+            imageUtils.parseFeedbackLogoName("feedback_logo ").valid.should.be.false();
+            imageUtils.parseFeedbackLogoName(" feedback_logo").valid.should.be.false();
+            imageUtils.parseFeedbackLogoName("feedback_logo\n").valid.should.be.false();
+            done();
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Backport of three upstream security PRs to the **release.24.05** branch, plus a CHANGELOG entry for v24.05.50:

- **#7491** — Fix data migration path traversal (merged 2026-04-17): constrain export/import paths, add stream error handlers, introduce `common.resolvePathInBase` helper.
- **#7532** — Fix/feedback preview XSS (merged 2026-05-05): close stored XSS in star-rating feedback widget logo upload/preview; restrict to image MIME + magic-byte validation.
- **#7535** — Bug-bounty-style hardening pass (merged 2026-05-07): 4 Critical / 19 High / 11 Medium / 4 Low findings closed across auth, IDOR, NoSQL injection, SSRF, mass assignment, etc.

## What's in the branch (chronological order, ~50 commits)

**From #7491** (path-traversal + stream error handlers): 7 commits + helper consolidation
**From #7532** (star-rating XSS): 4 commits
**From #7535** (security hardening): 28 of 32 commits applied; 4 skipped/adapted (see below)

Plus PR-review fix-up commits and a CHANGELOG commit.

## #7535 cherry-pick decisions

**Applied as-is (24 commits):** H-5, C-2/C-3, C-4, H-6/M-6, H-4, H-1/H-2, H-3, H-9, H-17, H-15, H-14, H-8/M-12/M-16, H-21/H-22, H-23, H-16, L-4, L-6, M-7/M-9/M-10, M-1, M-2, H-20, plus 4 PR-review fix-up commits and the C-4 follow-up.

**Adapted for 24.05 (2 commits):**
- **C-1** — master uses a `whiteListedAggregationStages` mechanism (added by SER-2122 on master only) and removes `$graphLookup` from it. 24.05 has no whitelist at all (every aggregation stage allowed). Implemented a minimal targeted `$graphLookup` block in 24.05's `aggregate()` helper instead.
- **H-7** — master moves `plugins/hooks/api/ssrf-protection.js` → `api/utils/ssrf-protection.js`. 24.05 has no source file in the hooks plugin to move. Installed the SSRF protection module fresh from master's content; wired into `validateRedirect`; added `ipaddr.js` to root deps + lockfile. Hooks plugin's HTTPEffect remains unchanged in 24.05 (separate hardening if needed).

**Skipped — not applicable to 24.05 (4 commits):**
- **M-14** (drop `--disable-web-security`): the flag was never present in 24.05's puppeteer args. Added explanatory comment; nothing to remove.
- **M-11** (dbviewer non-admin filter scope `$and`): depends on master's `getBaseAppFilter` mechanism that 24.05 doesn't have. A broader 24.05 dbviewer hardening (porting SER-2122 + filter scope + M-11) is left for a separate change.
- **L-7** (drop wildcard CORS from reports preview/pdf): intentionally not backported — the wildcard is needed for puppeteer PDF rendering against `data:` URL documents. Same decision as master, where L-7 was reverted post-merge. The L-7 commit and its revert are both skipped (net effect identical to master).
- **chore: lockfile sync**: redundant — lockfile was already updated as part of the H-7 adaptation commit.

## Conflicts resolved during cherry-picks

- `plugins/dashboards/frontend/app.js` (#7491 backport): kept the new `if (!req || !req.params)` guard from incoming PR; removed pre-`safeStaticPath` lines.
- `api/utils/common.js` (#7491 backport): kept the 24.05 `var` declaration block, only added `path = require('path')` (not `semver`).
- `api/parts/mgmt/event_groups.js` (#7535 H-9): combined the new app_id-scope filter and field whitelist into the 24.05 `update()` shape.
- `api/utils/render.js` (#7535 M-14): replaced the master "removed --disable-web-security" comment with a 24.05-specific note explaining the flag never existed here.
- `api/utils/common.js` (#7491 backport): dropped the JSDoc `@type {import('../../types/common').Common}` since 24.05 has no `types/` directory.

## Changelog

`## Version 24.05.50` at the top of CHANGELOG.md now lists all backported security fixes per plugin/component, plus the per-finding 24.05-specific notes.

## Test plan

- [ ] CI lint + unit tests pass on this branch
- [ ] Manually verify: report PDF generation still works (sanity check on the L-7 skip decision — wildcard CORS still present, puppeteer can fetch sub-resources)
- [ ] Manually verify: star-rating feedback logo upload rejects non-image MIME types and SVG-with-script payloads
- [ ] Manually verify: data_migration export with `target_path` outside the allowed root is rejected; legitimate exports still work
- [ ] Manually verify the major findings: app-admin can no longer rewrite `owner`/`plugins.*` via `/i/apps/update`; tasks IDOR closed; push cross-app blocked; alerts cross-app blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)