### PR TITLE
views: enforce token app scope on /o/actions heatmap endpoint

### DIFF
--- a/plugins/views/api/api.js
+++ b/plugins/views/api/api.js
@@ -1576,6 +1576,11 @@ const escapedViewSegments = { "name": true, "segment": true, "height": true, "wi
                         db: common.db,
                         token: params.req.headers["countly-token"],
                         req_path: params.fullPath,
+                        // pass qstring so the token's app restriction is enforced
+                        // against the app resolved from app_key above. Without it,
+                        // verify_token skips the app check entirely and an
+                        // app-scoped token would be accepted for any other app.
+                        qstring: params.qstring,
                         callback: function(owner, expires_after) {
                             if (owner) {
                                 var token = params.req.headers["countly-token"];

--- a/test/2.api/14.authorize.token.js
+++ b/test/2.api/14.authorize.token.js
@@ -268,6 +268,60 @@ describe('Creating token to allow only paths under /o/users/', function() {
 });
 
 
+describe('App-scoped token enforces its app restriction', function() {
+    var appScopedToken = "";
+    // an app id the token is NOT scoped to
+    var OTHER_APP_ID = "aaaaaaaaaaaaaaaaaaaaaaaa";
+
+    it('creating a token scoped to a single app', function(done) {
+        authorize.save({
+            db: testUtils.db,
+            endpoint: "^/o/actions",
+            multi: true,
+            app: [APP_ID + ""],
+            owner: testowner,
+            callback: function(err, token) {
+                if (err) {
+                    return done(err);
+                }
+                if (token) {
+                    appScopedToken = token;
+                    done();
+                }
+                else {
+                    done("token not created");
+                }
+            }
+        });
+    });
+
+    it('is valid for its own app when app_id matches', function(done) {
+        authorize.verify_return({
+            db: testUtils.db,
+            token: appScopedToken,
+            req_path: "/o/actions",
+            qstring: {app_id: APP_ID + ""},
+            callback: function(valid) {
+                should(valid).be.ok(); // owner id (truthy) on success
+                done();
+            }
+        });
+    });
+
+    it('is rejected for a different app_id', function(done) {
+        authorize.verify_return({
+            db: testUtils.db,
+            token: appScopedToken,
+            req_path: "/o/actions",
+            qstring: {app_id: OTHER_APP_ID},
+            callback: function(valid) {
+                (valid === false).should.be.exactly(true);
+                done();
+            }
+        });
+    });
+});
+
 describe("cleaning up", function() {
     it('remove token and user', function(done) {
         var params = {user_ids: [testowner]};


### PR DESCRIPTION
### Summary

The `countly-token` branch of the `/o/actions` heatmap endpoint resolves the target app from the caller-supplied `app_key`, sets `params.qstring.app_id` from it, and then calls `authorize.verify_return()` **without passing `qstring`**.

`authorizer.verify_token()` only enforces a token's `app` restriction when `options.qstring.app_id` is present:

```js
if (res.app && res.app !== "") {
    if (!Array.isArray(res.app)) { res.app = [res.app]; }
    if (options.qstring && options.qstring.app_id) {   // skipped when qstring absent
        if (res.app.indexOf(options.qstring.app_id) === -1) { valid_app = false; }
    }
}
```

With `qstring` omitted, the app check is skipped and `valid_app` stays `true`, so an app-scoped token is accepted for **any** app. The branch then calls `getHeatmap()` directly (the token is the authorization model here), returning the target app's heatmap rows.

### Fix

Pass `qstring` into `verify_return` so the token's app list is checked against the app resolved from `app_key`. A token scoped to app A is now rejected when replayed against app B. Global-admin/unrestricted tokens and correctly-scoped requests are unaffected.

This matches the only other `verify_return` caller (`api/utils/rights.js`), which already passes `qstring`. No other callers omit it.

### Tests

Adds a block to `test/2.api/14.authorize.token.js`: an app-scoped token verifies for its own `app_id` and is rejected for a different one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)