### PR TITLE
docs: expand bug bounty exclusions / out-of-scope list

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,7 +17,7 @@ All software related security bugs with severity of medium and higher will be aw
 
 The following are out of scope. They may still be reported, and configuration issues will be forwarded to the relevant parties, but they do not qualify for a bounty reward:
 
-1. **Deployment & server configuration.** Server-specific and deployment-specific configuration issues, due to the on-premise nature of our software (TLS setup, reverse-proxy/CORS/header configuration, exposed ports, OS/database hardening, rate-limiting tuning, etc.). These are forwarded to the relevant departments/parties/companies but carry no bounty guarantee.
+1. **Deployment & server configuration.** Server-specific and deployment-specific configuration issues, due to the on-premises nature of our software (TLS setup, reverse-proxy/CORS/header configuration, exposed ports, OS/database hardening, rate-limiting tuning, etc.). These are forwarded to the relevant departments/parties/companies but carry no bounty guarantee.
 
 2. **Privileged / admin-only endpoints behaving as designed.** Endpoints intended to be used only by authenticated global administrators or trusted server operators — for example `/mobile-login` and other operator/management endpoints — are not vulnerabilities when they require the privileges they are designed to require. "A global admin can do X across the system" is by design; global admin is a fully trusted role.
 
@@ -31,4 +31,4 @@ The following are out of scope. They may still be reported, and configuration is
 
 7. **Duplicates and already-known issues.** Reports duplicating an already-reported or already-fixed issue; only the first actionable report is eligible.
 
-8. **Theoretical issues without a working proof of concept**, self-inflicted issues (self-XSS, pasting attacker scripts into one's own console/session), and missing best-practice hardening that does not itself lead to an exploit (covered under "Low" above).
+8. **Theoretical, self-inflicted, or hardening-only issues.** Issues without a working proof of concept, self-inflicted issues (self-XSS, pasting attacker scripts into one's own console/session), and missing best-practice hardening that does not itself lead to an exploit (covered under "Low" above).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,22 @@ All software related security bugs with severity of medium and higher will be aw
 
 **Low** - no bounty rewards, does not directly lead to vulnerability, but provides a possibility (like exposing software version, which can be mapped to specific vulnerabilities), old dependencies, server misconfiguration
 
-**Exclusion**
+**Exclusions (out of scope — not eligible for bounty)**
 
-Server specific configurations and deployment specific configurations due to on premise nature of our software.
-All server configuration related issues will be reported to related departments/parties/companies, but we cannot guarantee any bounty rewards for them.
+The following are out of scope. They may still be reported, and configuration issues will be forwarded to the relevant parties, but they do not qualify for a bounty reward:
+
+1. **Deployment & server configuration.** Server-specific and deployment-specific configuration issues, due to the on-premise nature of our software (TLS setup, reverse-proxy/CORS/header configuration, exposed ports, OS/database hardening, rate-limiting tuning, etc.). These are forwarded to the relevant departments/parties/companies but carry no bounty guarantee.
+
+2. **Privileged / admin-only endpoints behaving as designed.** Endpoints intended to be used only by authenticated global administrators or trusted server operators — for example `/mobile-login` and other operator/management endpoints — are not vulnerabilities when they require the privileges they are designed to require. "A global admin can do X across the system" is by design; global admin is a fully trusted role.
+
+3. **By-design cross-app access for global admins.** Plugins and features whose documented purpose is to aggregate or operate on data across multiple applications for global administrators are working as intended. Accessing cross-app data while holding global-admin rights is not a privilege escalation.
+
+4. **Findings that require code already fixed in the current codebase.** Reports reproduced only against an outdated or unpatched running server, demo, or hosted instance — where the issue is already fixed in the current source — are not eligible. Bounty assessment is made against the current code in this repository.
+
+5. **Excluded plugins.** Issues confined to the following plugins/components are out of scope: `consolidate`, `errorlogs`, `system-utility`, `vue-example`.
+
+6. **Reliance on already-privileged access.** Issues that require the attacker to already hold rights equal to or greater than the access obtained (e.g. needing global admin to reach data a global admin already sees), or that depend on knowing a non-enumerable identifier of another tenant that is only ever exposed to authorized users.
+
+7. **Duplicates and already-known issues.** Reports duplicating an already-reported or already-fixed issue; only the first actionable report is eligible.
+
+8. **Theoretical issues without a working proof of concept**, self-inflicted issues (self-XSS, pasting attacker scripts into one's own console/session), and missing best-practice hardening that does not itself lead to an exploit (covered under "Low" above).


### PR DESCRIPTION
Expands the **Exclusion** section of the root `SECURITY.md` bug-bounty policy into an explicit, itemized out-of-scope list, based on recurring triage decisions.

### Added exclusions
1. Deployment & server configuration (on-premise nature) — kept from the existing text.
2. Privileged / admin-only endpoints behaving as designed (e.g. `/mobile-login`); global admin is a fully trusted role.
3. By-design cross-app access for global admins.
4. Findings only reproducible against outdated/unpatched running servers when already fixed in current code.
5. Excluded plugins: `consolidate`, `errorlogs`, `system-utility`, `vue-example`.
6. Reliance on already-privileged access / non-enumerable identifiers exposed only to authorized users.
7. Duplicates and already-known issues.
8. Theoretical issues without a working PoC, self-inflicted issues, and best-practice hardening that does not itself lead to an exploit.

These codify how reports have been triaged so reporters have clear, upfront scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)