### PR TITLE
security(populator): authorize saveEnvironment by app_id, not body-supplied appId

### DIFF
--- a/plugins/populator/api/api.js
+++ b/plugins/populator/api/api.js
@@ -225,24 +225,23 @@ const FEATURE_NAME = 'populator';
                 return false;
             }
 
-            //the stored appId comes from the request body; bind it to the
-            //authorized app so a caller can't create environment records under
-            //another app by supplying a foreign appId
-            var authorizedAppId = params.qstring.app_id + "";
-            var foreignApp = users.some(function(u) {
-                return (u.appId + "") !== authorizedAppId;
-            });
-            if (foreignApp) {
-                common.returnMessage(obParams, 403, "User does not have right");
+            if (!params.qstring.app_id) {
+                common.returnMessage(obParams, 400, "Missing parameter app_id");
                 return false;
             }
+            //derive every stored id/appId from the authorized app_id (enforced
+            //by validateCreate) rather than the client-supplied users[].appId,
+            //so a caller can only create environment records under the app they
+            //are authorized for. Consistent with the check/list/get/remove
+            //endpoints, which already key by params.qstring.app_id.
+            const appId = params.qstring.app_id + "";
 
-            const environmentId = common.crypto.createHash('sha1').update(users[0].appId + users[0].environmentName).digest('hex');
+            const environmentId = common.crypto.createHash('sha1').update(appId + users[0].environmentName).digest('hex');
             const insertedInformations = [];
             const createdAt = new Date().getTime();
             for (let i = 0; i < users.length; i++) {
                 insertedInformations.push({
-                    _id: users[i].appId + "_" + users[i].templateId + "_" + environmentId + "_" + users[i].deviceId,
+                    _id: appId + "_" + users[i].templateId + "_" + environmentId + "_" + users[i].deviceId,
                     userName: users[i].userName,
                     platform: users[i].platform,
                     device: users[i].device,
@@ -257,14 +256,14 @@ const FEATURE_NAME = 'populator';
                     _id: environmentId,
                     name: users[0].environmentName,
                     templateId: users[0].templateId,
-                    appId: users[0].appId,
+                    appId: appId,
                     createdAt: createdAt
                 }, function(err) {
                     if (err) {
                         common.returnMessage(ob.params, 500, err.message);
                         return false;
                     }
-                    plugins.dispatch("/systemlogs", {params: params, action: "populator_environment_created", data: {environmentId: environmentId, environmentName: users[0].environmentName, appId: users[0].appId, templateId: users[0].templateId}});
+                    plugins.dispatch("/systemlogs", {params: params, action: "populator_environment_created", data: {environmentId: environmentId, environmentName: users[0].environmentName, appId: appId, templateId: users[0].templateId}});
                 });
             }
             common.db.collection('populator_environment_users').insertMany(insertedInformations, function(err) {

--- a/plugins/populator/frontend/public/javascripts/countly.models.js
+++ b/plugins/populator/frontend/public/javascripts/countly.models.js
@@ -1481,7 +1481,7 @@
 
         this.saveEnvironment = function(environmentUserList, setEnviromentInformationOnce) {
             const data = {
-                app_key: countlyCommon.ACTIVE_APP_KEY,
+                app_id: countlyCommon.ACTIVE_APP_ID,
                 users: JSON.stringify(environmentUserList),
                 populator: true
             };


### PR DESCRIPTION
## Summary

`/i/populator/environment/save` is a dashboard-management write, but it was authorized off the ingestion-only **app_key** and then derived everything it stored from the **client-supplied `users[].appId`** instead of an authorized app. `app_key` is meant only for SDK data ingestion (`/i`, `/i/bulk`), never for management API calls that create records.

**Cross-app write:** a caller with populator create-right on app A could send `app_id=A` (to pass `validateCreate`) plus `users[].appId=B`, and the handler would build the `environmentId` hash, every record `_id`, the stored `appId`, and the systemlogs payload under **app B**.

**Broken-flow bug:** master also carried an interim guard comparing `users[].appId` to `params.qstring.app_id`. Since the frontend sent `app_key` (no `app_id`), `params.qstring.app_id` was `undefined`, so the guard returned **403 on every save** — breaking the feature.

This is the `saveEnvironment` outlier; the sibling populator writes (`/i/campaign/create`, `/i/remote-config/add-parameter`, `/i/feedback/widgets/create`, `/i/surveys/...`) all correctly send `app_id`, and the populator environment read/delete endpoints (`environment/check|list|get|remove`) already key by `params.qstring.app_id`.

## Fix (proper refactor, not a guard)

- **Frontend** (`countly.models.js` → `saveEnvironment`): send `app_id: countlyCommon.ACTIVE_APP_ID`, drop `app_key`.
- **Backend** (`api.js` → `saveEnvironment`): require `params.qstring.app_id` (400 if missing); set `const appId = params.qstring.app_id + ""` and use that authorized id for the `environmentId` hash, every record `_id`, the stored `appId`, and the systemlogs data. Stops reading `users[].appId` entirely.
- Removed the interim `foreignApp` guard (now redundant — `validateCreate` enforces per-app authorization natively, and records can only be created under the authorized app).

Net: consistent with the read/delete endpoints, and a non-admin can no longer create an environment for an app they lack create-rights on. Legit flow works because the frontend now sends `app_id` (no more `undefined` → 403).

## Verification
- `node --check` passes on both files; eslint clean.
- The `e2e-data-populate` job (`populate.cy.js` → "Save Environment True") lives in the countly-platform superset (not in this OSS repo's `ui-tests`, which only has the populate element/lib helpers) — it will exercise this there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)