### PR TITLE
fix(subdirectory): annotation icons, Pace guard, star-rating assets

### DIFF
--- a/frontend/express/public/javascripts/countly/vue/components/vis.js
+++ b/frontend/express/public/javascripts/countly/vue/components/vis.js
@@ -2002,12 +2002,12 @@
             '<div class="chart-type-annotation-wrapper">\
                 <el-dropdown data-test-id="chart-type-annotation-button" trigger="click" @command="graphNotesHandleCommand($event)">\
                     <el-button size="small">\
-                        <img src="../images/annotation/notation-icon.svg" class="chart-type-annotation-wrapper__icon" data-test-id="chart-type-annotation-icon"/>\
+                        <img :src="getIconUrl(\'notation-icon\')" class="chart-type-annotation-wrapper__icon" data-test-id="chart-type-annotation-icon"/>\
                     </el-button>\
                     <el-dropdown-menu slot="dropdown">\
-                        <el-dropdown-item data-test-id="chart-type-annotation-item-add-note" v-if="hasCreateRight" command="add"><img src="../images/annotation/add-icon.svg" class="chart-type-annotation-wrapper__img bu-mr-4"/><span>{{i18n("notes.add-note")}}</span></el-dropdown-item>\
-                        <el-dropdown-item data-test-id="chart-type-annotation-item-manage-notes" command="manage"><img src="../images/annotation/manage-icon.svg" class="chart-type-annotation-wrapper__img bu-mr-4"/>{{i18n("notes.manage-notes")}}</el-dropdown-item>\
-                        <el-dropdown-item data-test-id="chart-type-annotation-item-hide-notes" v-if="hasUpdateRight" command="show"><img src="../images/annotation/show-icon.svg" class="chart-type-annotation-wrapper__img bu-mr-3"/>{{!areNotesHidden ? i18n("notes.hide-notes") : i18n("notes.show-notes")}}</el-dropdown-item>\
+                        <el-dropdown-item data-test-id="chart-type-annotation-item-add-note" v-if="hasCreateRight" command="add"><img :src="getIconUrl(\'add-icon\')" class="chart-type-annotation-wrapper__img bu-mr-4"/><span>{{i18n("notes.add-note")}}</span></el-dropdown-item>\
+                        <el-dropdown-item data-test-id="chart-type-annotation-item-manage-notes" command="manage"><img :src="getIconUrl(\'manage-icon\')" class="chart-type-annotation-wrapper__img bu-mr-4"/>{{i18n("notes.manage-notes")}}</el-dropdown-item>\
+                        <el-dropdown-item data-test-id="chart-type-annotation-item-hide-notes" v-if="hasUpdateRight" command="show"><img :src="getIconUrl(\'show-icon\')" class="chart-type-annotation-wrapper__img bu-mr-3"/>{{!areNotesHidden ? i18n("notes.hide-notes") : i18n("notes.show-notes")}}</el-dropdown-item>\
                     </el-dropdown-menu>\
                 </el-dropdown>\
                 <drawer :settings="drawerSettings" :controls="drawers.annotation" @cly-refresh="refresh"></drawer>\

--- a/frontend/express/public/javascripts/dom/pace/pace.js
+++ b/frontend/express/public/javascripts/dom/pace/pace.js
@@ -497,7 +497,7 @@
     for (_j = 0, _len1 = _ref2.length; _j < _len1; _j++) {
       pattern = _ref2[_j];
       if (typeof pattern === 'string') {
-        if (url.indexOf(pattern) !== -1) {
+        if (url && url.indexOf(pattern) !== -1) {
           return true;
         }
       } else {


### PR DESCRIPTION
## Summary

Port of [Countly/countly-platform#420](https://github.com/Countly/countly-platform/pull/420) — two frontend fixes for subdirectory (`/<subdir>/`) deployments, found while testing the subdirectory-path work on a real subdirectory deploy.

### 1. Annotation/notes icons 404 on subdirectory deploys (`vis.js`)
The chart "notes" dropdown rendered 4 icons via hardcoded **relative** paths (`<img src="../images/annotation/*.svg">`). Under a subdirectory deploy the browser resolves `../images/...` from the document base `/<subdir>/dashboard` up to `/images/...` → **404** (the asset lives at `/<subdir>/images/...`). On a root deploy `../images/...` happens to resolve to the correct `/images/...`, so it was never caught.

The component already has a `getIconUrl(icon)` helper returning `` `${countlyGlobal.path}/images/annotation/${icon}.svg` `` but the template was never wired to it. This binds the 4 icons to that helper.

### 2. Pace `shouldIgnoreURL` null-guard (`pace.js`)
On data-heavy views, Pace's `shouldIgnoreURL(url)` could be called with an `undefined` url and throw `Cannot read properties of undefined (reading 'indexOf')` repeatedly (non-fatal, but noisy). The shipped `pace.min.js` already carries this guard; the CoffeeScript-compiled `pace.js` source did not — this adds the `url &&` guard to the source to close the source/min drift.

## Notes
- The platform PR's note about *not* removing `pace.min.js` from the `countly.dom.js` concat applies here too — that change was correctly dropped (Pace is loaded only via that bundle in production), and is not part of this PR.
- `node --check` passes on both files; eslint clean. Minified `/min/` bundles are rebuilt by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)