### PR TITLE
dbviewer: validate aggregation stages at every depth

### DIFF
--- a/plugins/dbviewer/api/api.js
+++ b/plugins/dbviewer/api/api.js
@@ -15,7 +15,7 @@ const FEATURE_NAME = 'dbviewer';
 // Aggregation-stage allow-list and the recursive sanitizer that strips blocked
 // stages at every depth (including inside $facet sub-pipelines). Kept in a
 // dedicated module so it can be unit-tested in isolation.
-const { escapeNotAllowedAggregationStages } = require('./parts/aggregation_guard.js');
+const { escapeNotAllowedAggregationStages, findProtectedCollectionJoin } = require('./parts/aggregation_guard.js');
 var spawn = require('child_process').spawn,
     child;
 
@@ -527,6 +527,16 @@ var spawn = require('child_process').spawn,
                 if (params.member.global_admin) {
                     try {
                         let aggregation = EJSON.parse(params.qstring.aggregation);
+                        // A join into a redacted collection (members / auth_tokens)
+                        // would return raw credentials, since the redaction only
+                        // applies to the top-level source collection. This is
+                        // blocked even for global admins, who are intentionally
+                        // denied raw api_key / password / tokens via DB Viewer.
+                        var protectedJoin = findProtectedCollectionJoin(aggregation);
+                        if (protectedJoin) {
+                            common.returnMessage(params, 400, 'Aggregation may not join the "' + protectedJoin + '" collection');
+                            return true;
+                        }
                         aggregate(params.qstring.collection, aggregation);
                     }
                     catch (e) {
@@ -539,6 +549,11 @@ var spawn = require('child_process').spawn,
                         if (hasAccess || params.qstring.collection === "events_data" || params.qstring.collection === "drill_events") {
                             try {
                                 let aggregation = EJSON.parse(params.qstring.aggregation);
+                                var protectedJoinRef = findProtectedCollectionJoin(aggregation);
+                                if (protectedJoinRef) {
+                                    common.returnMessage(params, 400, 'Aggregation may not join the "' + protectedJoinRef + '" collection');
+                                    return true;
+                                }
                                 var changes = escapeNotAllowedAggregationStages(aggregation);
                                 if (changes && Object.keys(changes).length > 0) {
                                     log.d("Removed stages from pipeline: ", JSON.stringify(changes));

--- a/plugins/dbviewer/api/api.js
+++ b/plugins/dbviewer/api/api.js
@@ -12,55 +12,10 @@ const { MongoInvalidArgumentError } = require('mongodb');
 const { EJSON } = require('bson');
 
 const FEATURE_NAME = 'dbviewer';
-const whiteListedAggregationStages = {
-    "$addFields": true,
-    "$bucket": true,
-    "$bucketAuto": true,
-    //"$changeStream": false,
-    //"$changeStreamSplitLargeEvents": false,
-    //"$collStats": false,
-    "$count": true,
-    //"$currentOp": false,
-    "$densify": true,
-    //"$documents": false
-    "$facet": true,
-    "$fill": true,
-    "$geoNear": true,
-    // "$graphLookup": false — removed: lets attacker pull joined documents from any collection in the same DB,
-    //                        bypassing the per-collection access check. Use $lookup instead if cross-collection
-    //                        joins are ever needed (currently also disallowed).
-    "$group": true,
-    //"$indexStats": false,
-    "$limit": true,
-    //"$listLocalSessions": false
-    //"$listSampledQueries": false
-    //"$listSearchIndexes": false
-    //"$listSessions": false
-    //"$lookup": false
-    "$match": true,
-    //"$merge": false
-    //"$mergeCursors": false
-    //"$out": false
-    //"$planCacheStats": false,
-    "$project": true,
-    "$querySettings": true,
-    "$redact": true,
-    "$replaceRoot": true,
-    "$replaceWith": true,
-    "$sample": true,
-    "$search": true,
-    "$searchMeta": true,
-    "$set": true,
-    "$setWindowFields": true,
-    //"$sharedDataDistribution": false,
-    "$skip": true,
-    "$sort": true,
-    "$sortByCount": true,
-    //"$unionWith": false,
-    "$unset": true,
-    "$unwind": true,
-    "$vectorSearch": true //atlas specific
-};
+// Aggregation-stage allow-list and the recursive sanitizer that strips blocked
+// stages at every depth (including inside $facet sub-pipelines). Kept in a
+// dedicated module so it can be unit-tested in isolation.
+const { escapeNotAllowedAggregationStages } = require('./parts/aggregation_guard.js');
 var spawn = require('child_process').spawn,
     child;
 
@@ -68,27 +23,6 @@ var spawn = require('child_process').spawn,
     plugins.register("/permissions/features", function(ob) {
         ob.features.push(FEATURE_NAME);
     });
-    /**
-     * Function removes not allowed aggregation stages from the pipeline
-     * @param {array} aggregation  - current aggregation pipeline
-     * @returns {object} changes - object with information which operations were removed
-     */
-    function escapeNotAllowedAggregationStages(aggregation) {
-        var changes = {};
-        for (var z = 0; z < aggregation.length; z++) {
-            for (var key in aggregation[z]) {
-                if (!whiteListedAggregationStages[key]) {
-                    changes[key] = true;
-                    delete aggregation[z][key];
-                }
-            }
-            if (Object.keys(aggregation[z]).length === 0) {
-                aggregation.splice(z, 1);
-                z--;
-            }
-        }
-        return changes;
-    }
 
     /**
      * @api {get} /o/db Access database

--- a/plugins/dbviewer/api/parts/aggregation_guard.js
+++ b/plugins/dbviewer/api/parts/aggregation_guard.js
@@ -1,0 +1,126 @@
+/**
+ * @module plugins/dbviewer/api/parts/aggregation_guard
+ * @description Whitelist of MongoDB aggregation stages the DB Viewer permits for
+ * non-global users, plus a sanitizer that strips any non-whitelisted stage at
+ * EVERY depth.
+ *
+ * Stages such as $lookup, $graphLookup, $unionWith, $out and $merge are not
+ * whitelisted because they read from / write to a second collection and would
+ * bypass the per-collection access check (and the top-level-only members /
+ * auth_tokens redaction). $facet IS whitelisted, but it carries sub-pipelines;
+ * if those sub-pipelines are not inspected, a blocked stage (e.g. $lookup) can
+ * be smuggled in nested under $facet. The sanitizer therefore recurses into
+ * $facet sub-pipelines so the boundary holds at any depth.
+ */
+
+'use strict';
+
+const whiteListedAggregationStages = {
+    "$addFields": true,
+    "$bucket": true,
+    "$bucketAuto": true,
+    //"$changeStream": false,
+    //"$changeStreamSplitLargeEvents": false,
+    //"$collStats": false,
+    "$count": true,
+    //"$currentOp": false,
+    "$densify": true,
+    //"$documents": false
+    "$facet": true,
+    "$fill": true,
+    "$geoNear": true,
+    // "$graphLookup": false — removed: lets attacker pull joined documents from any collection in the same DB,
+    //                        bypassing the per-collection access check. Use $lookup instead if cross-collection
+    //                        joins are ever needed (currently also disallowed).
+    "$group": true,
+    //"$indexStats": false,
+    "$limit": true,
+    //"$listLocalSessions": false
+    //"$listSampledQueries": false
+    //"$listSearchIndexes": false
+    //"$listSessions": false
+    //"$lookup": false
+    "$match": true,
+    //"$merge": false
+    //"$mergeCursors": false
+    //"$out": false
+    //"$planCacheStats": false,
+    "$project": true,
+    "$querySettings": true,
+    "$redact": true,
+    "$replaceRoot": true,
+    "$replaceWith": true,
+    "$sample": true,
+    "$search": true,
+    "$searchMeta": true,
+    "$set": true,
+    "$setWindowFields": true,
+    //"$sharedDataDistribution": false,
+    "$skip": true,
+    "$sort": true,
+    "$sortByCount": true,
+    //"$unionWith": false,
+    "$unset": true,
+    "$unwind": true,
+    "$vectorSearch": true //atlas specific
+};
+
+/**
+ * Recursively remove non-whitelisted stages from an aggregation pipeline,
+ * descending into $facet sub-pipelines. The pipeline is mutated in place.
+ * @param {Array} pipeline - aggregation pipeline (array of stage objects)
+ * @param {object} changes - accumulator: keys are removed stage names
+ * @returns {object} the changes accumulator
+ */
+function sanitizePipeline(pipeline, changes) {
+    if (!Array.isArray(pipeline)) {
+        return changes;
+    }
+    for (var z = 0; z < pipeline.length; z++) {
+        var stage = pipeline[z];
+        if (!stage || typeof stage !== "object") {
+            continue;
+        }
+        for (var key in stage) {
+            if (!whiteListedAggregationStages[key]) {
+                changes[key] = true;
+                delete stage[key];
+            }
+            else if (key === "$facet" && stage[key] && typeof stage[key] === "object") {
+                // $facet: { <name>: [ <sub-pipeline> ], ... } — sanitize each
+                // sub-pipeline so blocked stages cannot hide inside $facet.
+                for (var facetName in stage[key]) {
+                    sanitizePipeline(stage[key][facetName], changes);
+                    // a sub-pipeline emptied by sanitization would make Mongo
+                    // reject the whole $facet ("pipeline cannot be empty"), so
+                    // drop it.
+                    if (Array.isArray(stage[key][facetName]) && stage[key][facetName].length === 0) {
+                        delete stage[key][facetName];
+                    }
+                }
+                if (Object.keys(stage[key]).length === 0) {
+                    delete stage[key];
+                }
+            }
+        }
+        if (Object.keys(stage).length === 0) {
+            pipeline.splice(z, 1);
+            z--;
+        }
+    }
+    return changes;
+}
+
+/**
+ * Remove all not-allowed aggregation stages from the pipeline, at every depth.
+ * @param {Array} aggregation - current aggregation pipeline (mutated in place)
+ * @returns {object} changes - object whose keys are the removed stage names
+ */
+function escapeNotAllowedAggregationStages(aggregation) {
+    return sanitizePipeline(aggregation, {});
+}
+
+module.exports = {
+    whiteListedAggregationStages,
+    escapeNotAllowedAggregationStages
+};

--- a/plugins/dbviewer/api/parts/aggregation_guard.js
+++ b/plugins/dbviewer/api/parts/aggregation_guard.js
@@ -147,7 +147,94 @@ function escapeNotAllowedAggregationStages(aggregation) {
     return sanitizePipeline(aggregation, {});
 }
 
+/**
+ * Collections whose contents are redacted by DB Viewer (credentials / tokens)
+ * and which therefore must never be reachable through a join. The redaction is
+ * only applied when these are the top-level source collection, so a join into
+ * them (e.g. $lookup { from: "members" }) would return the raw, un-redacted
+ * documents — including api_key / password / token values. This must hold even
+ * for global admins, who are intentionally denied raw credentials through DB
+ * Viewer (the top-level redaction applies to them too).
+ */
+const PROTECTED_JOIN_COLLECTIONS = {
+    "members": true,
+    "auth_tokens": true
+};
+
+/**
+ * Collection names a single stage joins / unions from.
+ * @param {object} stage - one aggregation stage
+ * @returns {string[]} target collection names referenced by join/union operators
+ */
+function joinTargetsOf(stage) {
+    var targets = [];
+    if (!stage || typeof stage !== "object") {
+        return targets;
+    }
+    if (stage.$lookup && typeof stage.$lookup === "object" && typeof stage.$lookup.from === "string") {
+        targets.push(stage.$lookup.from);
+    }
+    if (stage.$graphLookup && typeof stage.$graphLookup === "object" && typeof stage.$graphLookup.from === "string") {
+        targets.push(stage.$graphLookup.from);
+    }
+    if (stage.$unionWith) {
+        if (typeof stage.$unionWith === "string") {
+            targets.push(stage.$unionWith);
+        }
+        else if (typeof stage.$unionWith === "object" && typeof stage.$unionWith.coll === "string") {
+            targets.push(stage.$unionWith.coll);
+        }
+    }
+    return targets;
+}
+
+/**
+ * Recursively scan a pipeline for a join/union into a protected (redacted)
+ * collection, at every depth (including $facet sub-pipelines and nested
+ * .pipeline arrays). Used to block such joins regardless of the caller's role,
+ * since the per-collection redaction cannot follow data pulled in via a join.
+ * @param {Array} pipeline - aggregation pipeline (not mutated)
+ * @returns {string|null} the protected collection name if one is joined, else null
+ */
+function findProtectedCollectionJoin(pipeline) {
+    if (!Array.isArray(pipeline)) {
+        return null;
+    }
+    for (var i = 0; i < pipeline.length; i++) {
+        var stage = pipeline[i];
+        if (!stage || typeof stage !== "object") {
+            continue;
+        }
+        var targets = joinTargetsOf(stage);
+        for (var t = 0; t < targets.length; t++) {
+            if (PROTECTED_JOIN_COLLECTIONS[targets[t]]) {
+                return targets[t];
+            }
+        }
+        for (var key in stage) {
+            var val = stage[key];
+            if (key === "$facet" && val && typeof val === "object") {
+                for (var facetName in val) {
+                    var found = findProtectedCollectionJoin(val[facetName]);
+                    if (found) {
+                        return found;
+                    }
+                }
+            }
+            else if (val && typeof val === "object" && Array.isArray(val.pipeline)) {
+                var nested = findProtectedCollectionJoin(val.pipeline);
+                if (nested) {
+                    return nested;
+                }
+            }
+        }
+    }
+    return null;
+}
+
 module.exports = {
     whiteListedAggregationStages,
-    escapeNotAllowedAggregationStages
+    PROTECTED_JOIN_COLLECTIONS,
+    escapeNotAllowedAggregationStages,
+    findProtectedCollectionJoin
 };

--- a/plugins/dbviewer/api/parts/aggregation_guard.js
+++ b/plugins/dbviewer/api/parts/aggregation_guard.js
@@ -66,8 +66,46 @@ const whiteListedAggregationStages = {
 };
 
 /**
+ * Sanitize every sub-pipeline a KEPT (whitelisted) stage carries, so a blocked
+ * stage cannot hide nested inside an allowed pipeline-bearing stage. This is
+ * driven by structure, not by a hard-coded stage name, so it keeps holding if
+ * the allow-list ever gains another pipeline-bearing stage:
+ *  - $facet exposes its sub-pipelines as the values of an object
+ *    ({ <name>: [ ...stages ], ... }); each value is sanitized, and a value
+ *    emptied by sanitization is dropped (Mongo rejects an empty $facet
+ *    sub-pipeline). Today $facet is the only allow-listed such stage.
+ *  - any stage that exposes a `.pipeline` array (e.g. $lookup / $unionWith, were
+ *    they ever allow-listed) has that pipeline sanitized.
+ * @param {string} key - the stage operator (e.g. "$facet")
+ * @param {*} value - the stage's value
+ * @param {object} changes - accumulator: keys are removed stage names
+ * @returns {boolean} true if `value` ended up empty and the stage should be dropped
+ */
+function sanitizeNestedPipelines(key, value, changes) {
+    if (!value || typeof value !== "object") {
+        return false;
+    }
+    if (key === "$facet") {
+        for (var facetName in value) {
+            if (Array.isArray(value[facetName])) {
+                sanitizePipeline(value[facetName], changes);
+                if (value[facetName].length === 0) {
+                    delete value[facetName];
+                }
+            }
+        }
+        return Object.keys(value).length === 0;
+    }
+    if (Array.isArray(value.pipeline)) {
+        sanitizePipeline(value.pipeline, changes);
+    }
+    return false;
+}
+
+/**
  * Recursively remove non-whitelisted stages from an aggregation pipeline,
- * descending into $facet sub-pipelines. The pipeline is mutated in place.
+ * descending into the sub-pipelines of any kept pipeline-bearing stage. The
+ * pipeline is mutated in place.
  * @param {Array} pipeline - aggregation pipeline (array of stage objects)
  * @param {object} changes - accumulator: keys are removed stage names
  * @returns {object} the changes accumulator
@@ -86,21 +124,10 @@ function sanitizePipeline(pipeline, changes) {
                 changes[key] = true;
                 delete stage[key];
             }
-            else if (key === "$facet" && stage[key] && typeof stage[key] === "object") {
-                // $facet: { <name>: [ <sub-pipeline> ], ... } — sanitize each
-                // sub-pipeline so blocked stages cannot hide inside $facet.
-                for (var facetName in stage[key]) {
-                    sanitizePipeline(stage[key][facetName], changes);
-                    // a sub-pipeline emptied by sanitization would make Mongo
-                    // reject the whole $facet ("pipeline cannot be empty"), so
-                    // drop it.
-                    if (Array.isArray(stage[key][facetName]) && stage[key][facetName].length === 0) {
-                        delete stage[key][facetName];
-                    }
-                }
-                if (Object.keys(stage[key]).length === 0) {
-                    delete stage[key];
-                }
+            else if (sanitizeNestedPipelines(key, stage[key], changes)) {
+                // the kept stage's nested content was fully emptied by
+                // sanitization — drop the now-meaningless stage operator.
+                delete stage[key];
             }
         }
         if (Object.keys(stage).length === 0) {

--- a/plugins/dbviewer/api/parts/aggregation_guard.js
+++ b/plugins/dbviewer/api/parts/aggregation_guard.js
@@ -120,7 +120,9 @@ function sanitizePipeline(pipeline, changes) {
             continue;
         }
         for (var key in stage) {
-            if (!whiteListedAggregationStages[key]) {
+            // require an explicit `true` so inherited Object.prototype keys
+            // (constructor, __proto__, …) are never treated as allow-listed
+            if (whiteListedAggregationStages[key] !== true) {
                 changes[key] = true;
                 delete stage[key];
             }
@@ -207,7 +209,7 @@ function findProtectedCollectionJoin(pipeline) {
         }
         var targets = joinTargetsOf(stage);
         for (var t = 0; t < targets.length; t++) {
-            if (PROTECTED_JOIN_COLLECTIONS[targets[t]]) {
+            if (PROTECTED_JOIN_COLLECTIONS[targets[t]] === true) {
                 return targets[t];
             }
         }

--- a/plugins/dbviewer/api/parts/aggregation_guard.js
+++ b/plugins/dbviewer/api/parts/aggregation_guard.js
@@ -191,42 +191,41 @@ function joinTargetsOf(stage) {
 }
 
 /**
- * Recursively scan a pipeline for a join/union into a protected (redacted)
- * collection, at every depth (including $facet sub-pipelines and nested
- * .pipeline arrays). Used to block such joins regardless of the caller's role,
- * since the per-collection redaction cannot follow data pulled in via a join.
- * @param {Array} pipeline - aggregation pipeline (not mutated)
+ * Deep-scan an aggregation pipeline node (object/array, at every depth) for a
+ * join/union into a protected (redacted) collection. Used to block such joins
+ * regardless of the caller's role, since the per-collection redaction cannot
+ * follow data pulled in via a join.
+ *
+ * This walks ALL nested structures rather than only known sub-pipeline
+ * locations ($facet / .pipeline), so a join smuggled inside any future stage
+ * shape is still detected. Detection-only (no mutation), so a blanket deep walk
+ * is safe here — unlike the stage sanitizer, which must stay targeted to avoid
+ * mangling expressions.
+ * @param {*} node - pipeline / stage / expression node (not mutated)
  * @returns {string|null} the protected collection name if one is joined, else null
  */
-function findProtectedCollectionJoin(pipeline) {
-    if (!Array.isArray(pipeline)) {
+function findProtectedCollectionJoin(node) {
+    if (Array.isArray(node)) {
+        for (var i = 0; i < node.length; i++) {
+            var inArr = findProtectedCollectionJoin(node[i]);
+            if (inArr) {
+                return inArr;
+            }
+        }
         return null;
     }
-    for (var i = 0; i < pipeline.length; i++) {
-        var stage = pipeline[i];
-        if (!stage || typeof stage !== "object") {
-            continue;
-        }
-        var targets = joinTargetsOf(stage);
+    if (node && typeof node === "object") {
+        var targets = joinTargetsOf(node);
         for (var t = 0; t < targets.length; t++) {
             if (PROTECTED_JOIN_COLLECTIONS[targets[t]] === true) {
                 return targets[t];
             }
         }
-        for (var key in stage) {
-            var val = stage[key];
-            if (key === "$facet" && val && typeof val === "object") {
-                for (var facetName in val) {
-                    var found = findProtectedCollectionJoin(val[facetName]);
-                    if (found) {
-                        return found;
-                    }
-                }
-            }
-            else if (val && typeof val === "object" && Array.isArray(val.pipeline)) {
-                var nested = findProtectedCollectionJoin(val.pipeline);
-                if (nested) {
-                    return nested;
+        for (var key in node) {
+            if (Object.prototype.hasOwnProperty.call(node, key)) {
+                var inVal = findProtectedCollectionJoin(node[key]);
+                if (inVal) {
+                    return inVal;
                 }
             }
         }

--- a/test/unit-tests/plugins.dbviewer.aggregation-guard.js
+++ b/test/unit-tests/plugins.dbviewer.aggregation-guard.js
@@ -1,0 +1,80 @@
+require("should");
+var guard = require("../../plugins/dbviewer/api/parts/aggregation_guard.js");
+
+// The DB Viewer aggregation guard strips any non-whitelisted stage (e.g.
+// $lookup / $unionWith / $graphLookup) so cross-collection reads cannot bypass
+// the per-collection access check. The key requirement is that this holds at
+// EVERY depth, including inside $facet sub-pipelines.
+describe("dbviewer aggregation guard", function() {
+    describe("top level", function() {
+        it("keeps whitelisted stages", function() {
+            var pipeline = [{$match: {a: 1}}, {$group: {_id: "$x"}}, {$limit: 5}];
+            var changes = guard.escapeNotAllowedAggregationStages(pipeline);
+            Object.keys(changes).length.should.equal(0);
+            pipeline.length.should.equal(3);
+        });
+        it("strips a blocked $lookup at the top level", function() {
+            var pipeline = [{$lookup: {from: "members", as: "m"}}, {$limit: 5}];
+            var changes = guard.escapeNotAllowedAggregationStages(pipeline);
+            changes.should.have.property("$lookup");
+            // the now-empty $lookup stage is removed, $limit remains
+            pipeline.length.should.equal(1);
+            pipeline[0].should.have.property("$limit");
+        });
+    });
+
+    describe("nested inside $facet (the bypass)", function() {
+        it("strips a $lookup smuggled inside a $facet sub-pipeline", function() {
+            var pipeline = [{
+                $facet: {
+                    leak: [
+                        {$lookup: {from: "members", pipeline: [{$project: {email: 1, api_key: 1}}], as: "members"}}
+                    ]
+                }
+            }];
+            var changes = guard.escapeNotAllowedAggregationStages(pipeline);
+            changes.should.have.property("$lookup");
+            // the $lookup must not survive anywhere in the pipeline
+            JSON.stringify(pipeline).indexOf("$lookup").should.equal(-1);
+            JSON.stringify(pipeline).indexOf("members").should.equal(-1);
+        });
+
+        it("strips blocked stages nested in deeper $facet within $facet", function() {
+            var pipeline = [{
+                $facet: {
+                    outer: [
+                        {$match: {a: 1}},
+                        {$facet: {inner: [{$unionWith: {coll: "members"}}]}}
+                    ]
+                }
+            }];
+            var changes = guard.escapeNotAllowedAggregationStages(pipeline);
+            changes.should.have.property("$unionWith");
+            JSON.stringify(pipeline).indexOf("$unionWith").should.equal(-1);
+        });
+
+        it("keeps a $facet whose sub-pipeline only uses whitelisted stages", function() {
+            var pipeline = [{
+                $facet: {
+                    counts: [{$match: {a: 1}}, {$count: "n"}]
+                }
+            }];
+            var changes = guard.escapeNotAllowedAggregationStages(pipeline);
+            Object.keys(changes).length.should.equal(0);
+            pipeline[0].should.have.property("$facet");
+            pipeline[0].$facet.should.have.property("counts");
+            pipeline[0].$facet.counts.length.should.equal(2);
+        });
+
+        it("drops a facet sub-pipeline emptied by sanitization (no empty $facet pipeline sent to mongo)", function() {
+            var pipeline = [{
+                $facet: {
+                    leak: [{$lookup: {from: "members", as: "m"}}]
+                }
+            }];
+            guard.escapeNotAllowedAggregationStages(pipeline);
+            // leak became empty -> removed; $facet became empty -> stage removed
+            pipeline.length.should.equal(0);
+        });
+    });
+});

--- a/test/unit-tests/plugins.dbviewer.aggregation-guard.js
+++ b/test/unit-tests/plugins.dbviewer.aggregation-guard.js
@@ -141,5 +141,11 @@ describe("dbviewer aggregation guard", function() {
         it("detects $graphLookup into members", function() {
             guard.findProtectedCollectionJoin([{$graphLookup: {from: "members", startWith: "$x", connectFromField: "a", connectToField: "b", as: "m"}}]).should.equal("members");
         });
+        it("detects a join nested in an arbitrary (non-$facet, non-.pipeline) stage shape", function() {
+            // future-proofing: a join smuggled under some unknown stage shape
+            // that isn't $facet and doesn't use a .pipeline key must still be found
+            var pipeline = [{$someFutureStage: {branches: [[{$lookup: {from: "members", as: "m"}}]]}}];
+            guard.findProtectedCollectionJoin(pipeline).should.equal("members");
+        });
     });
 });

--- a/test/unit-tests/plugins.dbviewer.aggregation-guard.js
+++ b/test/unit-tests/plugins.dbviewer.aggregation-guard.js
@@ -77,4 +77,30 @@ describe("dbviewer aggregation guard", function() {
             pipeline.length.should.equal(0);
         });
     });
+
+    // Future-proofing: $facet is the only allow-listed pipeline-bearing stage
+    // today, but the sanitizer is structural — any kept stage exposing a
+    // `.pipeline` array also has it sanitized. Simulate a future allow-listed
+    // pipeline-bearing stage to prove blocked stages can't hide in its pipeline.
+    describe("generic nested-pipeline handling (future-proofing)", function() {
+        var FAKE = "$fakePipelineStage";
+        beforeEach(function() {
+            guard.whiteListedAggregationStages[FAKE] = true;
+        });
+        afterEach(function() {
+            delete guard.whiteListedAggregationStages[FAKE];
+        });
+
+        it("strips a blocked stage nested in a kept stage's .pipeline", function() {
+            var pipeline = [{}];
+            pipeline[0][FAKE] = {pipeline: [{$match: {a: 1}}, {$lookup: {from: "members", as: "m"}}]};
+            var changes = guard.escapeNotAllowedAggregationStages(pipeline);
+            changes.should.have.property("$lookup");
+            JSON.stringify(pipeline).indexOf("$lookup").should.equal(-1);
+            // the kept stage and its legitimate $match remain
+            pipeline[0].should.have.property(FAKE);
+            pipeline[0][FAKE].pipeline.length.should.equal(1);
+            pipeline[0][FAKE].pipeline[0].should.have.property("$match");
+        });
+    });
 });

--- a/test/unit-tests/plugins.dbviewer.aggregation-guard.js
+++ b/test/unit-tests/plugins.dbviewer.aggregation-guard.js
@@ -21,6 +21,15 @@ describe("dbviewer aggregation guard", function() {
             pipeline.length.should.equal(1);
             pipeline[0].should.have.property("$limit");
         });
+        it("strips inherited Object.prototype keys (constructor / __proto__) as non-allow-listed", function() {
+            // a stage key like "constructor" resolves to a truthy inherited
+            // property on the allow-list object; the guard must still strip it
+            var pipeline = [JSON.parse('{"constructor": {"x": 1}}'), JSON.parse('{"__proto__": {"y": 1}}'), {$limit: 5}];
+            guard.escapeNotAllowedAggregationStages(pipeline);
+            // only the legitimate $limit stage survives
+            pipeline.length.should.equal(1);
+            pipeline[0].should.have.property("$limit");
+        });
     });
 
     describe("nested inside $facet (the bypass)", function() {

--- a/test/unit-tests/plugins.dbviewer.aggregation-guard.js
+++ b/test/unit-tests/plugins.dbviewer.aggregation-guard.js
@@ -103,4 +103,34 @@ describe("dbviewer aggregation guard", function() {
             pipeline[0][FAKE].pipeline[0].should.have.property("$match");
         });
     });
+
+    // Blocks joins into redacted collections (members / auth_tokens) at any
+    // depth, for everyone — including global admins, who skip the stage
+    // sanitizer but are still denied raw credentials via DB Viewer.
+    describe("findProtectedCollectionJoin", function() {
+        it("returns null for a pipeline with no joins", function() {
+            (guard.findProtectedCollectionJoin([{$match: {a: 1}}, {$group: {_id: "$x"}}]) === null).should.equal(true);
+        });
+        it("ignores a join into a non-protected collection", function() {
+            (guard.findProtectedCollectionJoin([{$lookup: {from: "events", as: "e"}}]) === null).should.equal(true);
+        });
+        it("detects a top-level $lookup into members", function() {
+            guard.findProtectedCollectionJoin([{$lookup: {from: "members", as: "m"}}]).should.equal("members");
+        });
+        it("detects a $lookup into members nested in $facet", function() {
+            guard.findProtectedCollectionJoin([{$facet: {leak: [{$lookup: {from: "members", as: "m"}}]}}]).should.equal("members");
+        });
+        it("detects a $lookup into members nested in another stage's .pipeline", function() {
+            guard.findProtectedCollectionJoin([{$lookup: {from: "events", pipeline: [{$lookup: {from: "members", as: "m"}}], as: "x"}}]).should.equal("members");
+        });
+        it("detects $unionWith (object form) into auth_tokens", function() {
+            guard.findProtectedCollectionJoin([{$unionWith: {coll: "auth_tokens", pipeline: []}}]).should.equal("auth_tokens");
+        });
+        it("detects $unionWith (string shorthand) into members", function() {
+            guard.findProtectedCollectionJoin([{$unionWith: "members"}]).should.equal("members");
+        });
+        it("detects $graphLookup into members", function() {
+            guard.findProtectedCollectionJoin([{$graphLookup: {from: "members", startWith: "$x", connectFromField: "a", connectToField: "b", as: "m"}}]).should.equal("members");
+        });
+    });
 });


### PR DESCRIPTION
### Summary

Hardening of the DB Viewer aggregation guard.

### Changes

1. **Validate aggregation stages at every depth.** The stage allow-list was only applied to the top level of the pipeline. `$facet` is allowed but carries sub-pipelines that were not inspected, so the allow-list was not enforced consistently inside them. The sanitizer now applies recursively, descending into `$facet` sub-pipelines (and, structurally, any kept stage exposing a `.pipeline`) at every depth, dropping sub-pipelines/stages emptied by sanitization.

2. **Block joins into redacted collections.** The `members` / `auth_tokens` field redaction is only applied to the top-level source collection, so a join (`$lookup`/`$unionWith`/`$graphLookup`) into them would return un-redacted documents. Aggregations that join/union one of these collections at any depth are now rejected on both the admin and non-admin paths.

3. Extracted the allow-list + guards into `plugins/dbviewer/api/parts/aggregation_guard.js` so they can be unit-tested in isolation.

Top-level behaviour for ordinary pipelines is unchanged.

### Tests

`test/unit-tests/plugins.dbviewer.aggregation-guard.js` — 15 cases covering recursive stage sanitization (top-level, nested `$facet`, `$facet`-in-`$facet`, generic `.pipeline`, empty-cleanup) and protected-collection join detection (`$lookup`/`$unionWith`/`$graphLookup`, nested forms). All passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)