### PR TITLE
fix(subdirectory): star-rating ratings widget assets under subpath

### DIFF
--- a/plugins/star-rating/frontend/public/javascripts/countly.views.js
+++ b/plugins/star-rating/frontend/public/javascripts/countly.views.js
@@ -848,7 +848,7 @@
                 empty: {
                     title: CV.i18n("ratings.empty.title"),
                     body: CV.i18n("ratings.empty.body"),
-                    image: "/star-rating/images/star-rating/ratings-empty.svg"
+                    image: countlyGlobal.path + "/star-rating/images/star-rating/ratings-empty.svg"
                 },
                 widgets: [],
                 drawerSettings: {

--- a/plugins/star-rating/frontend/public/stylesheets/ratings.scss
+++ b/plugins/star-rating/frontend/public/stylesheets/ratings.scss
@@ -252,7 +252,7 @@
         width: 50px;
         background-repeat: no-repeat;
         margin: 0px 5px 0px 5px;
-        background-image: url("/star-rating/images/star-rating/emoji.svg");
+        background-image: url("../images/star-rating/emoji.svg");
     }
 
     &__rp-ratings-item__emoji1 {
@@ -261,7 +261,7 @@
         width: 50px;
         background-repeat: no-repeat;
         margin: 0px 5px 0px 5px;
-        background-image: url("/star-rating/images/star-rating/emojis_1-default.svg")
+        background-image: url("../images/star-rating/emojis_1-default.svg")
     }
 
     &__rp-ratings-item__emoji2 {
@@ -270,7 +270,7 @@
         width: 50px;
         background-repeat: no-repeat;
         margin: 0px 5px 0px 5px;
-        background-image: url("/star-rating/images/star-rating/emojis_2-default.svg")
+        background-image: url("../images/star-rating/emojis_2-default.svg")
     }
 
     &__rp-ratings-item__emoji3 {
@@ -279,7 +279,7 @@
         width: 50px;
         background-repeat: no-repeat;
         margin: 0px 5px 0px 5px;
-        background-image: url("/star-rating/images/star-rating/emojis_3-default.svg")
+        background-image: url("../images/star-rating/emojis_3-default.svg")
     }
 
     &__rp-ratings-item__emoji4 {
@@ -288,7 +288,7 @@
         width: 50px;
         background-repeat: no-repeat;
         margin: 0px 5px 0px 5px;
-        background-image: url("/star-rating/images/star-rating/emojis_4-default.svg")
+        background-image: url("../images/star-rating/emojis_4-default.svg")
     }
 
     &__rp-ratings-item__emoji5 {
@@ -297,31 +297,31 @@
         width: 50px;
         background-repeat: no-repeat;
         margin: 0px 5px 0px 5px;
-        background-image: url("/star-rating/images/star-rating/emojis_5-default.svg")
+        background-image: url("../images/star-rating/emojis_5-default.svg")
     }
 
     &__rp-ratings-active-item__emojis {
-        background-image: url("/star-rating/images/star-rating/emoji_filled.svg");
+        background-image: url("../images/star-rating/emoji_filled.svg");
     }
 
     &__rp-ratings-active-item__emoji1 {
-        background-image: url("/star-rating/images/star-rating/emojis-1.svg")
+        background-image: url("../images/star-rating/emojis-1.svg")
     }
 
     &__rp-ratings-active-item__emoji2 {
-        background-image: url("/star-rating/images/star-rating/emojis-2.svg")
+        background-image: url("../images/star-rating/emojis-2.svg")
     }
 
     &__rp-ratings-active-item__emoji3 {
-        background-image: url("/star-rating/images/star-rating/emojis-3.svg")
+        background-image: url("../images/star-rating/emojis-3.svg")
     }
 
     &__rp-ratings-active-item__emoji4 {
-        background-image: url("/star-rating/images/star-rating/emojis-4.svg")
+        background-image: url("../images/star-rating/emojis-4.svg")
     }
 
     &__rp-ratings-active-item__emoji5 {
-        background-image: url("/star-rating/images/star-rating/emojis-5.svg")
+        background-image: url("../images/star-rating/emojis-5.svg")
     }
 
     &__rp-ratings-item__thumbs {
@@ -330,11 +330,11 @@
         width: 50px;
         background-repeat: no-repeat;
         margin: 0px 5px 0px 5px;
-        background-image: url("/star-rating/images/star-rating/thumbs_up-default.svg")
+        background-image: url("../images/star-rating/thumbs_up-default.svg")
     }
 
     &__rp-ratings-active-item__thumbs {
-        background-image: url("/star-rating/images/star-rating/thumbs_up-filled.svg")
+        background-image: url("../images/star-rating/thumbs_up-filled.svg")
     }
 
     &__rp-ratings-item__stars {
@@ -343,11 +343,11 @@
         width: 50px;
         background-repeat: no-repeat;
         margin: 0px 5px 0px 5px;
-        background-image: url("/star-rating/images/star-rating/star-default.svg")
+        background-image: url("../images/star-rating/star-default.svg")
     }
 
     &__rp-ratings-active-item__stars {
-        background-image: url("/star-rating/images/star-rating/star-filled.svg")
+        background-image: url("../images/star-rating/star-filled.svg")
     }
 
     &__rp-question-area {


### PR DESCRIPTION
## Summary

Follow-up to #7660 — the two **additional** changes that were added to [countly-platform#420](https://github.com/Countly/countly-platform/pull/420) after #7660 had already merged. (They were pushed to the #7660 branch post-merge, so they never landed; this is a fresh PR for just that delta.)

- `star-rating/.../countly.views.js`: the ratings empty-state image used a root-absolute path (`"/star-rating/images/star-rating/ratings-empty.svg"`), which 404s under a subdirectory deploy. Prefix with `countlyGlobal.path` (safe — JS string, not a Vue template expression).
- `star-rating/.../ratings.scss`: the rating-preview emoji/thumb/star `background-image` URLs were root-absolute (`url("/star-rating/images/…")`); make them relative (`url("../images/…")`) so they resolve from the served `/<subdir>/star-rating/stylesheets/ratings.css` under both root and subdirectory deploys.

`node --check` passes on `countly.views.js`; SCSS converted `+16/-16`. Compiled `ratings.css` / minified bundles are rebuilt by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)