### PR TITLE
security: cast app_key to string before apps lookup (NoSQL operator injection on /o/sdk)

### DIFF
--- a/api/utils/requestProcessor.js
+++ b/api/utils/requestProcessor.js
@@ -3627,7 +3627,7 @@ const validateAppForFetchAPI = (params, done, try_times) => {
     if (ignorePossibleDevices(params)) {
         return done ? done() : false;
     }
-    common.readBatcher.getOne("apps", {'key': params.qstring.app_key}, (err, app) => {
+    common.readBatcher.getOne("apps", {'key': params.qstring.app_key + ""}, (err, app) => {
         if (!app) {
             common.returnMessage(params, 400, 'App does not exist');
             params.cancelRequest = "App not found or no Database connection";

--- a/plugins/logger/api/api.js
+++ b/plugins/logger/api/api.js
@@ -313,7 +313,7 @@ plugins.setConfigs("logger", {
             processSDKRequest(params);
         }
         else {
-            common.db.collection('apps').findOne({'key': params.qstring.app_key}, (err, app) => {
+            common.db.collection('apps').findOne({'key': params.qstring.app_key + ""}, (err, app) => {
                 if (!err && app) {
                     params.app_id = app._id;
                     params.app_cc = app.country;

--- a/plugins/views/api/api.js
+++ b/plugins/views/api/api.js
@@ -1566,7 +1566,7 @@ const escapedViewSegments = { "name": true, "segment": true, "height": true, "wi
 
         if (common.drillDb && params.qstring && params.qstring.view) {
             if (params.req.headers["countly-token"]) {
-                common.readBatcher.getOne("apps", {'key': params.qstring.app_key}, (err1, app) => {
+                common.readBatcher.getOne("apps", {'key': params.qstring.app_key + ""}, (err1, app) => {
                     if (!app) {
                         common.returnMessage(params, 401, 'User does not have view right for this application');
                         return false;

--- a/test/2.api/12.fail.sdk.appkey.injection.js
+++ b/test/2.api/12.fail.sdk.appkey.injection.js
@@ -1,0 +1,33 @@
+var request = require('supertest');
+var should = require('should');
+var testUtils = require("../testUtils");
+request = request(testUtils.url);
+
+var APP_KEY = "";
+
+// Regression test for the NoSQL operator-injection / boolean-oracle on the
+// SDK fetch path. Passing app_key as a Mongo operator object (e.g.
+// {"$regex":"^a"}) must NOT be honored as a query operator: the value is cast
+// to a string before the apps lookup, so an operator can never match a real
+// app_key and the response must not differ based on a matching prefix.
+describe('SDK app_key NoSQL injection', function() {
+    describe('app_key as $regex operator on /o/sdk fetch', function() {
+        it('should not be treated as a query operator (no boolean oracle)', function(done) {
+            APP_KEY = testUtils.get("APP_KEY");
+            // ^<first char of the real app key> would match the real app if the
+            // operator were honored. After casting it must never match.
+            var prefix = "^" + (APP_KEY ? APP_KEY.charAt(0) : "a");
+            request
+                .get('/o/sdk?method=fetch_remote_config&device_id=injection_probe&app_key[$regex]=' + encodeURIComponent(prefix))
+                .expect(400)
+                .end(function(err, res) {
+                    if (err) {
+                        return done(err);
+                    }
+                    var ob = JSON.parse(res.text);
+                    ob.should.have.property('result', 'App does not exist');
+                    done();
+                });
+        });
+    });
+});


### PR DESCRIPTION
## Summary

The SDK fetch path (`validateAppForFetchAPI` in `api/utils/requestProcessor.js`) and two plugin app lookups (`logger` `/sdk/cancel`, `views` `/o/actions`) queried the `apps` collection with the raw, user-supplied `app_key`. A non-string value such as `{"$regex":"^a"}` was passed straight through to MongoDB as a query operator.

On `/o/sdk` this produced an unauthenticated **boolean oracle**: HTTP 200 when the regex matched an existing `app_key`, HTTP 400 (`App does not exist`) when it did not. An attacker could extract any app's `app_key` character-by-character, then use it for unauthenticated write ingestion (event/session injection, analytics pollution) on `/i`.

`common.stripUnsafeMongoOperators` only strips `$where/$expr/$function/$accumulator`, so it did not catch `$regex` here.

## Fix

Cast `app_key` to a string at all three lookup sites (`params.qstring.app_key + ""`), matching the already-safe write path `validateAppForWriteAPI`. Operator objects can no longer be honored.

- `api/utils/requestProcessor.js:3630` (`validateAppForFetchAPI`)
- `plugins/logger/api/api.js:316` (`/sdk/cancel`)
- `plugins/views/api/api.js:1569` (`/o/actions`)

## Test

Adds `test/2.api/12.fail.sdk.appkey.injection.js`: sends `app_key[$regex]=^<real key prefix>` to `/o/sdk` fetch and asserts `400 App does not exist` rather than a prefix match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)