### PR TITLE
fix(app-management): show real error + reset form on app-key save failure

### DIFF
--- a/frontend/express/public/core/app-management/javascripts/countly.views.js
+++ b/frontend/express/public/core/app-management/javascripts/countly.views.js
@@ -480,7 +480,7 @@
                         error: function(xhr, status, error) {
                             CountlyHelpers.notify({
                                 title: jQuery.i18n.map["configs.not-saved"],
-                                message: error || jQuery.i18n.map["configs.not-changed"],
+                                message: (xhr && xhr.responseJSON && xhr.responseJSON.result) || error || jQuery.i18n.map["configs.not-changed"],
                                 type: "error"
                             });
                         }
@@ -538,9 +538,12 @@
                         });
                     },
                     error: function(xhr, status, error) {
+                        // Revert the rejected/edited values so the form reflects the actual
+                        // saved state instead of leaving the failed value on screen.
+                        self.discardForm();
                         CountlyHelpers.notify({
                             title: jQuery.i18n.map["configs.not-saved"],
-                            message: error || jQuery.i18n.map["configs.not-changed"],
+                            message: (xhr && xhr.responseJSON && xhr.responseJSON.result) || error || jQuery.i18n.map["configs.not-changed"],
                             type: "error"
                         });
                     }

--- a/frontend/express/public/core/app-management/templates/app-management.html
+++ b/frontend/express/public/core/app-management/templates/app-management.html
@@ -223,7 +223,7 @@
                                                 <span v-else class="text-medium color-cool-gray-50">{{ i18n("common.diff-helper.keep-single") }}</span>
                                             </span>
                                             <span class="vertical-divider bu-mr-4 bu-ml-4"></span>
-                                            <el-button data-test-id="save-changes-button" skin="red" class="bu-mr-2" size="small" type="default" @click="save(formScope.editedObject)">
+                                            <el-button data-test-id="save-changes-button" skin="red" class="bu-mr-2" size="small" type="default" :disabled="isSaveDisabled(formScope.editedObject)" @click="save(formScope.editedObject)">
                                                 <i class="cly-io-16 cly-io cly-io-save-disc" style="font-size: larger;"></i>
                                                 <span class="bu-ml-1">
                                                     {{ i18n('dashboards.save-changes') }}


### PR DESCRIPTION
## Summary

Port of [Countly/countly-platform#422](https://github.com/Countly/countly-platform/pull/422). When an app-key save/rotation is rejected by the API, the dashboard behaved confusingly:
- showed a generic **"Bad Request"** toast instead of the API's actual message;
- **left the rejected key value on screen** (view-model not reset), so it looked applied until a reload.

Reproduced via editing an App Key to a value already used by another app → API correctly rejects with `400 {"result":"App key already in use"}` (key unchanged), but the UI showed "Bad Request" + the stale key.

## Fix
- **Surface the API message** — use `xhr.responseJSON.result` (→ HTTP statusText → existing i18n default) in the error toast on **both** the create and update (`saveApp`) paths. User now sees "App key already in use".
- **Reset the form on update failure** — `self.discardForm()` in the update error handler so the form reverts to the actual saved state (the success path already did this).
- **Disable the save button** via the existing `isSaveDisabled()` guard on the `save-changes-button`.

The unrelated third error handler in this view is left untouched. `node --check` + eslint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)