### PR TITLE
security: review-feedback follow-ups (hooks/alerts/times-of-day/apps)

### DIFF
--- a/api/parts/mgmt/apps.js
+++ b/api/parts/mgmt/apps.js
@@ -295,6 +295,10 @@ appsApi.createApp = async function(params) {
     //key rotation does not break already-deployed SDK clients.
     newApp.keys = [{key: newApp.key, added_at: Math.floor(Date.now() / 1000), last_data: 0}];
 
+    //run the uniqueness check against the actual key being stored, including
+    //an auto-generated one (checkUniqueKey only inspects args.key and would
+    //otherwise skip validation entirely when the key was generated)
+    params.qstring.args.key = newApp.key;
     checkUniqueKey(params, function() {
         common.db.collection('apps').insert(newApp, function(err, app) {
             if (!err && app && app.ops && app.ops[0] && app.ops[0]._id) {

--- a/docs/APP_KEY_ROTATION.md
+++ b/docs/APP_KEY_ROTATION.md
@@ -41,12 +41,11 @@ A key must be unique across all applications, including keys that are still
 accepted from previous rotations. If you choose a value already in use, the save
 is rejected.
 
-> **Note on dashboard support.** A dedicated key-management screen (listing all
-> accepted keys, showing per-key "last received" time, and removing old keys) is
-> not part of the dashboard yet. Today the app edit form lets you set the
-> current key; the workflows below for listing and retiring accepted keys are
-> performed through the apps management API. This section will be updated when
-> the dashboard UI lands.
+> **Dashboard support.** The application management screen lists all accepted
+> keys under "Accepted app keys", showing the current/primary key and each old
+> key with its per-key "last received" time, and lets you retire an old key once
+> it is no longer receiving data. The same workflows are also available through
+> the apps management API described below.
 
 ## Seeing which keys are still receiving data
 

--- a/plugins/alerts/api/api.js
+++ b/plugins/alerts/api/api.js
@@ -466,6 +466,12 @@ function getScheduleTextExpression(period, offset) {
                     //the user no longer has access to are not disclosed
                     var allowedApps = (getAdminApps(params.member) || [])
                         .concat(getUserAppsForFeaturePermission(params.member, FEATURE_NAME, 'r') || []);
+                    //legacy members (no permission object) are not covered by
+                    //getUserAppsForFeaturePermission, so include their user_of
+                    //apps too, otherwise they would see none of their own alerts
+                    if (typeof params.member.permission === "undefined" && Array.isArray(params.member.user_of)) {
+                        allowedApps = allowedApps.concat(params.member.user_of);
+                    }
                     query = { createdBy: params.member._id, selectedApps: { $in: allowedApps } };
                     count_query = {_id: 'email:' + params.member.email};
                 }

--- a/plugins/hooks/api/utils.js
+++ b/plugins/hooks/api/utils.js
@@ -52,7 +52,7 @@ utils.parseStringTemplate = function(str, data, httpMethod, escapeHtml) {
         //when the result is rendered as HTML (e.g. an email body) escape the
         //substituted values so trigger data cannot inject markup/scripts
         if (escapeHtml) {
-            return ("" + d).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+            return ("" + d).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
         }
         return d;
     };

--- a/plugins/times-of-day/api/api.js
+++ b/plugins/times-of-day/api/api.js
@@ -183,11 +183,26 @@ const FEATURE_NAME = 'times_of_day';
             var collectionName = "times_of_day";
 
             validateRead(params, FEATURE_NAME, function() {
+                //validateRead does not require app_id for global admins, so
+                //guard it here: a missing/invalid id would otherwise make
+                //ObjectID("undefined") throw and 500 the endpoint
+                if (!params.qstring.app_id) {
+                    common.returnMessage(params, 400, "Missing parameter app_id");
+                    return false;
+                }
+                var appObjId;
+                try {
+                    appObjId = common.db.ObjectID(params.qstring.app_id + "");
+                }
+                catch (e) {
+                    common.returnMessage(params, 400, "Invalid app_id");
+                    return false;
+                }
                 //scope to the authorized app; the app id is stored as an
                 //ObjectId in the "a" field of each times_of_day document
                 var criteria = {
                     "s": todType,
-                    "a": common.db.ObjectID(params.qstring.app_id + "")
+                    "a": appObjId
                 };
 
                 if (params.qstring.date_range) {


### PR DESCRIPTION
## Summary

Applies Copilot review feedback (raised on the release.24.05 backports #7646 and #7649) to the corresponding **already-merged master code** those backports were derived from, so master and the release branch stay consistent.

## Changes

- **`plugins/hooks/api/utils.js`** (from #7616) — the HTML-escape branch of `parseStringTemplate` now also escapes single quotes (`'` → `&#39;`), so attacker-controlled trigger values can't break out of single-quoted attributes in admin-authored email templates.
- **`plugins/alerts/api/api.js`** `/o/alert/list` (from #7613) — include legacy members' `user_of` apps in the allowed-apps scope. Legacy members have no `permission` object (which `getUserAppsForFeaturePermission` needs), so without this they'd see **none of their own alerts**.
- **`plugins/times-of-day/api/api.js`** (from #7612) — guard a missing/invalid `app_id` (return 400) instead of letting `ObjectID("undefined")` throw a 500 (`validateRead` does not require `app_id` for global admins).
- **`api/parts/mgmt/apps.js`** `createApp` (from #7635/#7636) — run the key-uniqueness check against the actual key being stored, including an **auto-generated** one. `checkUniqueKey` only inspects `params.qstring.args.key`, so a generated key was never validated for collisions against existing apps' current/accepted keys.
- **`docs/APP_KEY_ROTATION.md`** (from #7636/#7637) — the accepted-keys list + retire UI now exists in app management, so the "not part of the dashboard yet" note is removed.

## Not changed (reviewed, intentional)

- **`api/utils/taskmanager.js` `isReadableBy`** — Copilot flagged that a `global !== false` task is readable without an app check. This is **by design and documented**: global tasks are intentionally globally readable, matching the `/o/tasks/all` listing filter (`{global: {$ne: false}}`). Non-global tasks still go through `isAuthorizedFor`. Left as-is.

All changed JS passes `node --check` and eslint cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)