### PR TITLE
fix(subdirectory): Pace guard + star-rating assets (24.05 backport)

### DIFF
--- a/frontend/express/public/javascripts/dom/pace/pace.js
+++ b/frontend/express/public/javascripts/dom/pace/pace.js
@@ -497,7 +497,7 @@
     for (_j = 0, _len1 = _ref2.length; _j < _len1; _j++) {
       pattern = _ref2[_j];
       if (typeof pattern === 'string') {
-        if (url.indexOf(pattern) !== -1) {
+        if (url && url.indexOf(pattern) !== -1) {
           return true;
         }
       } else {


### PR DESCRIPTION
## Summary

Partial backport of [Countly/countly-platform#420](https://github.com/Countly/countly-platform/pull/420) to `release.24.05`.

Pace's `shouldIgnoreURL(url)` could be called with an `undefined` url on data-heavy views and throw `Cannot read properties of undefined (reading 'indexOf')` repeatedly (non-fatal, but noisy). The shipped `pace.min.js` already carries this guard; the CoffeeScript-compiled `pace.js` source did not — this adds the `url &&` guard to the source to close the source/min drift.

### Why only the pace.js half
The other half of #420 (wiring the chart annotation/notes icons to `getIconUrl` instead of hardcoded `../images/annotation/*.svg`) is **already present on release.24.05** — those icons are bound to `getIconUrl(...)` here, so no `vis.js` change is needed.

`node --check` passes; minified `/min/` bundles are rebuilt by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)