### PR TITLE
fix(app-management): show real error + reset form on app-key save failure (24.05 backport)

### DIFF
--- a/frontend/express/public/core/app-management/javascripts/countly.views.js
+++ b/frontend/express/public/core/app-management/javascripts/countly.views.js
@@ -426,7 +426,7 @@
                         error: function(xhr, status, error) {
                             CountlyHelpers.notify({
                                 title: jQuery.i18n.map["configs.not-saved"],
-                                message: error || jQuery.i18n.map["configs.not-changed"],
+                                message: (xhr && xhr.responseJSON && xhr.responseJSON.result) || error || jQuery.i18n.map["configs.not-changed"],
                                 type: "error"
                             });
                         }
@@ -483,9 +483,12 @@
                         });
                     },
                     error: function(xhr, status, error) {
+                        // Revert the rejected/edited values so the form reflects the actual
+                        // saved state instead of leaving the failed value on screen.
+                        self.discardForm();
                         CountlyHelpers.notify({
                             title: jQuery.i18n.map["configs.not-saved"],
-                            message: error || jQuery.i18n.map["configs.not-changed"],
+                            message: (xhr && xhr.responseJSON && xhr.responseJSON.result) || error || jQuery.i18n.map["configs.not-changed"],
                             type: "error"
                         });
                     }


### PR DESCRIPTION
## Summary

Backport of [Countly/countly-platform#422](https://github.com/Countly/countly-platform/pull/422) to `release.24.05`.

On app-key save/rotation rejection (e.g. `400 {"result":"App key already in use"}`) the dashboard showed a generic "Bad Request" toast and left the rejected key on screen.

- **Surface the API message** — `xhr.responseJSON.result` (→ HTTP statusText → existing i18n default) in the error toast on both the create and update (`saveApp`) paths.
- **Reset the form on update failure** — `self.discardForm()` so it reverts to the actual saved state.

### Why no template change here
The `:disabled="isSaveDisabled(...)"` part of #422 isn't needed on 24.05: the save is triggered via `cly-diff-helper`, which **already** binds `:disabled="isSaveDisabled(formScope.editedObject)"` (24.05 has no standalone `save-changes-button` like master). The unrelated third error handler in this view is untouched.

`node --check` + eslint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)