### PR TITLE
chore: CI smoke-test on release.24.05 (dummy, do not merge)

### DIFF
--- a/plugins/empty/api/api.js
+++ b/plugins/empty/api/api.js
@@ -1,5 +1,7 @@
 var plugins = require('../../pluginManager.js');
 
+// no-op: dummy change to trigger CI (see PR description); safe to revert
+
 //write api call
 plugins.register("/i", function(/*ob*/) {
     //process sdk request here


### PR DESCRIPTION
## Purpose

**Dummy PR to verify the CI / test pipeline on `release.24.05` only — not for merge.**

Single no-op change: a comment in the sample `plugins/empty/api/api.js`. No behavior change. To be closed/reverted once CI results are confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)