### PR TITLE
push: bind estimate audience endpoint to permission-checked app_id

### DIFF
--- a/plugins/push/api/api-message.js
+++ b/plugins/push/api/api-message.js
@@ -609,6 +609,18 @@ module.exports.estimate = async params => {
         return true;
     }
 
+    // Cross-app guard. validateRead only checks the caller's permission against
+    // params.qstring.app_id, while the body's "app" field selects which app's
+    // push audience is counted. Without this binding a user with push:read on
+    // app A could pass app_id=A and body app=B to read app B's audience count,
+    // locale distribution and run filter.user/filter.drill segment queries over
+    // app B's user profiles. Force the body's app to match the
+    // permission-checked qstring.app_id.
+    if (params.qstring.app_id && data.app && (data.app + "") !== (params.qstring.app_id + "")) {
+        common.returnMessage(params, 400, {errors: ['app does not match request app_id']}, null, true);
+        return true;
+    }
+
     let app = await common.db.collection('apps').findOne({_id: data.app});
     if (!app) {
         common.returnMessage(params, 400, {errors: ['No such app']}, null, true);

--- a/plugins/push/api/api-message.js
+++ b/plugins/push/api/api-message.js
@@ -617,7 +617,7 @@ module.exports.estimate = async params => {
     // app B's user profiles. Force the body's app to match the
     // permission-checked qstring.app_id.
     if (params.qstring.app_id && data.app && (data.app + "") !== (params.qstring.app_id + "")) {
-        common.returnMessage(params, 400, {errors: ['app does not match request app_id']}, null, true);
+        common.returnMessage(params, 400, {errors: ['args.app does not match request app_id']}, null, true);
         return true;
     }
 


### PR DESCRIPTION
### Summary

`/o/push/message/estimate` is routed as `[validateRead, estimate]`. `validateRead` only checks the caller's permission against `params.qstring.app_id`, but the `estimate` handler (`plugins/push/api/api-message.js`) independently reads the body's `app` field, loads that app, and aggregates `app_users<app>` for the count and locale buckets — without verifying that the body `app` matches the permission-checked `app_id`.

A user with `push:read` on app A could pass `app_id=A` with body `app=B` and receive app B's push audience count and locale distribution, and the accepted `filter.user` / `filter.drill` fields allow targeted segment queries over app B's user profiles (a cross-app audience oracle).

Unlike `create`/`test`/`update`/`one`/`remove`/`toggle`, which already bind the body app to `qstring.app_id` (via `validate(args, draft, params)`), `estimate` does not call that guarded path and was missed.

### Fix

Add the same binding to `estimate`: reject the request with 400 when the body `app` does not match `params.qstring.app_id`, before loading the body-selected app or aggregating users.

### Regression test (recommended)

The push integration suite (`plugins/push/tests/index.js`) is currently fully commented out, so a wired test would not run today. When the suite is re-enabled, the regression to add: create two apps, grant the caller `push:read` on app A only, then assert `POST /o/push/message/estimate?app_id=<A>` with body `app=<B>` is rejected and returns no count/locales for app B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)