### PR TITLE
docs(changelog): add drill contextual links and save-error fix entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## Version 25.03.X
 Enterprise Fixes:
 - [drill] Add query hint based on default indexes
+- [drill] Add contextual links in drill table for user IDs and crash groups
+- [drill] Resolve device IDs to user profiles via server-side redirect endpoint
+- [drill] Open crash group and user profile links in new tab
+- [drill] Show user-friendly error message when saving a query fails
 
 
 ## Version 25.03.43


### PR DESCRIPTION
## Summary

Adds CHANGELOG entries under the unreleased `25.03.X` section for the drill plugin fixes ported in [countly-enterprise-plugins#3148](https://github.com/Countly/countly-enterprise-plugins/pull/3148).

## Entries added

- [drill] Add contextual links in drill table for user IDs and crash groups
- [drill] Resolve device IDs to user profiles via server-side redirect endpoint
- [drill] Open crash group and user profile links in new tab
- [drill] Show user-friendly error message when saving a query fails