### PR TITLE
fix(notes): accept numeric color in saveNote schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Version 25.03.X
+Fixes:
+- [core] Accept numeric color in saveNote schema so graph note create/edit no longer fails validation
+
 Enterprise Fixes:
 - [drill] Add query hint based on default indexes
 - [drill] Add contextual links in drill table for user IDs and crash groups

--- a/api/parts/mgmt/users.js
+++ b/api/parts/mgmt/users.js
@@ -911,8 +911,11 @@ usersApi.saveNote = async function(params) {
             'type': 'String',
         },
         'color': {
+            // Frontend (countly.common.notes.js COLOR_TAGS) sends a numeric
+            // index 1..5. URL query callers may send "5" as a string.
+            // Mirror the ts handling — IntegerString accepts both.
             'required': true,
-            'type': 'String'
+            'type': 'IntegerString'
         },
         'category': {
             'required': false,


### PR DESCRIPTION
## Summary
- `saveNote` schema declared `color` as `String` but the dashboard (`countly.common.notes.js` `COLOR_TAGS`) sends a numeric index `1..5`. Validation stayed dormant until H-5 started enforcing `validateArgs`, after which every create/edit failed with `Invalid type for color`.
- Switched `color` to `IntegerString` so both Number (JSON body) and numeric string (URL query) are accepted.
- Added a `[core]` entry under 25.03.X in CHANGELOG.

Slack context: https://countly.slack.com/archives/CV9KV4UQ1/p1779195915103949
Ports: Countly/countly-platform#280

## Test plan
- [ ] Create a graph note from the dashboard → 200 Success (was 400 'Invalid type for color')
- [ ] Edit an existing graph note → 200 Success
- [ ] Direct API call with `color: 5` (number) succeeds
- [ ] Direct API call with `color: "5"` (string) still succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)