### PR TITLE
reports: preserve report owner on update

### DIFF
--- a/plugins/reports/api/api.js
+++ b/plugins/reports/api/api.js
@@ -303,6 +303,11 @@ const FEATURE_NAME = 'reports';
                 props = params.qstring.args;
                 var id = props._id;
                 delete props._id;
+                //the report owner is set at creation and must not be changed on
+                //update: repointing it to an unresolvable id would make the
+                //scheduled sender fall back to a global admin and render the
+                //report (e.g. a dashboard) with elevated access
+                delete props.user;
                 if (props.frequency !== "daily" && props.frequency !== "weekly" && props.frequency !== "monthly") {
                     delete props.frequency;
                 }

--- a/plugins/reports/tests.js
+++ b/plugins/reports/tests.js
@@ -93,6 +93,34 @@ describe('Testing Reports', function() {
                     });
             });
 
+            it('should not change the report owner on update', function(done) {
+                const reportID = reports[0]._id;
+                const originalUser = reports[0].user + "";
+                const bogusUser = "000000000000000000000000";
+                const reportConfig = Object.assign({}, reports[0], {user: bogusUser});
+                request.get(getRequestURL('/i/reports/update') + "&args=" + encodeURIComponent(JSON.stringify(reportConfig)))
+                    .expect(200)
+                    .end(function(err) {
+                        if (err) {
+                            return done(err);
+                        }
+                        request.get(getRequestURL('/o/reports/all'))
+                            .expect(200)
+                            .end(function(err2, res) {
+                                if (err2) {
+                                    return done(err2);
+                                }
+                                var updated = res.body.filter(function(r) {
+                                    return r._id === reportID;
+                                })[0];
+                                should.exist(updated);
+                                (updated.user + "").should.not.equal(bogusUser);
+                                (updated.user + "").should.equal(originalUser);
+                                done();
+                            });
+                    });
+            });
+
             it('should able to change report status', function(done) {
                 const reportID = reports[0]._id;
                 request.get(getRequestURL('/i/reports/status') + "&args=" + encodeURIComponent(JSON.stringify({[reportID]: false})))


### PR DESCRIPTION
## Summary

A scheduled report's owner (`user`) is set when the report is created and should be immutable thereafter. The `update` handler in `plugins/reports/api/api.js` applied the raw request args to the document, so `user` could be reassigned on update.

If `user` is repointed to an id that no longer resolves to a member, the scheduled sender (`reports.getReport`) falls back to the first global administrator and renders the report under that identity. For dashboard reports, that means a server-side render with global-admin access, which can capture content the report's actual owner is not authorized to see.

## Fix

Drop `user` from the update payload so the owner assigned at creation stays fixed. The create path already pins `user` to the creating member; this makes update consistent.

This keeps the existing behavior for genuinely orphaned reports (a real owner deletion is handled separately) and does not change the global-admin fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)