### PR TITLE
ssrf-protection: pin resolved IP at connect time

### DIFF
--- a/api/utils/ssrf-protection.js
+++ b/api/utils/ssrf-protection.js
@@ -202,9 +202,65 @@ async function isUrlSafe(urlString) {
 }
 
 /**
+ * Build a blocked-target error for the connect-time lookup guard.
+ * @param {string} hostname - hostname being resolved
+ * @param {string} address - resolved IP that was blocked
+ * @returns {Error} error with an identifiable code
+ */
+function blockedLookupError(hostname, address) {
+    const err = new Error(`Blocked SSRF target: "${hostname}" resolved to private/reserved IP "${address}"`);
+    err.code = 'ESSRFBLOCKED';
+    return err;
+}
+
+/**
+ * A dns.lookup-compatible function that resolves a hostname and then rejects
+ * the lookup if the resolved address is private/reserved/internal. Passing this
+ * as the `lookup` option of an HTTP request (got, node http/https) validates the
+ * IP AT CONNECT TIME, which closes the DNS-rebinding (TOCTOU) gap left by a
+ * parse-time-only check: even if a name resolves to a safe IP during isUrlSafe
+ * and to an internal IP a moment later, the socket only ever connects to an
+ * address that passed isBlockedIP here.
+ *
+ * @param {string} hostname - hostname to resolve
+ * @param {object|function} options - dns.lookup options, or the callback
+ * @param {function} [callback] - callback(err, address, family)
+ * @returns {void}
+ */
+function safeLookup(hostname, options, callback) {
+    if (typeof options === 'function') {
+        callback = options;
+        options = {};
+    }
+    options = options || {};
+    dns.lookup(hostname, options, function(err, address, family) {
+        if (err) {
+            return callback(err);
+        }
+        // options.all === true -> address is an array of {address, family}
+        if (options.all) {
+            const list = Array.isArray(address) ? address : [address];
+            for (let i = 0; i < list.length; i++) {
+                if (isBlockedIP(list[i].address)) {
+                    return callback(blockedLookupError(hostname, list[i].address));
+                }
+            }
+            return callback(null, list);
+        }
+        if (isBlockedIP(address)) {
+            return callback(blockedLookupError(hostname, address));
+        }
+        callback(null, address, family);
+    });
+}
+
+/**
  * Build got-compatible request options with SSRF protection baked in.
  *
- * Disables redirects to prevent redirect-based SSRF bypasses.
+ * Disables redirects to prevent redirect-based SSRF bypasses, and pins DNS
+ * resolution through safeLookup so the connected IP is validated at connect
+ * time (DNS-rebinding protection). Callers that issue requests via raw node
+ * http/https can pass `lookup: safeLookup` directly.
  *
  * @param {object} requestOptions - base request options (uri, timeout, headers, etc.)
  * @returns {object} the same options object with SSRF settings injected
@@ -215,10 +271,14 @@ function getSsrfSafeOptions(requestOptions) {
     // Disable redirects entirely — prevents redirect-based SSRF bypasses
     options.followRedirect = false;
 
+    // Validate the resolved IP at connect time (DNS-rebinding protection)
+    options.lookup = safeLookup;
+
     return options;
 }
 
 module.exports = {
     isUrlSafe,
     getSsrfSafeOptions,
+    safeLookup,
 };

--- a/test/unit-tests/api.utils.ssrf-protection.js
+++ b/test/unit-tests/api.utils.ssrf-protection.js
@@ -1,0 +1,61 @@
+var should = require("should");
+var ssrf = require("../../api/utils/ssrf-protection");
+
+// These tests use IP literals only, so isUrlSafe and safeLookup do not perform
+// any network DNS resolution and the assertions are deterministic.
+describe("SSRF protection utility", function() {
+    describe("isUrlSafe", function() {
+        it("blocks the cloud metadata address", async function() {
+            (await ssrf.isUrlSafe("http://169.254.169.254/latest/meta-data/")).safe.should.equal(false);
+        });
+        it("blocks loopback", async function() {
+            (await ssrf.isUrlSafe("http://127.0.0.1/")).safe.should.equal(false);
+        });
+        it("blocks private ranges", async function() {
+            (await ssrf.isUrlSafe("http://10.0.0.1/")).safe.should.equal(false);
+            (await ssrf.isUrlSafe("http://192.168.1.1/")).safe.should.equal(false);
+        });
+        it("blocks non-http(s) protocols", async function() {
+            (await ssrf.isUrlSafe("ftp://8.8.8.8/")).safe.should.equal(false);
+        });
+        it("blocks embedded credentials", async function() {
+            (await ssrf.isUrlSafe("http://user:pass@8.8.8.8/")).safe.should.equal(false);
+        });
+        it("allows a public IP literal", async function() {
+            (await ssrf.isUrlSafe("http://8.8.8.8/")).safe.should.equal(true);
+        });
+    });
+
+    describe("safeLookup (connect-time DNS pinning)", function() {
+        it("rejects a blocked resolved IP", function(done) {
+            ssrf.safeLookup("127.0.0.1", {}, function(err, address) {
+                should.exist(err);
+                err.code.should.equal("ESSRFBLOCKED");
+                should.not.exist(address);
+                done();
+            });
+        });
+        it("allows a public IP", function(done) {
+            ssrf.safeLookup("8.8.8.8", {}, function(err, address) {
+                should.not.exist(err);
+                address.should.equal("8.8.8.8");
+                done();
+            });
+        });
+        it("supports the (hostname, callback) signature", function(done) {
+            ssrf.safeLookup("10.0.0.1", function(err) {
+                should.exist(err);
+                err.code.should.equal("ESSRFBLOCKED");
+                done();
+            });
+        });
+    });
+
+    describe("getSsrfSafeOptions", function() {
+        it("disables redirects and pins the lookup", function() {
+            var opts = ssrf.getSsrfSafeOptions({uri: "http://8.8.8.8/"});
+            opts.followRedirect.should.equal(false);
+            opts.lookup.should.equal(ssrf.safeLookup);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Hardens the shared `api/utils/ssrf-protection` module. `isUrlSafe` validates a URL by resolving DNS at parse time, but the subsequent request re-resolves the name independently, leaving a DNS-rebinding (TOCTOU) window: a hostname can resolve to a public IP during the check and to an internal IP a moment later, at connect time.

## Change

- Add `safeLookup`, a `dns.lookup`-compatible function that re-checks the resolved address against the private/reserved blocklist **at connect time** and fails the connection if it is blocked (handles the `(hostname, callback)` and `(hostname, options, callback)` signatures and `options.all`).
- Wire `safeLookup` into `getSsrfSafeOptions` via the `lookup` option. Every caller that already builds options through `getSsrfSafeOptions` inherits connect-time pinning automatically:
  - `redirect_url` validation (`api/utils/requestProcessor.js`)
  - hooks HTTP effect (`plugins/hooks/api/parts/effects/http.js`)
- `countly-request` is built on `got`, which honors a custom `lookup`; unknown options pass straight through `convertOptionsToGot`.
- Raw `http/https` callers can pass `lookup: safeLookup` directly (e.g. the push media fetch, which can adopt it on top of its `isUrlSafe` gate).

## Tests

`test/unit-tests/api.utils.ssrf-protection.js` (IP-literal based, no network): metadata/loopback/private/protocol/credentials blocking, public-IP allow, `safeLookup` block/allow and both call signatures, and that `getSsrfSafeOptions` disables redirects and pins the lookup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)