### PR TITLE
fix(subdirectory): star-rating ratings widget assets under subpath (24.05 backport)

### DIFF
--- a/plugins/star-rating/frontend/public/javascripts/countly.views.js
+++ b/plugins/star-rating/frontend/public/javascripts/countly.views.js
@@ -815,7 +815,7 @@
                 empty: {
                     title: CV.i18n("ratings.empty.title"),
                     body: CV.i18n("ratings.empty.body"),
-                    image: "/star-rating/images/star-rating/ratings-empty.svg"
+                    image: countlyGlobal.path + "/star-rating/images/star-rating/ratings-empty.svg"
                 },
                 widgets: [],
                 drawerSettings: {

--- a/plugins/star-rating/frontend/public/stylesheets/ratings.scss
+++ b/plugins/star-rating/frontend/public/stylesheets/ratings.scss
@@ -252,7 +252,7 @@
         width: 50px;
         background-repeat: no-repeat;
         margin: 0px 5px 0px 5px;
-        background-image: url("/star-rating/images/star-rating/emoji.svg");
+        background-image: url("../images/star-rating/emoji.svg");
     }
 
     &__rp-ratings-item__emoji1 {
@@ -261,7 +261,7 @@
         width: 50px;
         background-repeat: no-repeat;
         margin: 0px 5px 0px 5px;
-        background-image: url("/star-rating/images/star-rating/emoji_1.svg");
+        background-image: url("../images/star-rating/emoji_1.svg");
     }
 
     &__rp-ratings-item__emoji2 {
@@ -270,7 +270,7 @@
         width: 50px;
         background-repeat: no-repeat;
         margin: 0px 5px 0px 5px;
-        background-image: url("/star-rating/images/star-rating/emoji_2.svg");
+        background-image: url("../images/star-rating/emoji_2.svg");
     }
 
     &__rp-ratings-item__emoji3 {
@@ -279,7 +279,7 @@
         width: 50px;
         background-repeat: no-repeat;
         margin: 0px 5px 0px 5px;
-        background-image: url("/star-rating/images/star-rating/emoji_3.svg");
+        background-image: url("../images/star-rating/emoji_3.svg");
     }
 
     &__rp-ratings-item__emoji4 {
@@ -288,7 +288,7 @@
         width: 50px;
         background-repeat: no-repeat;
         margin: 0px 5px 0px 5px;
-        background-image: url("/star-rating/images/star-rating/emoji_4.svg");
+        background-image: url("../images/star-rating/emoji_4.svg");
     }
 
     &__rp-ratings-item__emoji5 {
@@ -297,31 +297,31 @@
         width: 50px;
         background-repeat: no-repeat;
         margin: 0px 5px 0px 5px;
-        background-image: url("/star-rating/images/star-rating/emoji_5.svg");
+        background-image: url("../images/star-rating/emoji_5.svg");
     }
 
     &__rp-ratings-active-item__emojis {
-        background-image: url("/star-rating/images/star-rating/emoji_filled.svg");
+        background-image: url("../images/star-rating/emoji_filled.svg");
     }
 
     &__rp-ratings-active-item__emoji1 {
-        background-image: url("/star-rating/images/star-rating/emoji_filled_1.svg");
+        background-image: url("../images/star-rating/emoji_filled_1.svg");
     }
 
     &__rp-ratings-active-item__emoji2 {
-        background-image: url("/star-rating/images/star-rating/emoji_filled_2.svg");
+        background-image: url("../images/star-rating/emoji_filled_2.svg");
     }
 
     &__rp-ratings-active-item__emoji3 {
-        background-image: url("/star-rating/images/star-rating/emoji_filled_3.svg");
+        background-image: url("../images/star-rating/emoji_filled_3.svg");
     }
 
     &__rp-ratings-active-item__emoji4 {
-        background-image: url("/star-rating/images/star-rating/emoji_filled_4.svg");
+        background-image: url("../images/star-rating/emoji_filled_4.svg");
     }
 
     &__rp-ratings-active-item__emoji5 {
-        background-image: url("/star-rating/images/star-rating/emoji_filled_5.svg");
+        background-image: url("../images/star-rating/emoji_filled_5.svg");
     }
 
     &__rp-ratings-item__thumbs {
@@ -330,11 +330,11 @@
         width: 50px;
         background-repeat: no-repeat;
         margin: 0px 5px 0px 5px;
-        background-image: url("/star-rating/images/star-rating/thumbs.svg");
+        background-image: url("../images/star-rating/thumbs.svg");
     }
 
     &__rp-ratings-active-item__thumbs {
-        background-image: url("/star-rating/images/star-rating/thumbs_filled.svg");
+        background-image: url("../images/star-rating/thumbs_filled.svg");
     }
 
     &__rp-ratings-item__stars {
@@ -343,11 +343,11 @@
         width: 50px;
         background-repeat: no-repeat;
         margin: 0px 5px 0px 5px;
-        background-image: url("/star-rating/images/star-rating/stars.svg");
+        background-image: url("../images/star-rating/stars.svg");
     }
 
     &__rp-ratings-active-item__stars {
-        background-image: url("/star-rating/images/star-rating/stars_filled.svg");
+        background-image: url("../images/star-rating/stars_filled.svg");
     }
 
     &__rp-question-area {


### PR DESCRIPTION
## Summary

Follow-up to #7661 — the star-rating half of [countly-platform#420](https://github.com/Countly/countly-platform/pull/420) that was added after #7661 merged (pushed to the merged branch, so it never landed; fresh PR for just that delta).

- `star-rating/.../countly.views.js`: prefix the ratings empty-state image with `countlyGlobal.path` (was root-absolute, 404s under subpath).
- `star-rating/.../ratings.scss`: rating-preview emoji/thumb/star `background-image` URLs made relative (`../images/…`) instead of root-absolute, so they resolve under both root and subdirectory deploys.

`node --check` passes; SCSS converted `+16/-16`. Compiled `ratings.css` rebuilt by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)