### PR TITLE
fix(vue): expose countlyGlobal on Vue prototype (template render crash in dev build)

### DIFF
--- a/frontend/express/public/javascripts/countly/vue/core.js
+++ b/frontend/express/public/javascripts/countly/vue/core.js
@@ -619,6 +619,18 @@
 
     Vue.prototype.$route = new BackboneRouteAdapter();
 
+    // countlyGlobal is a window-level global, but Vue 2's render proxy does not fall
+    // through to window for identifiers in template expressions, so a bare
+    // countlyGlobal.* in a template resolves to undefined and throws during render.
+    // Expose it on the prototype (via a getter so it always reflects the current
+    // window.countlyGlobal) so templates can use countlyGlobal.* safely.
+    Object.defineProperty(Vue.prototype, "countlyGlobal", {
+        configurable: true,
+        get: function() {
+            return window.countlyGlobal;
+        }
+    });
+
     var DummyCompAPI = VueCompositionAPI.defineComponent({
         name: "DummyCompAPI",
         template: '<div></div>',


### PR DESCRIPTION
## Symptom

With the dev/warning Vue build (`frontend.production=false`), any page whose Vue template references `countlyGlobal` throws during render and breaks the page:

```
[Vue warn]: Property or method "countlyGlobal" is not defined on the instance but referenced during render
TypeError: Cannot read properties of undefined (reading 'path')
```

(In countly-platform this crashed the Drill page on every query — the loading/thinking avatar template uses `countlyGlobal.path`.)

## Root cause

`countlyGlobal` is a `window`-level global. Vue 2's render proxy (present in the dev/warning build) does **not** fall through to `window` for identifiers in template expressions, so `countlyGlobal` resolves to `undefined` and `undefined.path` throws. It only "works" in the minified build, where `with(this)` falls through to `window.countlyGlobal`. So any `countlyGlobal.*` in a `.html` template binding (`:src=`, `:href=`, `{{ }}`) is a latent crash. The defensive `(countlyGlobal.path || '')` form doesn't help — `countlyGlobal.path` is evaluated before `|| ''`. (JS-file uses in `countly.models.js`/`countly.views.js` are fine — this only affects template expressions.)

## Fix (single, central)

In `frontend/express/public/javascripts/countly/vue/core.js`, right after `Vue.prototype.$route = new BackboneRouteAdapter();`, expose it on the prototype via a getter (so it always reflects the current `window.countlyGlobal`):

```js
Object.defineProperty(Vue.prototype, "countlyGlobal", {
    configurable: true,
    get: function() { return window.countlyGlobal; }
});
```

This covers **every** dashboard template referencing `countlyGlobal` across core and all plugins. Enterprise plugins need no separate change — they render inside this same dashboard Vue instance. No per-component data/computed shims. Confirmed `Vue.prototype.countlyGlobal` wasn't already defined.

## Verify
- `node --check` on `core.js` passes; eslint clean.
- With `frontend.production=false`, a page using a `countlyGlobal.*` template binding (Drill run-query, push compose preview, views config) renders with no `[Vue warn]`/render error and resolves asset URLs.
- For production/minified mode the bundled `/min/` assets are rebuilt by CI (`grunt dist-all`); only the source change is committed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)