### PR TITLE
security(populator): authorize saveEnvironment by app_id, not body appId (24.05 backport)

### DIFF
--- a/plugins/populator/api/api.js
+++ b/plugins/populator/api/api.js
@@ -225,24 +225,23 @@ const FEATURE_NAME = 'populator';
                 return false;
             }
 
-            //the stored appId comes from the request body; bind it to the
-            //authorized app so a caller can't create environment records under
-            //another app by supplying a foreign appId
-            var authorizedAppId = params.qstring.app_id + "";
-            var foreignApp = users.some(function(u) {
-                return (u.appId + "") !== authorizedAppId;
-            });
-            if (foreignApp) {
-                common.returnMessage(obParams, 403, "User does not have right");
+            if (!params.qstring.app_id) {
+                common.returnMessage(obParams, 400, "Missing parameter app_id");
                 return false;
             }
+            //derive every stored id/appId from the authorized app_id (enforced
+            //by validateCreate) rather than the client-supplied users[].appId,
+            //so a caller can only create environment records under the app they
+            //are authorized for. Consistent with the check/list/get/remove
+            //endpoints, which already key by params.qstring.app_id.
+            const appId = params.qstring.app_id + "";
 
-            const environmentId = common.crypto.createHash('sha1').update(users[0].appId + users[0].environmentName).digest('hex');
+            const environmentId = common.crypto.createHash('sha1').update(appId + users[0].environmentName).digest('hex');
             const insertedInformations = [];
             const createdAt = new Date().getTime();
             for (let i = 0; i < users.length; i++) {
                 insertedInformations.push({
-                    _id: users[i].appId + "_" + users[i].templateId + "_" + environmentId + "_" + users[i].deviceId,
+                    _id: appId + "_" + users[i].templateId + "_" + environmentId + "_" + users[i].deviceId,
                     userName: users[i].userName,
                     platform: users[i].platform,
                     device: users[i].device,
@@ -257,14 +256,14 @@ const FEATURE_NAME = 'populator';
                     _id: environmentId,
                     name: users[0].environmentName,
                     templateId: users[0].templateId,
-                    appId: users[0].appId,
+                    appId: appId,
                     createdAt: createdAt
                 }, function(err) {
                     if (err) {
                         common.returnMessage(ob.params, 500, err.message);
                         return false;
                     }
-                    plugins.dispatch("/systemlogs", {params: params, action: "populator_environment_created", data: {environmentId: environmentId, environmentName: users[0].environmentName, appId: users[0].appId, templateId: users[0].templateId}});
+                    plugins.dispatch("/systemlogs", {params: params, action: "populator_environment_created", data: {environmentId: environmentId, environmentName: users[0].environmentName, appId: appId, templateId: users[0].templateId}});
                 });
             }
             common.db.collection('populator_environment_users').insertMany(insertedInformations, function(err) {

--- a/plugins/populator/frontend/public/javascripts/countly.models.js
+++ b/plugins/populator/frontend/public/javascripts/countly.models.js
@@ -1302,7 +1302,7 @@
 
         this.saveEnvironment = function(environmentUserList, setEnviromentInformationOnce) {
             const data = {
-                app_key: countlyCommon.ACTIVE_APP_KEY,
+                app_id: countlyCommon.ACTIVE_APP_ID,
                 users: JSON.stringify(environmentUserList),
                 populator: true
             };


### PR DESCRIPTION
## Summary

Backport of #7654 to `release.24.05` — the same `saveEnvironment` issue exists verbatim on this branch.

`/i/populator/environment/save` is a dashboard-management write but was authorized off the ingestion-only **app_key** and derived the `environmentId` hash, every record `_id`, the stored `appId`, and the systemlogs payload from the **client-supplied `users[].appId`**. A caller with populator create-right on app A could pass `app_id=A` (to satisfy `validateCreate`) and `users[].appId=B` to write environment records under **app B** (cross-app write). The interim `foreignApp` guard also returned **403 on every save**, since the frontend sent `app_key` (so `params.qstring.app_id` was `undefined`).

## Fix
- **Frontend**: `saveEnvironment` now sends `app_id: countlyCommon.ACTIVE_APP_ID`, drops `app_key`.
- **Backend**: require `params.qstring.app_id` (400 if missing) and derive the `environmentId` hash, all record `_id`s, the stored `appId`, and the systemlogs data from that authorized id; stops reading `users[].appId`; removes the interim guard. Consistent with the environment `check`/`list`/`get`/`remove` endpoints, which already key by `params.qstring.app_id`.

`node --check` passes on both files; eslint clean. (The `populate.cy.js` "Save Environment" e2e gate lives in the countly-platform superset, not in this repo's `ui-tests`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)