### PR TITLE
dbviewer: scope event-data base filter for members without app access

### DIFF
--- a/api/utils/rights.js
+++ b/api/utils/rights.js
@@ -1093,18 +1093,33 @@ function validateWrite(params, feature, accessType, callback, callbackParam) {
 exports.getBaseAppFilter = function(member, dbName, collectionName) {
     var base_filter = {};
     var apps = exports.getUserApps(member);
+    // getUserApps() returns [] both for a global admin (meaning "all apps") and
+    // for a non-global member that has no app access at all. Those two cases
+    // must NOT be treated the same: a global admin should see everything, but a
+    // non-global member with an empty app list must be scoped to nothing.
+    // Without this guard the empty list produced an empty {} filter, which the
+    // callers treat as "no scope" and therefore returned every app's rows.
+    var hasApps = Array.isArray(apps) && apps.length > 0;
     if (dbName === "countly_drill" && collectionName === "drill_events") {
-        if (Array.isArray(apps) && apps.length > 0) {
+        if (hasApps) {
             base_filter.a = {"$in": apps};
+        }
+        else if (!member.global_admin) {
+            // non-global member without app access: match nothing
+            base_filter.a = {"$in": []};
         }
     }
     else if (dbName === "countly" && collectionName === "events_data") {
-        var in_array = [];
-        if (Array.isArray(apps) && apps.length > 0) {
+        if (hasApps) {
+            var in_array = [];
             for (var i = 0; i < apps.length; i++) {
                 in_array.push(new RegExp("^" + apps[i] + "_.*"));
             }
             base_filter = {"_id": {"$in": in_array}};
+        }
+        else if (!member.global_admin) {
+            // non-global member without app access: match nothing
+            base_filter = {"_id": {"$in": []}};
         }
     }
     return base_filter;

--- a/test/unit-tests/api.utils.rights.getBaseAppFilter.js
+++ b/test/unit-tests/api.utils.rights.getBaseAppFilter.js
@@ -1,0 +1,49 @@
+var should = require("should");
+var rights = require("../../api/utils/rights.js");
+
+// getBaseAppFilter() builds the app-scoping filter applied to events_data /
+// drill_events reads and exports in the dbviewer plugin. getUserApps() returns
+// an empty array both for a global admin (meaning "all apps") and for a
+// non-global member with no app access — these two must produce different
+// filters: the admin sees everything, the no-access member must see nothing.
+describe("rights.getBaseAppFilter", function() {
+    var globalAdmin = { global_admin: true };
+    var noAppMember = { global_admin: false, permission: { _: { a: [], u: [] } } };
+    var scopedMember = { global_admin: false, permission: { _: { a: ["aaaaaaaaaaaaaaaaaaaaaaaa"], u: [] } } };
+
+    describe("events_data", function() {
+        it("returns an empty (all-access) filter for a global admin", function() {
+            var f = rights.getBaseAppFilter(globalAdmin, "countly", "events_data");
+            Object.keys(f).length.should.equal(0);
+        });
+        it("scopes a member to their own apps", function() {
+            var f = rights.getBaseAppFilter(scopedMember, "countly", "events_data");
+            f.should.have.property("_id");
+            f._id.should.have.property("$in");
+            f._id.$in.length.should.equal(1);
+        });
+        it("denies a non-global member with no app access (match nothing)", function() {
+            var f = rights.getBaseAppFilter(noAppMember, "countly", "events_data");
+            f.should.have.property("_id");
+            f._id.should.have.property("$in");
+            f._id.$in.length.should.equal(0);
+        });
+    });
+
+    describe("drill_events", function() {
+        it("returns an empty (all-access) filter for a global admin", function() {
+            var f = rights.getBaseAppFilter(globalAdmin, "countly_drill", "drill_events");
+            Object.keys(f).length.should.equal(0);
+        });
+        it("scopes a member to their own apps", function() {
+            var f = rights.getBaseAppFilter(scopedMember, "countly_drill", "drill_events");
+            f.should.have.property("a");
+            f.a.$in.length.should.equal(1);
+        });
+        it("denies a non-global member with no app access (match nothing)", function() {
+            var f = rights.getBaseAppFilter(noAppMember, "countly_drill", "drill_events");
+            f.should.have.property("a");
+            f.a.$in.length.should.equal(0);
+        });
+    });
+});

--- a/test/unit-tests/api.utils.rights.getBaseAppFilter.js
+++ b/test/unit-tests/api.utils.rights.getBaseAppFilter.js
@@ -1,4 +1,4 @@
-var should = require("should");
+require("should");
 var rights = require("../../api/utils/rights.js");
 
 // getBaseAppFilter() builds the app-scoping filter applied to events_data /


### PR DESCRIPTION
### Summary

`getBaseAppFilter()` builds the app-scoping filter applied to `events_data` and `drill_events` reads (`/o/db`) and exports (`/o/export/db`) in the dbviewer plugin.

`getUserApps()` returns an empty array in **two different situations**:
- a **global admin** — empty means "all apps";
- a **non-global member with no app access** — should mean "no apps".

`getBaseAppFilter()` only applied a scope when the app list was non-empty, so the second case fell through to an empty `{}` filter. The dbviewer read path treats `{}` as "no scope" (`Object.keys(base_filter).length > 0` is false → no filter applied) and the export path turns it into `{$match: {}}` — both return **every** app's rows.

### Fix

Distinguish the two cases inside `getBaseAppFilter()`:
- global admin → unchanged `{}` (all-access);
- member **with** apps → unchanged per-app scope;
- non-global member with an **empty** app list → match-nothing filter (`{_id:{$in:[]}}` for `events_data`, `{a:{$in:[]}}` for `drill_events`).

This is the correct layer to fix: the `events_data`/`drill_events` access-gate special-case is intentionally relied on by members who *do* have app access (the per-collection grant list does not include event data), so scoping must happen on the data filter.

### Tests

Adds `test/unit-tests/api.utils.rights.getBaseAppFilter.js` — 6 cases covering global admin / scoped member / no-app member for both `events_data` and `drill_events`. All passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)