### PR TITLE
api: return uniform response for unverified SDK requests

### DIFF
--- a/api/utils/requestProcessor.js
+++ b/api/utils/requestProcessor.js
@@ -3363,7 +3363,10 @@ const checksumSaltVerification = (params) => {
                 payloads[i] = common.crypto.createHash('sha1').update(payloads[i] + params.app.checksum_salt).digest('hex').toUpperCase();
             }
             if (payloads.indexOf((params.qstring.checksum + "").toUpperCase()) === -1) {
-                common.returnMessage(params, 200, 'Request does not match checksum');
+                //return the same response as an unknown app so a valid app key
+                //with a wrong/absent checksum cannot be distinguished from an
+                //invalid app key (avoids an app key validity oracle)
+                common.returnMessage(params, 400, 'App does not exist');
                 console.log("Checksum did not match", params.href, params.req.body, payloads);
                 params.cancelRequest = 'Request does not match checksum sha1';
                 plugins.dispatch("/sdk/cancel", {params: params});
@@ -3376,7 +3379,10 @@ const checksumSaltVerification = (params) => {
                 payloads[i] = common.crypto.createHash('sha256').update(payloads[i] + params.app.checksum_salt).digest('hex').toUpperCase();
             }
             if (payloads.indexOf((params.qstring.checksum256 + "").toUpperCase()) === -1) {
-                common.returnMessage(params, 200, 'Request does not match checksum');
+                //return the same response as an unknown app so a valid app key
+                //with a wrong/absent checksum cannot be distinguished from an
+                //invalid app key (avoids an app key validity oracle)
+                common.returnMessage(params, 400, 'App does not exist');
                 console.log("Checksum did not match", params.href, params.req.body, payloads);
                 params.cancelRequest = 'Request does not match checksum sha256';
                 plugins.dispatch("/sdk/cancel", {params: params});
@@ -3384,7 +3390,8 @@ const checksumSaltVerification = (params) => {
             }
         }
         else {
-            common.returnMessage(params, 200, 'Request does not have checksum');
+            //same uniform response as above (no app key validity oracle)
+            common.returnMessage(params, 400, 'App does not exist');
             console.log("Request does not have checksum", params.href, params.req.body);
             params.cancelRequest = "Request does not have checksum";
             plugins.dispatch("/sdk/cancel", {params: params});

--- a/api/utils/requestProcessor.js
+++ b/api/utils/requestProcessor.js
@@ -3519,14 +3519,17 @@ const validateAppForWriteAPI = (params, done, try_times) => {
         }
 
         if (app.paused) {
-            common.returnMessage(params, 400, 'App is currently not accepting data');
+            //return the same response as an unknown app so a valid app key for
+            //a paused app cannot be distinguished from an invalid one
+            common.returnMessage(params, 400, 'App does not exist');
             params.cancelRequest = "App is currently not accepting data";
             plugins.dispatch("/sdk/cancel", {params: params});
             return done ? done() : false;
         }
 
         if ((params.populator || params.qstring.populator) && app.locked) {
-            common.returnMessage(params, 403, "App is locked");
+            //same uniform response (no app key existence oracle)
+            common.returnMessage(params, 400, 'App does not exist');
             params.cancelRequest = "App is locked";
             plugins.dispatch("/sdk/cancel", {params: params});
             return false;

--- a/test/3.api.write/8.checksums.js
+++ b/test/3.api.write/8.checksums.js
@@ -46,14 +46,14 @@ describe("Testing checksum validations", function() {
             request
                 .get("/i")
                 .query({device_id: DEVICE_ID, app_key: APP_KEY})
-                .expect(200)
+                .expect(400)
                 .end(function(error, response) {
                     if (error) {
                         return done(error);
                     }
 
                     const responseObject = JSON.parse(response.text);
-                    responseObject.should.have.property("result", "Request does not have checksum");
+                    responseObject.should.have.property("result", "App does not exist");
                     setTimeout(done, 1000 * testUtils.testScalingFactor);
                 });
         });
@@ -66,14 +66,14 @@ describe("Testing checksum validations", function() {
             request
                 .get("/i")
                 .query({device_id: DEVICE_ID, app_key: APP_KEY, checksum: checksum}).sortQuery()
-                .expect(200)
+                .expect(400)
                 .end(function(error, response) {
                     if (error) {
                         return done(error);
                     }
 
                     const responseObject = JSON.parse(response.text);
-                    responseObject.should.have.property("result", "Request does not match checksum");
+                    responseObject.should.have.property("result", "App does not exist");
                     setTimeout(done, 1000 * testUtils.testScalingFactor);
                 });
         });
@@ -86,14 +86,14 @@ describe("Testing checksum validations", function() {
             request
                 .get("/i")
                 .query({device_id: DEVICE_ID, app_key: APP_KEY, checksum256: checksum}).sortQuery()
-                .expect(200)
+                .expect(400)
                 .end(function(error, response) {
                     if (error) {
                         return done(error);
                     }
 
                     const responseObject = JSON.parse(response.text);
-                    responseObject.should.have.property("result", "Request does not match checksum");
+                    responseObject.should.have.property("result", "App does not exist");
                     setTimeout(done, 1000 * testUtils.testScalingFactor);
                 });
         });


### PR DESCRIPTION
## Summary

The SDK write/fetch validation returned responses that revealed whether a supplied `app_key` was valid, before the request was fully verified. This closes those app-key existence/validity oracles by returning the same `400 "App does not exist"` for every pre-verification failure, while still logging the specific reason server-side.

Unified cases (previously distinguishable from an unknown app key):
- **Wrong / missing checksum** for a salt-protected app — was `200 "Request does not match checksum"` / `"Request does not have checksum"`.
- **Paused app** — was `400 "App is currently not accepting data"`.
- **Locked app** (populator requests) — was `403 "App is locked"`.

All now return `400 "App does not exist"`, matching the unknown-app-key response, so a valid key can no longer be distinguished from an invalid one prior to full verification.

## Note (SDK-facing behavior change)

For salt-protected, paused, or locked apps, an SDK request that fails these checks now receives `400 "App does not exist"` instead of the previous specific message/status. Operators debugging such cases should rely on the server logs, which still record the precise reason (`cancelRequest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)