### PR TITLE
Backport saveNote ts/color IntegerString fixes to feature/new-ui-dw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Security Fixes (backport of #7535 — bug-bounty-style hardening pass):
 - [output] Remove `noescape` query-string bypass on `returnOutput` (reflected-XSS via parameter)
 - [auth] Handle `req.session.regenerate` error in token login
 - [data] Return 404 (not 500) when `event_groups` lookup misses
+- [notes] Accept numeric color in saveNote schema so graph note create/edit no longer fails validation after H-5 enforcement (backport of #7578)
 
 24.05-specific notes (some master fixes were not directly applicable):
 - C-1 (`$graphLookup`) and M-11 (dbviewer non-admin filter scope): master uses a `whiteListedAggregationStages` mechanism (added by SER-2122) and a `getBaseAppFilter` per-collection app-id mechanism that 24.05 does not have. C-1 is implemented as a minimal targeted block; M-11 is not applicable here. A broader 24.05 dbviewer hardening (porting SER-2122 + filter scope + M-11) is left for a separate change.

--- a/api/parts/mgmt/users.js
+++ b/api/parts/mgmt/users.js
@@ -901,7 +901,7 @@ usersApi.saveNote = async function(params) {
         },
         'ts': {
             'required': true,
-            'type': ''
+            'type': 'IntegerString'
         },
         'noteType': {
             'required': true,

--- a/api/parts/mgmt/users.js
+++ b/api/parts/mgmt/users.js
@@ -908,8 +908,11 @@ usersApi.saveNote = async function(params) {
             'type': 'String',
         },
         'color': {
+            // Frontend (countly.common.notes.js COLOR_TAGS) sends a numeric
+            // index 1..5. URL query callers may send "5" as a string.
+            // Mirror the ts handling — IntegerString accepts both.
             'required': true,
-            'type': 'String'
+            'type': 'IntegerString'
         },
         'category': {
             'required': false,


### PR DESCRIPTION
## Summary
Same two commits as the 24.05 backport in #7593, but cherry-picked directly onto `feature/new-ui-dw` so the customer branch picks up the saveNote validation regression fixes:

- [`b3f9d0f`](https://github.com/Countly/countly-server/commit/b3f9d0f6fe8) fix(notes): accept numeric color in saveNote schema (PR #7578)
- [`0b6cea6`](https://github.com/Countly/countly-server/commit/0b6cea6cd756e446315fc11052d80d1aabba3ef4) Change 'ts' type from empty to 'IntegerString'

Background: H-5 (`saveNote` schema enforcement) was just merged into this branch via #7568. Without these follow-ups, graph note create/edit fails validation because the dashboard sends numeric `color` (1..5) and numeric `ts`.

Companion PR to release.24.05: #7593.

## Conflict resolution
- `api/parts/mgmt/users.js`: applied cleanly.
- `CHANGELOG.md`: master's `25.03.X` heading replaced with an entry under the existing `24.05.50` Security Fixes block (this is a follow-up to the H-5 fix listed there).

## Test plan
- [ ] Create a graph note from the dashboard — succeeds
- [ ] Edit an existing graph note — succeeds
- [ ] Schema still rejects truly invalid color/ts payloads (e.g. `color: "abc"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)