### PR TITLE
security: prevent JS injection via redirect_url in migration mongo --eval

### DIFF
--- a/plugins/data_migration/api/data_migration_helper.js
+++ b/plugins/data_migration/api/data_migration_helper.js
@@ -542,7 +542,12 @@ module.exports = function(my_db) {
                         //remove redirect field and add it after dump.
                         scripts.push({cmd: 'mongo', args: [countly_db_name, ...dbargs0, "--eval", 'db.apps.update({ "_id": ObjectId("' + appid + '")}, { "$unset": { "redirect_url": 1 } })']});
                         scripts.push({cmd: 'mongodump', args: [...dbargs, "--collection", "apps", "-q", '{ "_id": {"$oid":"' + appid + '"}}', "--out", my_folder]});
-                        scripts.push({cmd: 'mongo', args: [countly_db_name, ...dbargs0, "--eval", 'db.apps.update({ "_id": ObjectId("' + appid + '")}, { $set: { redirect_url: "' + res.redirect_url + '" } })']});
+                        //JSON.stringify the redirect_url so it becomes a safely
+                        //escaped JS string literal - it is a user-settable app
+                        //field and was previously interpolated raw into the
+                        //mongo --eval script, allowing JS injection into the
+                        //mongo shell (full-DB access).
+                        scripts.push({cmd: 'mongo', args: [countly_db_name, ...dbargs0, "--eval", 'db.apps.update({ "_id": ObjectId("' + appid + '")}, { $set: { redirect_url: ' + JSON.stringify(res.redirect_url + "") + ' } })']});
                     }
 
                     var appDocs = ['app_users', 'metric_changes', 'app_crashes', 'app_crashgroups', 'app_crashusers', 'app_nxret', 'app_viewdata', 'app_views', 'app_userviews', 'app_viewsmeta', 'blocked_users', 'campaign_users', 'consent_history', 'crashes_jira', 'event_flows', 'timesofday', 'feedback', 'push_', 'apm', "nps", "survey", "completed_surveys"];


### PR DESCRIPTION
## Summary

Found by the injection endpoint census. `create_export_commands` (data migration) interpolated the app's `redirect_url` **raw** into a `mongo --eval` JavaScript string:

```js
scripts.push({cmd: 'mongo', args: [..., "--eval",
  'db.apps.update({ "_id": ObjectId("' + appid + '")}, { $set: { redirect_url: "' + res.redirect_url + '" } })']});
```

`redirect_url` is a user-settable app field validated only as `type:String` (no URL/format check, see `api/parts/mgmt/apps.js`). A crafted value containing a `"` breaks out of the string literal and injects arbitrary JavaScript into the **mongo shell**, which runs with full database access when a redirect-enabled export executes. Because `redirect_url` is settable by an app-admin and the export can be self-triggered by a user holding both app-admin and the assignable `data_migration` permission, this is an **app-scoped → full-DB privilege escalation**.

## Fix

Encode the value with `JSON.stringify(res.redirect_url + "")` so it becomes a properly escaped JS string literal (the payload becomes inert data). The adjacent `appid` is a validated 24-hex ObjectId and is safe.

## Severity

High (requires app-admin to set `redirect_url` + a redirect export to run; both are reachable by a sufficiently-permissioned non-global-admin → arbitrary mongo-shell JS = full DB read/write).

## Note (separate follow-up)

The census also flagged that the `$where/$expr/$function/$accumulator` sanitizer `common.stripUnsafeMongoOperators` is applied in some query endpoints (app_users, logger, compliance-hub) but **not** in others that `JSON.parse` a user `query`/`filter` (crashes, systemlogs, fetch, cms). Those are app-scoped and `$where` requires server-side JS to be enabled, so it's lower severity — recommended as a defense-in-depth follow-up to apply the sanitizer consistently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)