### PR TITLE
docs(changelog): note groups findGroups legacy group_id fix under 25.03.X

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Version 25.03.X
 Fixes:
 - [core] Accept numeric color in saveNote schema so graph note create/edit no longer fails validation
+- [groups] Tolerate legacy string `group_id` on members in findGroups aggregation so the groups listing, User Management, Alerts and Preset Management pages no longer 400 with MongoDB Location40081 on tenants with pre-2021 data
 
 ## Version 25.03.44
 Security fixes:


### PR DESCRIPTION
## Summary

Adds a 25.03.X changelog entry for the groups `findGroups` legacy `group_id` regression fix. The actual code change lives in the plugins repo (see "Related" below) — this PR only updates `CHANGELOG.md` so the next 25.03.X release notes reflect the fix.

## Why

Two customers hit `MongoServerError: ... $in requires an array as a second argument, found: string` (Mongo `Location40081`) after upgrading to v25.03.43, breaking the groups listing, User Management, Alerts and Preset Management screens. The new `$lookup` pipeline introduced in countly-platform `6fe036e3ad` does `$in: ["$$group_id", { $ifNull: ["$group_id", []] }]` against `members.group_id`, which throws when the field is a string (pre-2021 schema, before `d66a83b096`).

## Related

- Code fix + integration test: countly-enterprise-plugins PR https://github.com/Countly/countly-enterprise-plugins/pull/3179
- OSS mirror: countly-platform PR https://github.com/Countly/countly-platform/pull/295

## Tests

No code changes here — `CHANGELOG.md` only. The fix itself is covered by a new `Legacy string group_id tolerance` integration test in the plugins PR.