### PR TITLE
fix(vue): expose countlyGlobal on Vue prototype (24.05 backport)

### DIFF
--- a/frontend/express/public/javascripts/countly/vue/core.js
+++ b/frontend/express/public/javascripts/countly/vue/core.js
@@ -594,6 +594,18 @@
 
     Vue.prototype.$route = new BackboneRouteAdapter();
 
+    // countlyGlobal is a window-level global, but Vue 2's render proxy does not fall
+    // through to window for identifiers in template expressions, so a bare
+    // countlyGlobal.* in a template resolves to undefined and throws during render.
+    // Expose it on the prototype (via a getter so it always reflects the current
+    // window.countlyGlobal) so templates can use countlyGlobal.* safely.
+    Object.defineProperty(Vue.prototype, "countlyGlobal", {
+        configurable: true,
+        get: function() {
+            return window.countlyGlobal;
+        }
+    });
+
     var DummyCompAPI = VueCompositionAPI.defineComponent({
         name: "DummyCompAPI",
         template: '<div></div>',


### PR DESCRIPTION
## Summary

Backport of #7658 to `release.24.05`.

With the dev/warning Vue build (`frontend.production=false`), any dashboard template that references `countlyGlobal` (e.g. `:src="countlyGlobal.path + ...">`) throws during render — `[Vue warn]: Property or method "countlyGlobal" is not defined` + `TypeError: Cannot read properties of undefined (reading 'path')`. Vue 2's render proxy doesn't fall through to `window` for template-expression identifiers, so `countlyGlobal` is `undefined` (it only "worked" in the minified build via `with(this)`). The `(countlyGlobal.path || '')` form doesn't help since `countlyGlobal.path` is evaluated first.

**Fix:** in `frontend/express/public/javascripts/countly/vue/core.js`, expose it once on `Vue.prototype` via a getter (always reflects the current `window.countlyGlobal`), right after `Vue.prototype.$route = ...`. Covers every template referencing `countlyGlobal` across core and all plugins (they share this Vue instance). No per-component shims; JS-file uses unaffected.

`node --check` passes; eslint clean. Minified `/min/` bundles are rebuilt by CI (`grunt dist-all`); only the source change is committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)