### PR TITLE
[backport 24.05] views: enforce token app scope on /o/actions

### DIFF
--- a/plugins/views/api/api.js
+++ b/plugins/views/api/api.js
@@ -1538,6 +1538,11 @@ const escapedViewSegments = { "name": true, "segment": true, "height": true, "wi
                         db: common.db,
                         token: params.req.headers["countly-token"],
                         req_path: params.fullPath,
+                        // pass qstring so the token's app restriction is enforced
+                        // against the app resolved from app_key above. Without it,
+                        // verify_token skips the app check entirely and an
+                        // app-scoped token would be accepted for any other app.
+                        qstring: params.qstring,
                         callback: function(owner, expires_after) {
                             if (owner) {
                                 var token = params.req.headers["countly-token"];

--- a/test/2.api/14.authorize.token.js
+++ b/test/2.api/14.authorize.token.js
@@ -268,6 +268,60 @@ describe('Creating token to allow only paths under /o/users/', function() {
 });
 
 
+describe('App-scoped token enforces its app restriction', function() {
+    var appScopedToken = "";
+    // an app id the token is NOT scoped to
+    var OTHER_APP_ID = "aaaaaaaaaaaaaaaaaaaaaaaa";
+
+    it('creating a token scoped to a single app', function(done) {
+        authorize.save({
+            db: testUtils.db,
+            endpoint: "^/o/actions",
+            multi: true,
+            app: [APP_ID + ""],
+            owner: testowner,
+            callback: function(err, token) {
+                if (err) {
+                    return done(err);
+                }
+                if (token) {
+                    appScopedToken = token;
+                    done();
+                }
+                else {
+                    done("token not created");
+                }
+            }
+        });
+    });
+
+    it('is valid for its own app when app_id matches', function(done) {
+        authorize.verify_return({
+            db: testUtils.db,
+            token: appScopedToken,
+            req_path: "/o/actions",
+            qstring: {app_id: APP_ID + ""},
+            callback: function(valid) {
+                should(valid).be.ok(); // owner id (truthy) on success
+                done();
+            }
+        });
+    });
+
+    it('is rejected for a different app_id', function(done) {
+        authorize.verify_return({
+            db: testUtils.db,
+            token: appScopedToken,
+            req_path: "/o/actions",
+            qstring: {app_id: OTHER_APP_ID},
+            callback: function(valid) {
+                (valid === false).should.be.exactly(true);
+                done();
+            }
+        });
+    });
+});
+
 describe("cleaning up", function() {
     it('remove token and user', function(done) {
         var params = {user_ids: [testowner]};


### PR DESCRIPTION
Backport of #7677 to `release.24.05`.

The `/o/actions` countly-token branch resolved the app from the caller-supplied `app_key` and called `authorize.verify_return` without passing `qstring`; `verify_token` only enforces a token's app restriction when `qstring.app_id` is present, so an app-scoped token was accepted for any app. Fixed by passing `qstring`. Includes the authorizer-contract regression test (added to the existing `test/2.api/14.authorize.token.js`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)