### PR TITLE
security: fix stored XSS in remote-config condition definition

### DIFF
--- a/plugins/remote-config/frontend/public/templates/conditions.html
+++ b/plugins/remote-config/frontend/public/templates/conditions.html
@@ -26,7 +26,7 @@
         </el-table-column>
         <el-table-column test-id="condition" prop="condition_definition" :label="i18n('remote-config.definition')">
           <template v-slot:default="rowScope">
-            <div :data-test-id="'datatable-condition-description-' + rowScope.$index" v-html="rowScope.row.condition_definition"></div>
+            <div :data-test-id="'datatable-condition-description-' + rowScope.$index" v-text="rowScope.row.condition_definition"></div>
           </template>
         </el-table-column>
         <el-table-column test-id="condition" prop="seed_value" :label="i18n('remote-config.seed-value')">


### PR DESCRIPTION
## Summary

Fixes a **stored XSS** in the `remote-config` plugin, reported via the security program (validated against master).

`condition_definition` is stored verbatim from `POST /i/remote-config/add-condition` / `update-condition` — the handlers validate `condition_name` (alphanumeric) and `condition_color` but never sanitize `condition_definition`. The conditions table then rendered it with **`v-html`**:

```html
<!-- plugins/remote-config/frontend/public/templates/conditions.html:29 -->
<div ... v-html="rowScope.row.condition_definition"></div>
```

`v-html` assigns to `innerHTML`, so a stored payload like `<img src=x onerror=...>` executes when another dashboard user opens the Remote Config Conditions view for that app.

## Impact

- **Attacker:** any user with the assignable `remote_config` create/update permission on an app.
- **Victim:** any user who opens that app's conditions view — including an app admin or **global admin**, whose session the injected script then runs in (same-origin dashboard/API access). Low-privilege → admin privilege escalation.

## Fix

Render `condition_definition` with `v-text` instead of `v-html`. It's a query-builder **display string** (e.g. `"Device = Asus Nexus 10"`), never intended to be HTML — so text rendering loses no functionality and additionally fixes display of query text containing `<`/`>` comparison operators. It was the only `v-html` sink in the plugin.

## Severity

High (per [SECURITY.md](https://github.com/Countly/countly-server/blob/master/SECURITY.md)) — stored XSS requiring victim action (opening the view), with privilege-escalation potential into an admin session.

## Testing note

The fix is in DOM rendering (Vue template), so the meaningful regression test is a Cypress UI spec under `ui-tests/cypress/.../remoteConfig` asserting an injected payload renders as inert text. Recommended as a follow-up (separate UI-test harness). The fix itself follows directly from Vue semantics: `v-text` sets `textContent` and never parses HTML.

Reported by: external researcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)