### PR TITLE
[security][backport 24.05] Fortify-flagged path traversal, XSS, and info-leak fixes

### DIFF
--- a/api/utils/common.js
+++ b/api/utils/common.js
@@ -1562,7 +1562,10 @@ common.returnRaw = function(params, returnCode, body, heads) {
         else {
             console.error("Output already closed, can't write more");
             console.trace();
-            console.log(params);
+            // Don't dump the full params object — req.body/req.headers can
+            // contain credentials, session cookies, or other secrets. Log
+            // only the pathname (query string can carry api_key/auth_token).
+            console.log({pathname: params.urlParts && params.urlParts.pathname, apiPath: params.apiPath, qstringKeys: params.qstring && Object.keys(params.qstring)});
         }
     }
 };
@@ -1625,7 +1628,10 @@ common.returnMessage = function(params, returnCode, message, heads, noResult = f
         else {
             console.error("Output already closed, can't write more");
             console.trace();
-            console.log(params);
+            // Don't dump the full params object — req.body/req.headers can
+            // contain credentials, session cookies, or other secrets. Log
+            // only the pathname (query string can carry api_key/auth_token).
+            console.log({pathname: params.urlParts && params.urlParts.pathname, apiPath: params.apiPath, qstringKeys: params.qstring && Object.keys(params.qstring)});
         }
     }
 };
@@ -1703,7 +1709,10 @@ common.returnOutput = function(params, output, noescape, heads) {
         else {
             console.error("Output already closed, can't write more");
             console.trace();
-            console.log(params);
+            // Don't dump the full params object — req.body/req.headers can
+            // contain credentials, session cookies, or other secrets. Log
+            // only the pathname (query string can carry api_key/auth_token).
+            console.log({pathname: params.urlParts && params.urlParts.pathname, apiPath: params.apiPath, qstringKeys: params.qstring && Object.keys(params.qstring)});
         }
     }
 };

--- a/frontend/express/app.js
+++ b/frontend/express/app.js
@@ -442,12 +442,25 @@ Promise.all([plugins.dbConnection(countlyConfig), plugins.dbConnection("countly_
         var urlPath = req.path.replace(countlyConfig.path, "");
         var theme = req.cookies.theme || curTheme;
         if (theme && theme.length && (req.path.indexOf(countlyConfig.path + '/images/') === 0 || req.path.indexOf(countlyConfig.path + '/geodata/') === 0)) {
-            // Both `theme` (cookie) and `urlPath` (URL) are user-controlled.
+            // The `theme` cookie is user-controlled. Restrict it to a plain
+            // filename (no separators, no leading dots, no nulls) before
+            // building the path. This is defense-in-depth on top of the
+            // `root` option below; reject anything that doesn't survive
+            // sanitizeFilename unchanged.
+            if (common.sanitizeFilename(theme) !== theme) {
+                next();
+                return;
+            }
             // Hand the relative path to res.sendFile with `root` set to
             // /public/themes — express normalizes the path and rejects any
             // `..` traversal before touching the filesystem. Missing files
-            // surface via the error callback and fall through to next().
+            // and traversal-blocked requests fall through to next(); other
+            // errors are logged server-side but still fall through so a
+            // theme misconfiguration doesn't 500 the page.
             res.sendFile(theme + urlPath, {root: path.resolve(__dirname, 'public/themes')}, function(err) {
+                if (err && err.code !== 'ENOENT' && err.statusCode !== 403 && err.statusCode !== 404) {
+                    log.e('Error serving theme image %j: %s', req.path, err.message);
+                }
                 if (err) {
                     next();
                 }

--- a/frontend/express/app.js
+++ b/frontend/express/app.js
@@ -439,14 +439,16 @@ Promise.all([plugins.dbConnection(countlyConfig), plugins.dbConnection("countly_
     app.use(cookieParser());
     //server theme images
     app.use(function(req, res, next) {
-        var urlPath = req.url.replace(countlyConfig.path, "");
+        var urlPath = req.path.replace(countlyConfig.path, "");
         var theme = req.cookies.theme || curTheme;
-        if (theme && theme.length && (req.url.indexOf(countlyConfig.path + '/images/') === 0 || req.url.indexOf(countlyConfig.path + '/geodata/') === 0)) {
-            fs.exists(__dirname + '/public/themes/' + theme + urlPath, function(exists) {
-                if (exists) {
-                    res.sendFile(__dirname + '/public/themes/' + theme + urlPath);
-                }
-                else {
+        if (theme && theme.length && (req.path.indexOf(countlyConfig.path + '/images/') === 0 || req.path.indexOf(countlyConfig.path + '/geodata/') === 0)) {
+            // Both `theme` (cookie) and `urlPath` (URL) are user-controlled.
+            // Hand the relative path to res.sendFile with `root` set to
+            // /public/themes — express normalizes the path and rejects any
+            // `..` traversal before touching the filesystem. Missing files
+            // surface via the error callback and fall through to next().
+            res.sendFile(theme + urlPath, {root: path.resolve(__dirname, 'public/themes')}, function(err) {
+                if (err) {
                     next();
                 }
             });

--- a/plugins/sdk/api/api.js
+++ b/plugins/sdk/api/api.js
@@ -27,7 +27,8 @@ plugins.register("/permissions/features", function(ob) {
                 common.returnOutput(params, config);
             })
                 .catch(function(err) {
-                    common.returnMessage(params, 400, 'Error: ' + err);
+                    console.error("Error retrieving SDK config", err);
+                    common.returnMessage(params, 400, 'Error retrieving SDK config');
                 })
                 .finally(function() {
                     resolve();
@@ -72,7 +73,8 @@ plugins.register("/permissions/features", function(ob) {
                     common.returnOutput(params, res.config || {});
                 })
                     .catch(function(err) {
-                        common.returnMessage(params, 400, 'Error: ' + err);
+                        console.error("Error retrieving SDK config", err);
+                        common.returnMessage(params, 400, 'Error retrieving SDK config');
                     });
             });
 

--- a/plugins/two-factor-auth/frontend/public/templates/enter2fa_login.html
+++ b/plugins/two-factor-auth/frontend/public/templates/enter2fa_login.html
@@ -88,8 +88,8 @@
                     <%- inject_template.form %>
                 <% } %>
                 <div>
-                    <input type="hidden" value="<%- username %>" name="username"/>
-                    <input type="hidden" value="<%- password %>" name="password"/>
+                    <input type="hidden" value="<%= username %>" name="username"/>
+                    <input type="hidden" value="<%= password %>" name="password"/>
                     <input type="hidden" value="<%= csrf %>" name="_csrf" />
                     <input type="hidden" value="en" name="lang" id="form-lang" />
                     <input id="login-button" value="Continue" type="submit" data-localize="two-factor-auth.continue"/>

--- a/plugins/two-factor-auth/frontend/public/templates/setup2fa.html
+++ b/plugins/two-factor-auth/frontend/public/templates/setup2fa.html
@@ -81,8 +81,8 @@
                     <% } %>
                     <div>
                         <input type="hidden" value="<%= secret_token %>" name="secret_token"/>
-                        <input type="hidden" value="<%- username %>" name="username"/>
-                        <input type="hidden" value="<%- password %>" name="password"/>
+                        <input type="hidden" value="<%= username %>" name="username"/>
+                        <input type="hidden" value="<%= password %>" name="password"/>
                         <input type="hidden" value="<%= csrf %>" name="_csrf" />
                         <input type="hidden" value="en" name="lang" id="form-lang" />
                     </div>


### PR DESCRIPTION
## Summary
Backport of [#7547](https://github.com/Countly/countly-server/pull/7547) to `release.24.05`.

Addresses real findings from a customer Fortify scan against this branch. False positives and out-of-repo (enterprise plugin / Web SDK) findings will be answered separately to the customer with technical justifications.

### Fixes

- **Path traversal — `frontend/express/app.js`**
  Theme image handler built `sendFile` path from `req.cookies.theme + req.url` with only a prefix check on `/images/` or `/geodata/`. A URL like `/images/../../../etc/passwd` (or a malicious `theme` cookie) escaped the themes directory. Now uses `res.sendFile` with the `root` option — express normalizes the path and rejects `..` traversal natively (recognized by CodeQL as a sanitizer). Also switched `req.url` → `req.path` so query strings don't bleed into the filesystem lookup.

- **Reflected XSS — `plugins/two-factor-auth setup2fa.html / enter2fa_login.html`**
  Hidden `username` / `password` inputs used unescaped EJS (`<%-`). A username containing `\"><script>` broke out of the attribute and executed in the login origin. Switched to escaped `<%=`. (`secret_token` already used `<%=`.)

- **Sensitive data in logs — `api/utils/common.js`**
  `returnRaw` / `returnMessage` / `returnOutput` dumped the entire `params` object (incl. `req.body`, `req.headers` — passwords, session cookies) on the \"output already closed\" branch. Replaced with a non-sensitive summary (`pathname`, `apiPath`, `qstringKeys`). **Note:** 24.05 has three sites here versus two on master — `returnRaw` exists in this branch and was fixed for consistency.

- **Internal error leak to client — `plugins/sdk/api/api.js`**
  SDK config endpoints echoed `'Error: ' + err` to clients. Now log details server-side via `console.error` and return a generic `'Error retrieving SDK config'`.

### Differences from #7547
- `common.js` fix covers three call sites in 24.05 vs two in master (`returnRaw` was removed/refactored on master).
- All four fixes were rebased onto 24.05's slightly older surrounding code; no logic differences.

## Test plan
- [ ] Hit `/images/../../../etc/passwd` (and via crafted `theme` cookie) — verify `next()` is called instead of `sendFile`
- [ ] Log in with a 2FA-enabled user whose username contains `\"><script>alert(1)</script>` — verify it renders as text in the hidden input value, not as a script
- [ ] Trigger SDK config error path — verify client receives `\"Error retrieving SDK config\"`, server logs the underlying error
- [ ] Force the \"output already closed\" branch in `returnMessage`/`returnOutput`/`returnRaw` — verify the log line no longer contains password/cookie material

🤖 Generated with [Claude Code](https://claude.com/claude-code)