### PR TITLE
dbviewer: harden aggregation and query handling

### DIFF
--- a/plugins/dbviewer/api/api.js
+++ b/plugins/dbviewer/api/api.js
@@ -388,17 +388,16 @@ var spawn = require('child_process').spawn,
                 common.returnMessage(params, 500, "The aggregation pipeline must be of the type array");
             }
             else {
-                var addProjectionAt = 0;
-                if (aggregation[0] && aggregation[0].$match) {
-                    while (aggregation.length > addProjectionAt && aggregation[addProjectionAt].$match) {
-                        addProjectionAt++;
-                    }
-                }
                 if (collection === 'members') {
-                    aggregation.splice(addProjectionAt, 0, {"$project": {"password": 0, "api_key": 0, "two_factor_auth": 0}});
+                    // Insert the redaction as the very first stage so no
+                    // user-supplied stage — including a leading $match using
+                    // $expr, or a $project/$group that aliases or references the
+                    // field — can read the raw credential fields before they are
+                    // removed.
+                    aggregation.splice(0, 0, {"$project": {"password": 0, "api_key": 0, "two_factor_auth": 0}});
                 }
                 else if (collection === 'auth_tokens') {
-                    aggregation.splice(addProjectionAt, 0, {"$addFields": {"_id": "***redacted***"}});
+                    aggregation.splice(0, 0, {"$addFields": {"_id": "***redacted***"}});
                 }
                 else if ((collection === "events_data" || collection === "drill_events") && !params.member.global_admin) {
                     var base_filter = getBaseAppFilter(params.member, dbNameOnParam, params.qstring.collection);

--- a/plugins/dbviewer/api/api.js
+++ b/plugins/dbviewer/api/api.js
@@ -15,7 +15,8 @@ const FEATURE_NAME = 'dbviewer';
 // Aggregation-stage allow-list and the recursive sanitizer that strips blocked
 // stages at every depth (including inside $facet sub-pipelines). Kept in a
 // dedicated module so it can be unit-tested in isolation.
-const { escapeNotAllowedAggregationStages, findProtectedCollectionJoin } = require('./parts/aggregation_guard.js');
+const { escapeNotAllowedAggregationStages, findProtectedCollectionJoin, findWriteStage } = require('./parts/aggregation_guard.js');
+const { sanitizeProjection, escapeRegExp } = require('./parts/query_guard.js');
 var spawn = require('child_process').spawn,
     child;
 
@@ -123,11 +124,22 @@ var spawn = require('child_process').spawn,
                     params.qstring.document = common.db.ObjectID(params.qstring.document);
                 }
                 if (dbs[dbNameOnParam]) {
-                    dbs[dbNameOnParam].collection(params.qstring.collection).findOne({ _id: params.qstring.document }, function(err, results) {
+                    // Scope the lookup to the member's apps the same way the
+                    // collection listing does, so a document cannot be fetched
+                    // outside the caller's app scope by supplying its _id.
+                    var docFilter = { _id: params.qstring.document };
+                    if (!params.member.global_admin) {
+                        var docBaseFilter = getBaseAppFilter(params.member, dbNameOnParam, params.qstring.collection);
+                        if (docBaseFilter && Object.keys(docBaseFilter).length > 0) {
+                            docFilter = { $and: [docBaseFilter, docFilter] };
+                        }
+                    }
+                    dbs[dbNameOnParam].collection(params.qstring.collection).findOne(docFilter, function(err, results) {
                         if (!err) {
                             if (params.qstring.collection === 'members' && results) {
                                 delete results.password;
                                 delete results.api_key;
+                                delete results.two_factor_auth;
                             }
                             else if (params.qstring.collection === 'auth_tokens' && results) {
                                 if (results._id) {
@@ -182,7 +194,9 @@ var spawn = require('child_process').spawn,
                 filter._id = common.db.ObjectID(filter._id);
             }
             if (sSearch) {
-                filter._id = new RegExp(sSearch);
+                // treat the search term as a literal so a crafted pattern cannot
+                // cause catastrophic regex backtracking (ReDoS)
+                filter._id = new RegExp(escapeRegExp(sSearch));
             }
             try {
                 projection = EJSON.parse(projection);
@@ -199,6 +213,10 @@ var spawn = require('child_process').spawn,
             //viewer query cannot be abused to execute code on the server
             common.stripUnsafeMongoOperators(filter);
             common.stripUnsafeMongoOperators(sort);
+            //restrict the projection to plain field include/exclude — drop any
+            //expression / field-path alias (e.g. {x:"$password"}) that could
+            //compute or rename fields the viewer otherwise removes
+            sanitizeProjection(projection);
 
             var base_filter = {};
             if (!params.member.global_admin) {
@@ -244,6 +262,7 @@ var spawn = require('child_process').spawn,
                             if (params.qstring.collection === 'members' && doc) {
                                 delete doc.password;
                                 delete doc.api_key;
+                                delete doc.two_factor_auth;
                             }
                             else if (params.qstring.collection === 'auth_tokens' && doc) {
                                 if (doc._id) {
@@ -376,7 +395,7 @@ var spawn = require('child_process').spawn,
                     }
                 }
                 if (collection === 'members') {
-                    aggregation.splice(addProjectionAt, 0, {"$project": {"password": 0, "api_key": 0}});
+                    aggregation.splice(addProjectionAt, 0, {"$project": {"password": 0, "api_key": 0, "two_factor_auth": 0}});
                 }
                 else if (collection === 'auth_tokens') {
                     aggregation.splice(addProjectionAt, 0, {"$addFields": {"_id": "***redacted***"}});
@@ -532,6 +551,11 @@ var spawn = require('child_process').spawn,
                         // applies to the top-level source collection. This is
                         // blocked even for global admins, who are intentionally
                         // denied raw api_key / password / tokens via DB Viewer.
+                        var writeStage = findWriteStage(aggregation);
+                        if (writeStage) {
+                            common.returnMessage(params, 400, 'Aggregation may not use the "' + writeStage + '" stage');
+                            return true;
+                        }
                         var protectedJoin = findProtectedCollectionJoin(aggregation);
                         if (protectedJoin) {
                             common.returnMessage(params, 400, 'Aggregation may not join the "' + protectedJoin + '" collection');
@@ -549,6 +573,11 @@ var spawn = require('child_process').spawn,
                         if (hasAccess || params.qstring.collection === "events_data" || params.qstring.collection === "drill_events") {
                             try {
                                 let aggregation = EJSON.parse(params.qstring.aggregation);
+                                var writeStageRef = findWriteStage(aggregation);
+                                if (writeStageRef) {
+                                    common.returnMessage(params, 400, 'Aggregation may not use the "' + writeStageRef + '" stage');
+                                    return true;
+                                }
                                 var protectedJoinRef = findProtectedCollectionJoin(aggregation);
                                 if (protectedJoinRef) {
                                     common.returnMessage(params, 400, 'Aggregation may not join the "' + protectedJoinRef + '" collection');

--- a/plugins/dbviewer/api/api.js
+++ b/plugins/dbviewer/api/api.js
@@ -15,7 +15,7 @@ const FEATURE_NAME = 'dbviewer';
 // Aggregation-stage allow-list and the recursive sanitizer that strips blocked
 // stages at every depth (including inside $facet sub-pipelines). Kept in a
 // dedicated module so it can be unit-tested in isolation.
-const { escapeNotAllowedAggregationStages, findProtectedCollectionJoin, findWriteStage } = require('./parts/aggregation_guard.js');
+const { escapeNotAllowedAggregationStages, findProtectedCollectionJoin, findWriteStage, findServerSideJs } = require('./parts/aggregation_guard.js');
 const { sanitizeProjection, escapeRegExp } = require('./parts/query_guard.js');
 var spawn = require('child_process').spawn,
     child;
@@ -556,6 +556,11 @@ var spawn = require('child_process').spawn,
                         // applies to the top-level source collection. This is
                         // blocked even for global admins, who are intentionally
                         // denied raw api_key / password / tokens via DB Viewer.
+                        var jsOp = findServerSideJs(aggregation);
+                        if (jsOp) {
+                            common.returnMessage(params, 400, 'Aggregation may not use the "' + jsOp + '" operator');
+                            return true;
+                        }
                         var writeStage = findWriteStage(aggregation);
                         if (writeStage) {
                             common.returnMessage(params, 400, 'Aggregation may not use the "' + writeStage + '" stage');
@@ -578,6 +583,11 @@ var spawn = require('child_process').spawn,
                         if (hasAccess || params.qstring.collection === "events_data" || params.qstring.collection === "drill_events") {
                             try {
                                 let aggregation = EJSON.parse(params.qstring.aggregation);
+                                var jsOpRef = findServerSideJs(aggregation);
+                                if (jsOpRef) {
+                                    common.returnMessage(params, 400, 'Aggregation may not use the "' + jsOpRef + '" operator');
+                                    return true;
+                                }
                                 var writeStageRef = findWriteStage(aggregation);
                                 if (writeStageRef) {
                                     common.returnMessage(params, 400, 'Aggregation may not use the "' + writeStageRef + '" stage');

--- a/plugins/dbviewer/api/api.js
+++ b/plugins/dbviewer/api/api.js
@@ -18,7 +18,7 @@ const MAX_DBVIEWER_LIMIT = 10000;
 // Aggregation-stage allow-list and the recursive sanitizer that strips blocked
 // stages at every depth (including inside $facet sub-pipelines). Kept in a
 // dedicated module so it can be unit-tested in isolation.
-const { escapeNotAllowedAggregationStages, findProtectedCollectionJoin, findWriteStage, findServerSideJs } = require('./parts/aggregation_guard.js');
+const { sanitizeAggregation, ALLOWED_STAGES_USER, ALLOWED_STAGES_GLOBAL_ADMIN } = require('./parts/aggregation_guard.js');
 const { sanitizeProjection, escapeRegExp } = require('./parts/query_guard.js');
 var spawn = require('child_process').spawn,
     child;
@@ -568,66 +568,39 @@ var spawn = require('child_process').spawn,
             }
             // handle aggregation request
             else if (isContainDb && params.qstring.aggregation) {
-                if (params.member.global_admin) {
+                // Validate the pipeline against the caller's allow-list and run
+                // it. Global admins get the broader list (may join/union, but
+                // still no writes and never into a redacted collection); other
+                // users get the restricted list. Disallowed stages are stripped;
+                // server-side-JS operators and joins into members/auth_tokens
+                // reject the request.
+                var runAggregation = function(allowedStages) {
                     try {
                         let aggregation = EJSON.parse(params.qstring.aggregation);
-                        // A join into a redacted collection (members / auth_tokens)
-                        // would return raw credentials, since the redaction only
-                        // applies to the top-level source collection. This is
-                        // blocked even for global admins, who are intentionally
-                        // denied raw api_key / password / tokens via DB Viewer.
-                        var jsOp = findServerSideJs(aggregation);
-                        if (jsOp) {
-                            common.returnMessage(params, 400, 'Aggregation may not use the "' + jsOp + '" operator');
-                            return true;
+                        var guard = sanitizeAggregation(aggregation, allowedStages);
+                        if (guard.error) {
+                            var msg = guard.error.type === "join"
+                                ? 'Aggregation may not join the "' + guard.error.name + '" collection'
+                                : 'Aggregation may not use the "' + guard.error.name + '" operator';
+                            common.returnMessage(params, 400, msg);
+                            return;
                         }
-                        var writeStage = findWriteStage(aggregation);
-                        if (writeStage) {
-                            common.returnMessage(params, 400, 'Aggregation may not use the "' + writeStage + '" stage');
-                            return true;
+                        if (guard.changes && Object.keys(guard.changes).length > 0) {
+                            log.d("Removed stages from pipeline: ", JSON.stringify(guard.changes));
                         }
-                        var protectedJoin = findProtectedCollectionJoin(aggregation);
-                        if (protectedJoin) {
-                            common.returnMessage(params, 400, 'Aggregation may not join the "' + protectedJoin + '" collection');
-                            return true;
-                        }
-                        aggregate(params.qstring.collection, aggregation);
+                        aggregate(params.qstring.collection, aggregation, guard.changes);
                     }
                     catch (e) {
                         common.returnMessage(params, 500, 'Aggregation object is not valid.');
-                        return true;
                     }
+                };
+                if (params.member.global_admin) {
+                    runAggregation(ALLOWED_STAGES_GLOBAL_ADMIN);
                 }
                 else {
                     userHasAccess(params, params.qstring.collection, function(hasAccess) {
                         if (hasAccess || params.qstring.collection === "events_data" || params.qstring.collection === "drill_events") {
-                            try {
-                                let aggregation = EJSON.parse(params.qstring.aggregation);
-                                var jsOpRef = findServerSideJs(aggregation);
-                                if (jsOpRef) {
-                                    common.returnMessage(params, 400, 'Aggregation may not use the "' + jsOpRef + '" operator');
-                                    return true;
-                                }
-                                var writeStageRef = findWriteStage(aggregation);
-                                if (writeStageRef) {
-                                    common.returnMessage(params, 400, 'Aggregation may not use the "' + writeStageRef + '" stage');
-                                    return true;
-                                }
-                                var protectedJoinRef = findProtectedCollectionJoin(aggregation);
-                                if (protectedJoinRef) {
-                                    common.returnMessage(params, 400, 'Aggregation may not join the "' + protectedJoinRef + '" collection');
-                                    return true;
-                                }
-                                var changes = escapeNotAllowedAggregationStages(aggregation);
-                                if (changes && Object.keys(changes).length > 0) {
-                                    log.d("Removed stages from pipeline: ", JSON.stringify(changes));
-                                }
-                                aggregate(params.qstring.collection, aggregation, changes);
-                            }
-                            catch (e) {
-                                common.returnMessage(params, 500, 'Aggregation object is not valid.');
-                                return true;
-                            }
+                            runAggregation(ALLOWED_STAGES_USER);
                         }
                         else {
                             common.returnMessage(params, 401, 'User does not have right tot view this colleciton');

--- a/plugins/dbviewer/api/api.js
+++ b/plugins/dbviewer/api/api.js
@@ -12,6 +12,9 @@ const { MongoInvalidArgumentError } = require('mongodb');
 const { EJSON } = require('bson');
 
 const FEATURE_NAME = 'dbviewer';
+// upper bound on rows returned per find()/aggregation page, to keep a crafted
+// limit/iDisplayLength from requesting an unbounded result set
+const MAX_DBVIEWER_LIMIT = 10000;
 // Aggregation-stage allow-list and the recursive sanitizer that strips blocked
 // stages at every depth (including inside $facet sub-pipelines). Kept in a
 // dedicated module so it can be unit-tested in isolation.
@@ -149,7 +152,8 @@ var spawn = require('child_process').spawn,
                             common.returnOutput(params, objectIdCheck(results) || {});
                         }
                         else {
-                            common.returnOutput(params, 500, err);
+                            log.e(err);
+                            common.returnMessage(params, 500, "An unexpected error occurred.");
                         }
                     });
                 }
@@ -162,8 +166,19 @@ var spawn = require('child_process').spawn,
         * Get collection data from db
         **/
         async function dbGetCollection() {
-            var limit = parseInt(params.qstring.limit || 20);
-            var skip = parseInt(params.qstring.skip || 0);
+            // cap page size and guard against NaN so a crafted limit/skip can't
+            // request an unbounded result set
+            var limit = parseInt(params.qstring.limit, 10);
+            if (isNaN(limit) || limit <= 0) {
+                limit = 20;
+            }
+            if (limit > MAX_DBVIEWER_LIMIT) {
+                limit = MAX_DBVIEWER_LIMIT;
+            }
+            var skip = parseInt(params.qstring.skip, 10);
+            if (isNaN(skip) || skip < 0) {
+                skip = 0;
+            }
             var filter = params.qstring.filter || params.qstring.query || "{}";
             var sSearch = params.qstring.sSearch || "";
             var projection = params.qstring.project || params.qstring.projection || "{}";
@@ -316,7 +331,8 @@ var spawn = require('child_process').spawn,
                     }
                 }
                 catch (err) {
-                    common.returnMessage(params, 500, err);
+                    log.e(err);
+                    common.returnMessage(params, 500, "An unexpected error occurred.");
                 }
             }
         }
@@ -388,7 +404,10 @@ var spawn = require('child_process').spawn,
         * */
         function aggregate(collection, aggregation, changes) {
             if (params.qstring.iDisplayLength) {
-                aggregation.push({ "$limit": parseInt(params.qstring.iDisplayLength) });
+                var iDisplayLength = parseInt(params.qstring.iDisplayLength, 10);
+                if (!isNaN(iDisplayLength) && iDisplayLength > 0) {
+                    aggregation.push({ "$limit": Math.min(iDisplayLength, MAX_DBVIEWER_LIMIT) });
+                }
             }
             if (!Array.isArray(aggregation)) {
                 common.returnMessage(params, 500, "The aggregation pipeline must be of the type array");
@@ -448,7 +467,8 @@ var spawn = require('child_process').spawn,
                                     common.returnOutput(params, { sEcho: params.qstring.sEcho, iTotalRecords: 0, iTotalDisplayRecords: 0, "aaData": result, "removed": (changes || {}) });
                                 }
                                 else {
-                                    common.returnMessage(params, 500, aggregationErr);
+                                    log.e(aggregationErr);
+                                    common.returnMessage(params, 500, "An unexpected error occurred.");
                                 }
                             }
                         });

--- a/plugins/dbviewer/api/api.js
+++ b/plugins/dbviewer/api/api.js
@@ -15,7 +15,7 @@ const FEATURE_NAME = 'dbviewer';
 // Aggregation-stage allow-list and the recursive sanitizer that strips blocked
 // stages at every depth (including inside $facet sub-pipelines). Kept in a
 // dedicated module so it can be unit-tested in isolation.
-const { escapeNotAllowedAggregationStages } = require('./parts/aggregation_guard.js');
+const { escapeNotAllowedAggregationStages, findProtectedCollectionJoin } = require('./parts/aggregation_guard.js');
 var spawn = require('child_process').spawn,
     child;
 
@@ -527,6 +527,16 @@ var spawn = require('child_process').spawn,
                 if (params.member.global_admin) {
                     try {
                         let aggregation = EJSON.parse(params.qstring.aggregation);
+                        // A join into a redacted collection (members / auth_tokens)
+                        // would return raw credentials, since the redaction only
+                        // applies to the top-level source collection. This is
+                        // blocked even for global admins, who are intentionally
+                        // denied raw api_key / password / tokens via DB Viewer.
+                        var protectedJoin = findProtectedCollectionJoin(aggregation);
+                        if (protectedJoin) {
+                            common.returnMessage(params, 400, 'Aggregation may not join the "' + protectedJoin + '" collection');
+                            return true;
+                        }
                         aggregate(params.qstring.collection, aggregation);
                     }
                     catch (e) {
@@ -539,6 +549,11 @@ var spawn = require('child_process').spawn,
                         if (hasAccess || params.qstring.collection === "events_data" || params.qstring.collection === "drill_events") {
                             try {
                                 let aggregation = EJSON.parse(params.qstring.aggregation);
+                                var protectedJoinRef = findProtectedCollectionJoin(aggregation);
+                                if (protectedJoinRef) {
+                                    common.returnMessage(params, 400, 'Aggregation may not join the "' + protectedJoinRef + '" collection');
+                                    return true;
+                                }
                                 var changes = escapeNotAllowedAggregationStages(aggregation);
                                 if (changes && Object.keys(changes).length > 0) {
                                     log.d("Removed stages from pipeline: ", JSON.stringify(changes));

--- a/plugins/dbviewer/api/api.js
+++ b/plugins/dbviewer/api/api.js
@@ -204,6 +204,12 @@ var spawn = require('child_process').spawn,
             catch (SyntaxError) {
                 projection = {};
             }
+            //EJSON.parse("null") yields null and an array is also typeof
+            //"object"; normalize anything that isn't a plain object to {} so an
+            //invalid projection can't reach find()
+            if (!projection || typeof projection !== 'object' || Array.isArray(projection)) {
+                projection = {};
+            }
             if (typeof filter !== 'object' || Array.isArray(filter)) {
                 filter = {};
             }

--- a/plugins/dbviewer/api/api.js
+++ b/plugins/dbviewer/api/api.js
@@ -12,55 +12,10 @@ const { MongoInvalidArgumentError } = require('mongodb');
 const { EJSON } = require('bson');
 
 const FEATURE_NAME = 'dbviewer';
-const whiteListedAggregationStages = {
-    "$addFields": true,
-    "$bucket": true,
-    "$bucketAuto": true,
-    //"$changeStream": false,
-    //"$changeStreamSplitLargeEvents": false,
-    //"$collStats": false,
-    "$count": true,
-    //"$currentOp": false,
-    "$densify": true,
-    //"$documents": false
-    "$facet": true,
-    "$fill": true,
-    "$geoNear": true,
-    // "$graphLookup": false — removed: lets attacker pull joined documents from any collection in the same DB,
-    //                        bypassing the per-collection access check. Use $lookup instead if cross-collection
-    //                        joins are ever needed (currently also disallowed).
-    "$group": true,
-    //"$indexStats": false,
-    "$limit": true,
-    //"$listLocalSessions": false
-    //"$listSampledQueries": false
-    //"$listSearchIndexes": false
-    //"$listSessions": false
-    //"$lookup": false
-    "$match": true,
-    //"$merge": false
-    //"$mergeCursors": false
-    //"$out": false
-    //"$planCacheStats": false,
-    "$project": true,
-    "$querySettings": true,
-    "$redact": true,
-    "$replaceRoot": true,
-    "$replaceWith": true,
-    "$sample": true,
-    "$search": true,
-    "$searchMeta": true,
-    "$set": true,
-    "$setWindowFields": true,
-    //"$sharedDataDistribution": false,
-    "$skip": true,
-    "$sort": true,
-    "$sortByCount": true,
-    //"$unionWith": false,
-    "$unset": true,
-    "$unwind": true,
-    "$vectorSearch": true //atlas specific
-};
+// Aggregation-stage allow-list and the recursive sanitizer that strips blocked
+// stages at every depth (including inside $facet sub-pipelines). Kept in a
+// dedicated module so it can be unit-tested in isolation.
+const { escapeNotAllowedAggregationStages } = require('./parts/aggregation_guard.js');
 var spawn = require('child_process').spawn,
     child;
 
@@ -68,27 +23,6 @@ var spawn = require('child_process').spawn,
     plugins.register("/permissions/features", function(ob) {
         ob.features.push(FEATURE_NAME);
     });
-    /**
-     * Function removes not allowed aggregation stages from the pipeline
-     * @param {array} aggregation  - current aggregation pipeline
-     * @returns {object} changes - object with information which operations were removed
-     */
-    function escapeNotAllowedAggregationStages(aggregation) {
-        var changes = {};
-        for (var z = 0; z < aggregation.length; z++) {
-            for (var key in aggregation[z]) {
-                if (!whiteListedAggregationStages[key]) {
-                    changes[key] = true;
-                    delete aggregation[z][key];
-                }
-            }
-            if (Object.keys(aggregation[z]).length === 0) {
-                aggregation.splice(z, 1);
-                z--;
-            }
-        }
-        return changes;
-    }
 
     /**
      * @api {get} /o/db Access database

--- a/plugins/dbviewer/api/parts/aggregation_guard.js
+++ b/plugins/dbviewer/api/parts/aggregation_guard.js
@@ -1,50 +1,37 @@
 /**
  * @module plugins/dbviewer/api/parts/aggregation_guard
- * @description Whitelist of MongoDB aggregation stages the DB Viewer permits for
- * non-global users, plus a sanitizer that strips any non-whitelisted stage at
- * EVERY depth.
+ * @description Validates a DB Viewer aggregation pipeline against a role-specific
+ * allow-list of stages, and rejects pipelines that use server-side-JavaScript
+ * operators or join/union into a redacted (credential) collection.
  *
- * Stages such as $lookup, $graphLookup, $unionWith, $out and $merge are not
- * whitelisted because they read from / write to a second collection and would
- * bypass the per-collection access check (and the top-level-only members /
- * auth_tokens redaction). $facet IS whitelisted, but it carries sub-pipelines;
- * if those sub-pipelines are not inspected, a blocked stage (e.g. $lookup) can
- * be smuggled in nested under $facet. The sanitizer therefore recurses into
- * $facet sub-pipelines so the boundary holds at any depth.
+ * One routine, two lists:
+ *  - non-global users get ALLOWED_STAGES_USER (no joins, no writes);
+ *  - global admins get ALLOWED_STAGES_GLOBAL_ADMIN (the same plus join/union
+ *    stages).
+ * Anything not in the applicable list is stripped from the pipeline at every
+ * depth. Two hard rules apply to everyone, at any depth, and reject the request:
+ *  - no $function / $accumulator / $where (server-side JavaScript);
+ *  - no join/union into members / auth_tokens (their field redaction only
+ *    applies to the top-level source collection, so a join would return raw
+ *    credentials — denied even for global admins).
  */
 
 'use strict';
 
-const whiteListedAggregationStages = {
+// Stages a non-global user may run. No joins/unions (they read a second
+// collection, bypassing the per-collection access check) and no writes.
+const ALLOWED_STAGES_USER = {
     "$addFields": true,
     "$bucket": true,
     "$bucketAuto": true,
-    //"$changeStream": false,
-    //"$changeStreamSplitLargeEvents": false,
-    //"$collStats": false,
     "$count": true,
-    //"$currentOp": false,
     "$densify": true,
-    //"$documents": false
     "$facet": true,
     "$fill": true,
     "$geoNear": true,
-    // "$graphLookup": false — removed: lets attacker pull joined documents from any collection in the same DB,
-    //                        bypassing the per-collection access check. Use $lookup instead if cross-collection
-    //                        joins are ever needed (currently also disallowed).
     "$group": true,
-    //"$indexStats": false,
     "$limit": true,
-    //"$listLocalSessions": false
-    //"$listSampledQueries": false
-    //"$listSearchIndexes": false
-    //"$listSessions": false
-    //"$lookup": false
     "$match": true,
-    //"$merge": false
-    //"$mergeCursors": false
-    //"$out": false
-    //"$planCacheStats": false,
     "$project": true,
     "$querySettings": true,
     "$redact": true,
@@ -55,29 +42,42 @@ const whiteListedAggregationStages = {
     "$searchMeta": true,
     "$set": true,
     "$setWindowFields": true,
-    //"$sharedDataDistribution": false,
     "$skip": true,
     "$sort": true,
     "$sortByCount": true,
-    //"$unionWith": false,
     "$unset": true,
     "$unwind": true,
     "$vectorSearch": true //atlas specific
 };
 
-/**
- * Recognized aggregation STAGE operators (allow-listed plus the known blocked
- * ones). Used to tell a nested aggregation sub-pipeline (an array of stage
- * objects) apart from an ordinary expression array, so the sanitizer can
- * descend into sub-pipelines wherever they appear — $facet's branch arrays, a
- * stage's `.pipeline`, or any future nested-pipeline shape — without a
- * hard-coded stage name and without mistaking an expression array for a
- * pipeline.
- */
-const KNOWN_STAGE_OPERATORS = Object.assign({
+// Global admins may additionally use the join/union stages. Still no write
+// stages, and still never into a protected collection (see findHardViolation).
+const ALLOWED_STAGES_GLOBAL_ADMIN = Object.assign({}, ALLOWED_STAGES_USER, {
     "$lookup": true,
     "$graphLookup": true,
-    "$unionWith": true,
+    "$unionWith": true
+});
+
+// Expression operators that run server-side JavaScript. Never allowed for
+// anyone, at any depth — they live inside otherwise-allowed stages.
+const DENIED_OPERATORS = {
+    "$function": true,
+    "$accumulator": true,
+    "$where": true
+};
+
+// Collections whose contents DB Viewer redacts. A join/union into them would
+// return the raw documents (redaction only applies to the top-level source),
+// so such joins are rejected for everyone — including global admins.
+const PROTECTED_JOIN_COLLECTIONS = {
+    "members": true,
+    "auth_tokens": true
+};
+
+// All recognized aggregation STAGE operators (any role's allow-list plus the
+// known blocked stages), used to recognize a nested array as a sub-pipeline
+// (array of stage objects) and tell it apart from an ordinary expression array.
+const KNOWN_STAGE_OPERATORS = Object.assign({
     "$out": true,
     "$merge": true,
     "$documents": true,
@@ -93,146 +93,7 @@ const KNOWN_STAGE_OPERATORS = Object.assign({
     "$changeStreamSplitLargeEvents": true,
     "$mergeCursors": true,
     "$sharedDataDistribution": true
-}, whiteListedAggregationStages);
-
-/**
- * Does this array look like an aggregation sub-pipeline — i.e. a non-empty
- * array whose every element is a stage object (an object carrying a recognized
- * stage operator key)? Expression arrays (e.g. $concat's operands) do not match.
- * @param {*} arr - candidate value
- * @returns {boolean} true if it is a sub-pipeline
- */
-function isSubPipeline(arr) {
-    if (!Array.isArray(arr) || arr.length === 0) {
-        return false;
-    }
-    for (var i = 0; i < arr.length; i++) {
-        var el = arr[i];
-        if (!el || typeof el !== "object" || Array.isArray(el)) {
-            return false;
-        }
-        var isStage = false;
-        for (var k in el) {
-            if (Object.prototype.hasOwnProperty.call(el, k) && KNOWN_STAGE_OPERATORS[k] === true) {
-                isStage = true;
-                break;
-            }
-        }
-        if (!isStage) {
-            return false;
-        }
-    }
-    return true;
-}
-
-/**
- * Walk a kept (allow-listed) stage's value and sanitize every nested
- * sub-pipeline found anywhere within it — not just $facet branches or a
- * `.pipeline` field — so a blocked stage cannot hide inside any (including
- * future) nested-pipeline shape. A sub-pipeline that becomes empty after
- * sanitization is removed from its parent object (Mongo rejects an empty $facet
- * branch).
- * @param {*} value - the stage value (or any nested node) to scan
- * @param {object} changes - accumulator: keys are removed stage names
- * @returns {void}
- */
-function sanitizeNestedPipelines(value, changes) {
-    if (Array.isArray(value)) {
-        if (isSubPipeline(value)) {
-            sanitizePipeline(value, changes);
-        }
-        else {
-            for (var i = 0; i < value.length; i++) {
-                sanitizeNestedPipelines(value[i], changes);
-            }
-        }
-        return;
-    }
-    if (value && typeof value === "object") {
-        for (var k in value) {
-            if (!Object.prototype.hasOwnProperty.call(value, k)) {
-                continue;
-            }
-            var child = value[k];
-            if (Array.isArray(child) && isSubPipeline(child)) {
-                sanitizePipeline(child, changes);
-                if (child.length === 0) {
-                    delete value[k];
-                }
-            }
-            else {
-                sanitizeNestedPipelines(child, changes);
-            }
-        }
-    }
-}
-
-/**
- * Recursively remove non-whitelisted stages from an aggregation pipeline,
- * descending into the sub-pipelines of any kept stage at every depth. The
- * pipeline is mutated in place.
- * @param {Array} pipeline - aggregation pipeline (array of stage objects)
- * @param {object} changes - accumulator: keys are removed stage names
- * @returns {object} the changes accumulator
- */
-function sanitizePipeline(pipeline, changes) {
-    if (!Array.isArray(pipeline)) {
-        return changes;
-    }
-    for (var z = 0; z < pipeline.length; z++) {
-        var stage = pipeline[z];
-        if (!stage || typeof stage !== "object") {
-            continue;
-        }
-        for (var key in stage) {
-            // require an explicit `true` so inherited Object.prototype keys
-            // (constructor, __proto__, …) are never treated as allow-listed
-            if (whiteListedAggregationStages[key] !== true) {
-                changes[key] = true;
-                delete stage[key];
-            }
-            else {
-                // kept stage — sanitize any sub-pipeline nested anywhere in its
-                // value (structural, not keyed on a specific stage name)
-                sanitizeNestedPipelines(stage[key], changes);
-                // drop the stage if sanitization emptied its content (e.g. a
-                // $facet whose every branch was removed — Mongo rejects that)
-                var v = stage[key];
-                if (v && typeof v === "object" && !Array.isArray(v) && Object.keys(v).length === 0) {
-                    delete stage[key];
-                }
-            }
-        }
-        if (Object.keys(stage).length === 0) {
-            pipeline.splice(z, 1);
-            z--;
-        }
-    }
-    return changes;
-}
-
-/**
- * Remove all not-allowed aggregation stages from the pipeline, at every depth.
- * @param {Array} aggregation - current aggregation pipeline (mutated in place)
- * @returns {object} changes - object whose keys are the removed stage names
- */
-function escapeNotAllowedAggregationStages(aggregation) {
-    return sanitizePipeline(aggregation, {});
-}
-
-/**
- * Collections whose contents are redacted by DB Viewer (credentials / tokens)
- * and which therefore must never be reachable through a join. The redaction is
- * only applied when these are the top-level source collection, so a join into
- * them (e.g. $lookup { from: "members" }) would return the raw, un-redacted
- * documents — including api_key / password / token values. This must hold even
- * for global admins, who are intentionally denied raw credentials through DB
- * Viewer (the top-level redaction applies to them too).
- */
-const PROTECTED_JOIN_COLLECTIONS = {
-    "members": true,
-    "auth_tokens": true
-};
+}, ALLOWED_STAGES_GLOBAL_ADMIN);
 
 /**
  * Collection names a single stage joins / unions from.
@@ -262,23 +123,47 @@ function joinTargetsOf(stage) {
 }
 
 /**
- * Deep-scan an aggregation pipeline node (object/array, at every depth) for a
- * join/union into a protected (redacted) collection. Used to block such joins
- * regardless of the caller's role, since the per-collection redaction cannot
- * follow data pulled in via a join.
- *
- * This walks ALL nested structures rather than only known sub-pipeline
- * locations ($facet / .pipeline), so a join smuggled inside any future stage
- * shape is still detected. Detection-only (no mutation), so a blanket deep walk
- * is safe here — unlike the stage sanitizer, which must stay targeted to avoid
- * mangling expressions.
- * @param {*} node - pipeline / stage / expression node (not mutated)
- * @returns {string|null} the protected collection name if one is joined, else null
+ * Does this array look like an aggregation sub-pipeline — a non-empty array
+ * whose every element is a stage object (an object carrying a recognized stage
+ * operator key)? Expression arrays (e.g. $concat operands) do not match.
+ * @param {*} arr - candidate value
+ * @returns {boolean} true if it is a sub-pipeline
  */
-function findProtectedCollectionJoin(node) {
+function isSubPipeline(arr) {
+    if (!Array.isArray(arr) || arr.length === 0) {
+        return false;
+    }
+    for (var i = 0; i < arr.length; i++) {
+        var el = arr[i];
+        if (!el || typeof el !== "object" || Array.isArray(el)) {
+            return false;
+        }
+        var isStage = false;
+        for (var k in el) {
+            if (Object.prototype.hasOwnProperty.call(el, k) && KNOWN_STAGE_OPERATORS[k] === true) {
+                isStage = true;
+                break;
+            }
+        }
+        if (!isStage) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
+ * Deep-walk a node for a hard-rule violation that must reject the whole request,
+ * regardless of role: a server-side-JS operator, or a join/union into a
+ * protected (redacted) collection. Detection-only (no mutation), so a blanket
+ * deep walk is safe and stays correct for any (incl. future) nested shape.
+ * @param {*} node - pipeline / stage / expression node
+ * @returns {{type: string, name: string}|null} the violation, or null
+ */
+function findHardViolation(node) {
     if (Array.isArray(node)) {
         for (var i = 0; i < node.length; i++) {
-            var inArr = findProtectedCollectionJoin(node[i]);
+            var inArr = findHardViolation(node[i]);
             if (inArr) {
                 return inArr;
             }
@@ -289,15 +174,19 @@ function findProtectedCollectionJoin(node) {
         var targets = joinTargetsOf(node);
         for (var t = 0; t < targets.length; t++) {
             if (PROTECTED_JOIN_COLLECTIONS[targets[t]] === true) {
-                return targets[t];
+                return { type: "join", name: targets[t] };
             }
         }
         for (var key in node) {
-            if (Object.prototype.hasOwnProperty.call(node, key)) {
-                var inVal = findProtectedCollectionJoin(node[key]);
-                if (inVal) {
-                    return inVal;
-                }
+            if (!Object.prototype.hasOwnProperty.call(node, key)) {
+                continue;
+            }
+            if (DENIED_OPERATORS[key] === true) {
+                return { type: "operator", name: key };
+            }
+            var inVal = findHardViolation(node[key]);
+            if (inVal) {
+                return inVal;
             }
         }
     }
@@ -305,100 +194,112 @@ function findProtectedCollectionJoin(node) {
 }
 
 /**
- * Aggregation stages that WRITE to a collection. DB Viewer is a read-only tool,
- * so these must never run — including on the global-admin path, which otherwise
- * skips the stage allow-list.
+ * Walk a kept stage's value and strip disallowed stages from any sub-pipeline
+ * nested anywhere within it (structural — $facet branches, a .pipeline field,
+ * or any other nested-pipeline shape). A sub-pipeline emptied by stripping is
+ * removed from its parent object (Mongo rejects an empty $facet branch).
+ * @param {*} value - the stage value (or any nested node)
+ * @param {object} allowedStages - the role's allow-list
+ * @param {object} changes - accumulator: keys are removed stage names
+ * @returns {void}
  */
-const WRITE_STAGES = {
-    "$out": true,
-    "$merge": true
-};
-
-/**
- * Deep-scan an aggregation pipeline node (object/array, at every depth) for a
- * write stage ($out / $merge). Detection-only, so a blanket deep walk is safe
- * and stays correct for any (incl. future) nested stage shape.
- * @param {*} node - pipeline / stage / expression node (not mutated)
- * @returns {string|null} the write stage name if present, else null
- */
-function findWriteStage(node) {
-    if (Array.isArray(node)) {
-        for (var i = 0; i < node.length; i++) {
-            var inArr = findWriteStage(node[i]);
-            if (inArr) {
-                return inArr;
+function stripNested(value, allowedStages, changes) {
+    if (Array.isArray(value)) {
+        if (isSubPipeline(value)) {
+            stripStages(value, allowedStages, changes);
+        }
+        else {
+            for (var i = 0; i < value.length; i++) {
+                stripNested(value[i], allowedStages, changes);
             }
         }
-        return null;
+        return;
     }
-    if (node && typeof node === "object") {
-        for (var key in node) {
-            if (Object.prototype.hasOwnProperty.call(node, key)) {
-                if (WRITE_STAGES[key] === true) {
-                    return key;
+    if (value && typeof value === "object") {
+        for (var k in value) {
+            if (!Object.prototype.hasOwnProperty.call(value, k)) {
+                continue;
+            }
+            var child = value[k];
+            if (Array.isArray(child) && isSubPipeline(child)) {
+                stripStages(child, allowedStages, changes);
+                if (child.length === 0) {
+                    delete value[k];
                 }
-                var inVal = findWriteStage(node[key]);
-                if (inVal) {
-                    return inVal;
-                }
+            }
+            else {
+                stripNested(child, allowedStages, changes);
             }
         }
     }
-    return null;
 }
 
 /**
- * Aggregation EXPRESSION operators that execute server-side JavaScript. These
- * are not stages, so the stage allow-list does not catch them — they live
- * inside otherwise-allowed stages ($project / $group / $addFields / $match …).
- * They must never run via DB Viewer (the find() path already strips the
- * equivalent operators from filter/sort).
+ * Recursively remove stages not in `allowedStages` from a pipeline, at every
+ * depth. Mutates the pipeline in place.
+ * @param {Array} pipeline - aggregation pipeline
+ * @param {object} allowedStages - the role's allow-list (values must be === true)
+ * @param {object} changes - accumulator: keys are removed stage names
+ * @returns {void}
  */
-const SERVER_SIDE_JS_OPERATORS = {
-    "$function": true,
-    "$accumulator": true,
-    "$where": true
-};
+function stripStages(pipeline, allowedStages, changes) {
+    if (!Array.isArray(pipeline)) {
+        return;
+    }
+    for (var z = 0; z < pipeline.length; z++) {
+        var stage = pipeline[z];
+        if (!stage || typeof stage !== "object") {
+            continue;
+        }
+        for (var key in stage) {
+            if (!Object.prototype.hasOwnProperty.call(stage, key)) {
+                continue;
+            }
+            // require an explicit `true` so inherited Object.prototype keys
+            // (constructor, __proto__, …) are never treated as allow-listed
+            if (allowedStages[key] !== true) {
+                changes[key] = true;
+                delete stage[key];
+            }
+            else {
+                stripNested(stage[key], allowedStages, changes);
+                var v = stage[key];
+                if (v && typeof v === "object" && !Array.isArray(v) && Object.keys(v).length === 0) {
+                    delete stage[key];
+                }
+            }
+        }
+        if (Object.keys(stage).length === 0) {
+            pipeline.splice(z, 1);
+            z--;
+        }
+    }
+}
 
 /**
- * Deep-scan an aggregation pipeline (objects and arrays, at every depth,
- * including expression values) for a server-side-JavaScript operator.
- * @param {*} node - pipeline / stage / expression node
- * @returns {string|null} the operator name if present, else null
+ * Validate and sanitize an aggregation pipeline for a given role's allow-list.
+ * Rejects (without mutating) when a hard rule is violated; otherwise strips any
+ * stage not in the allow-list and returns what was removed.
+ * @param {Array} pipeline - aggregation pipeline (mutated in place when valid)
+ * @param {object} allowedStages - ALLOWED_STAGES_USER or ALLOWED_STAGES_GLOBAL_ADMIN
+ * @returns {{changes: object, error: ({type: string, name: string}|null)}}
+ *          When error is set the caller must reject the request and not run the
+ *          pipeline. Otherwise changes lists the removed stage names.
  */
-function findServerSideJs(node) {
-    if (Array.isArray(node)) {
-        for (var i = 0; i < node.length; i++) {
-            var inArr = findServerSideJs(node[i]);
-            if (inArr) {
-                return inArr;
-            }
-        }
-        return null;
+function sanitizeAggregation(pipeline, allowedStages) {
+    var violation = findHardViolation(pipeline);
+    if (violation) {
+        return { changes: {}, error: violation };
     }
-    if (node && typeof node === "object") {
-        for (var key in node) {
-            if (Object.prototype.hasOwnProperty.call(node, key)) {
-                if (SERVER_SIDE_JS_OPERATORS[key] === true) {
-                    return key;
-                }
-                var inVal = findServerSideJs(node[key]);
-                if (inVal) {
-                    return inVal;
-                }
-            }
-        }
-    }
-    return null;
+    var changes = {};
+    stripStages(pipeline, allowedStages, changes);
+    return { changes: changes, error: null };
 }
 
 module.exports = {
-    whiteListedAggregationStages,
+    ALLOWED_STAGES_USER,
+    ALLOWED_STAGES_GLOBAL_ADMIN,
+    DENIED_OPERATORS,
     PROTECTED_JOIN_COLLECTIONS,
-    WRITE_STAGES,
-    SERVER_SIDE_JS_OPERATORS,
-    escapeNotAllowedAggregationStages,
-    findProtectedCollectionJoin,
-    findWriteStage,
-    findServerSideJs
+    sanitizeAggregation
 };

--- a/plugins/dbviewer/api/parts/aggregation_guard.js
+++ b/plugins/dbviewer/api/parts/aggregation_guard.js
@@ -1,0 +1,126 @@
+/**
+ * @module plugins/dbviewer/api/parts/aggregation_guard
+ * @description Whitelist of MongoDB aggregation stages the DB Viewer permits for
+ * non-global users, plus a sanitizer that strips any non-whitelisted stage at
+ * EVERY depth.
+ *
+ * Stages such as $lookup, $graphLookup, $unionWith, $out and $merge are not
+ * whitelisted because they read from / write to a second collection and would
+ * bypass the per-collection access check (and the top-level-only members /
+ * auth_tokens redaction). $facet IS whitelisted, but it carries sub-pipelines;
+ * if those sub-pipelines are not inspected, a blocked stage (e.g. $lookup) can
+ * be smuggled in nested under $facet. The sanitizer therefore recurses into
+ * $facet sub-pipelines so the boundary holds at any depth.
+ */
+
+'use strict';
+
+const whiteListedAggregationStages = {
+    "$addFields": true,
+    "$bucket": true,
+    "$bucketAuto": true,
+    //"$changeStream": false,
+    //"$changeStreamSplitLargeEvents": false,
+    //"$collStats": false,
+    "$count": true,
+    //"$currentOp": false,
+    "$densify": true,
+    //"$documents": false
+    "$facet": true,
+    "$fill": true,
+    "$geoNear": true,
+    // "$graphLookup": false — removed: lets attacker pull joined documents from any collection in the same DB,
+    //                        bypassing the per-collection access check. Use $lookup instead if cross-collection
+    //                        joins are ever needed (currently also disallowed).
+    "$group": true,
+    //"$indexStats": false,
+    "$limit": true,
+    //"$listLocalSessions": false
+    //"$listSampledQueries": false
+    //"$listSearchIndexes": false
+    //"$listSessions": false
+    //"$lookup": false
+    "$match": true,
+    //"$merge": false
+    //"$mergeCursors": false
+    //"$out": false
+    //"$planCacheStats": false,
+    "$project": true,
+    "$querySettings": true,
+    "$redact": true,
+    "$replaceRoot": true,
+    "$replaceWith": true,
+    "$sample": true,
+    "$search": true,
+    "$searchMeta": true,
+    "$set": true,
+    "$setWindowFields": true,
+    //"$sharedDataDistribution": false,
+    "$skip": true,
+    "$sort": true,
+    "$sortByCount": true,
+    //"$unionWith": false,
+    "$unset": true,
+    "$unwind": true,
+    "$vectorSearch": true //atlas specific
+};
+
+/**
+ * Recursively remove non-whitelisted stages from an aggregation pipeline,
+ * descending into $facet sub-pipelines. The pipeline is mutated in place.
+ * @param {Array} pipeline - aggregation pipeline (array of stage objects)
+ * @param {object} changes - accumulator: keys are removed stage names
+ * @returns {object} the changes accumulator
+ */
+function sanitizePipeline(pipeline, changes) {
+    if (!Array.isArray(pipeline)) {
+        return changes;
+    }
+    for (var z = 0; z < pipeline.length; z++) {
+        var stage = pipeline[z];
+        if (!stage || typeof stage !== "object") {
+            continue;
+        }
+        for (var key in stage) {
+            if (!whiteListedAggregationStages[key]) {
+                changes[key] = true;
+                delete stage[key];
+            }
+            else if (key === "$facet" && stage[key] && typeof stage[key] === "object") {
+                // $facet: { <name>: [ <sub-pipeline> ], ... } — sanitize each
+                // sub-pipeline so blocked stages cannot hide inside $facet.
+                for (var facetName in stage[key]) {
+                    sanitizePipeline(stage[key][facetName], changes);
+                    // a sub-pipeline emptied by sanitization would make Mongo
+                    // reject the whole $facet ("pipeline cannot be empty"), so
+                    // drop it.
+                    if (Array.isArray(stage[key][facetName]) && stage[key][facetName].length === 0) {
+                        delete stage[key][facetName];
+                    }
+                }
+                if (Object.keys(stage[key]).length === 0) {
+                    delete stage[key];
+                }
+            }
+        }
+        if (Object.keys(stage).length === 0) {
+            pipeline.splice(z, 1);
+            z--;
+        }
+    }
+    return changes;
+}
+
+/**
+ * Remove all not-allowed aggregation stages from the pipeline, at every depth.
+ * @param {Array} aggregation - current aggregation pipeline (mutated in place)
+ * @returns {object} changes - object whose keys are the removed stage names
+ */
+function escapeNotAllowedAggregationStages(aggregation) {
+    return sanitizePipeline(aggregation, {});
+}
+
+module.exports = {
+    whiteListedAggregationStages,
+    escapeNotAllowedAggregationStages
+};

--- a/plugins/dbviewer/api/parts/aggregation_guard.js
+++ b/plugins/dbviewer/api/parts/aggregation_guard.js
@@ -282,11 +282,58 @@ function findWriteStage(pipeline) {
     return null;
 }
 
+/**
+ * Aggregation EXPRESSION operators that execute server-side JavaScript. These
+ * are not stages, so the stage allow-list does not catch them — they live
+ * inside otherwise-allowed stages ($project / $group / $addFields / $match …).
+ * They must never run via DB Viewer (the find() path already strips the
+ * equivalent operators from filter/sort).
+ */
+const SERVER_SIDE_JS_OPERATORS = {
+    "$function": true,
+    "$accumulator": true,
+    "$where": true
+};
+
+/**
+ * Deep-scan an aggregation pipeline (objects and arrays, at every depth,
+ * including expression values) for a server-side-JavaScript operator.
+ * @param {*} node - pipeline / stage / expression node
+ * @returns {string|null} the operator name if present, else null
+ */
+function findServerSideJs(node) {
+    if (Array.isArray(node)) {
+        for (var i = 0; i < node.length; i++) {
+            var inArr = findServerSideJs(node[i]);
+            if (inArr) {
+                return inArr;
+            }
+        }
+        return null;
+    }
+    if (node && typeof node === "object") {
+        for (var key in node) {
+            if (Object.prototype.hasOwnProperty.call(node, key)) {
+                if (SERVER_SIDE_JS_OPERATORS[key] === true) {
+                    return key;
+                }
+                var inVal = findServerSideJs(node[key]);
+                if (inVal) {
+                    return inVal;
+                }
+            }
+        }
+    }
+    return null;
+}
+
 module.exports = {
     whiteListedAggregationStages,
     PROTECTED_JOIN_COLLECTIONS,
     WRITE_STAGES,
+    SERVER_SIDE_JS_OPERATORS,
     escapeNotAllowedAggregationStages,
     findProtectedCollectionJoin,
-    findWriteStage
+    findWriteStage,
+    findServerSideJs
 };

--- a/plugins/dbviewer/api/parts/aggregation_guard.js
+++ b/plugins/dbviewer/api/parts/aggregation_guard.js
@@ -147,7 +147,94 @@ function escapeNotAllowedAggregationStages(aggregation) {
     return sanitizePipeline(aggregation, {});
 }
 
+/**
+ * Collections whose contents are redacted by DB Viewer (credentials / tokens)
+ * and which therefore must never be reachable through a join. The redaction is
+ * only applied when these are the top-level source collection, so a join into
+ * them (e.g. $lookup { from: "members" }) would return the raw, un-redacted
+ * documents — including api_key / password / token values. This must hold even
+ * for global admins, who are intentionally denied raw credentials through DB
+ * Viewer (the top-level redaction applies to them too).
+ */
+const PROTECTED_JOIN_COLLECTIONS = {
+    "members": true,
+    "auth_tokens": true
+};
+
+/**
+ * Collection names a single stage joins / unions from.
+ * @param {object} stage - one aggregation stage
+ * @returns {string[]} target collection names referenced by join/union operators
+ */
+function joinTargetsOf(stage) {
+    var targets = [];
+    if (!stage || typeof stage !== "object") {
+        return targets;
+    }
+    if (stage.$lookup && typeof stage.$lookup === "object" && typeof stage.$lookup.from === "string") {
+        targets.push(stage.$lookup.from);
+    }
+    if (stage.$graphLookup && typeof stage.$graphLookup === "object" && typeof stage.$graphLookup.from === "string") {
+        targets.push(stage.$graphLookup.from);
+    }
+    if (stage.$unionWith) {
+        if (typeof stage.$unionWith === "string") {
+            targets.push(stage.$unionWith);
+        }
+        else if (typeof stage.$unionWith === "object" && typeof stage.$unionWith.coll === "string") {
+            targets.push(stage.$unionWith.coll);
+        }
+    }
+    return targets;
+}
+
+/**
+ * Recursively scan a pipeline for a join/union into a protected (redacted)
+ * collection, at every depth (including $facet sub-pipelines and nested
+ * .pipeline arrays). Used to block such joins regardless of the caller's role,
+ * since the per-collection redaction cannot follow data pulled in via a join.
+ * @param {Array} pipeline - aggregation pipeline (not mutated)
+ * @returns {string|null} the protected collection name if one is joined, else null
+ */
+function findProtectedCollectionJoin(pipeline) {
+    if (!Array.isArray(pipeline)) {
+        return null;
+    }
+    for (var i = 0; i < pipeline.length; i++) {
+        var stage = pipeline[i];
+        if (!stage || typeof stage !== "object") {
+            continue;
+        }
+        var targets = joinTargetsOf(stage);
+        for (var t = 0; t < targets.length; t++) {
+            if (PROTECTED_JOIN_COLLECTIONS[targets[t]]) {
+                return targets[t];
+            }
+        }
+        for (var key in stage) {
+            var val = stage[key];
+            if (key === "$facet" && val && typeof val === "object") {
+                for (var facetName in val) {
+                    var found = findProtectedCollectionJoin(val[facetName]);
+                    if (found) {
+                        return found;
+                    }
+                }
+            }
+            else if (val && typeof val === "object" && Array.isArray(val.pipeline)) {
+                var nested = findProtectedCollectionJoin(val.pipeline);
+                if (nested) {
+                    return nested;
+                }
+            }
+        }
+    }
+    return null;
+}
+
 module.exports = {
     whiteListedAggregationStages,
-    escapeNotAllowedAggregationStages
+    PROTECTED_JOIN_COLLECTIONS,
+    escapeNotAllowedAggregationStages,
+    findProtectedCollectionJoin
 };

--- a/plugins/dbviewer/api/parts/aggregation_guard.js
+++ b/plugins/dbviewer/api/parts/aggregation_guard.js
@@ -244,36 +244,31 @@ const WRITE_STAGES = {
 };
 
 /**
- * Recursively scan a pipeline for a write stage ($out / $merge) at any depth.
- * @param {Array} pipeline - aggregation pipeline (not mutated)
+ * Deep-scan an aggregation pipeline node (object/array, at every depth) for a
+ * write stage ($out / $merge). Detection-only, so a blanket deep walk is safe
+ * and stays correct for any (incl. future) nested stage shape.
+ * @param {*} node - pipeline / stage / expression node (not mutated)
  * @returns {string|null} the write stage name if present, else null
  */
-function findWriteStage(pipeline) {
-    if (!Array.isArray(pipeline)) {
+function findWriteStage(node) {
+    if (Array.isArray(node)) {
+        for (var i = 0; i < node.length; i++) {
+            var inArr = findWriteStage(node[i]);
+            if (inArr) {
+                return inArr;
+            }
+        }
         return null;
     }
-    for (var i = 0; i < pipeline.length; i++) {
-        var stage = pipeline[i];
-        if (!stage || typeof stage !== "object") {
-            continue;
-        }
-        for (var key in stage) {
-            if (WRITE_STAGES[key] === true) {
-                return key;
-            }
-            var val = stage[key];
-            if (key === "$facet" && val && typeof val === "object") {
-                for (var facetName in val) {
-                    var found = findWriteStage(val[facetName]);
-                    if (found) {
-                        return found;
-                    }
+    if (node && typeof node === "object") {
+        for (var key in node) {
+            if (Object.prototype.hasOwnProperty.call(node, key)) {
+                if (WRITE_STAGES[key] === true) {
+                    return key;
                 }
-            }
-            else if (val && typeof val === "object" && Array.isArray(val.pipeline)) {
-                var nested = findWriteStage(val.pipeline);
-                if (nested) {
-                    return nested;
+                var inVal = findWriteStage(node[key]);
+                if (inVal) {
+                    return inVal;
                 }
             }
         }

--- a/plugins/dbviewer/api/parts/aggregation_guard.js
+++ b/plugins/dbviewer/api/parts/aggregation_guard.js
@@ -66,8 +66,46 @@ const whiteListedAggregationStages = {
 };
 
 /**
+ * Sanitize every sub-pipeline a KEPT (whitelisted) stage carries, so a blocked
+ * stage cannot hide nested inside an allowed pipeline-bearing stage. This is
+ * driven by structure, not by a hard-coded stage name, so it keeps holding if
+ * the allow-list ever gains another pipeline-bearing stage:
+ *  - $facet exposes its sub-pipelines as the values of an object
+ *    ({ <name>: [ ...stages ], ... }); each value is sanitized, and a value
+ *    emptied by sanitization is dropped (Mongo rejects an empty $facet
+ *    sub-pipeline). Today $facet is the only allow-listed such stage.
+ *  - any stage that exposes a `.pipeline` array (e.g. $lookup / $unionWith, were
+ *    they ever allow-listed) has that pipeline sanitized.
+ * @param {string} key - the stage operator (e.g. "$facet")
+ * @param {*} value - the stage's value
+ * @param {object} changes - accumulator: keys are removed stage names
+ * @returns {boolean} true if `value` ended up empty and the stage should be dropped
+ */
+function sanitizeNestedPipelines(key, value, changes) {
+    if (!value || typeof value !== "object") {
+        return false;
+    }
+    if (key === "$facet") {
+        for (var facetName in value) {
+            if (Array.isArray(value[facetName])) {
+                sanitizePipeline(value[facetName], changes);
+                if (value[facetName].length === 0) {
+                    delete value[facetName];
+                }
+            }
+        }
+        return Object.keys(value).length === 0;
+    }
+    if (Array.isArray(value.pipeline)) {
+        sanitizePipeline(value.pipeline, changes);
+    }
+    return false;
+}
+
+/**
  * Recursively remove non-whitelisted stages from an aggregation pipeline,
- * descending into $facet sub-pipelines. The pipeline is mutated in place.
+ * descending into the sub-pipelines of any kept pipeline-bearing stage. The
+ * pipeline is mutated in place.
  * @param {Array} pipeline - aggregation pipeline (array of stage objects)
  * @param {object} changes - accumulator: keys are removed stage names
  * @returns {object} the changes accumulator
@@ -86,21 +124,10 @@ function sanitizePipeline(pipeline, changes) {
                 changes[key] = true;
                 delete stage[key];
             }
-            else if (key === "$facet" && stage[key] && typeof stage[key] === "object") {
-                // $facet: { <name>: [ <sub-pipeline> ], ... } — sanitize each
-                // sub-pipeline so blocked stages cannot hide inside $facet.
-                for (var facetName in stage[key]) {
-                    sanitizePipeline(stage[key][facetName], changes);
-                    // a sub-pipeline emptied by sanitization would make Mongo
-                    // reject the whole $facet ("pipeline cannot be empty"), so
-                    // drop it.
-                    if (Array.isArray(stage[key][facetName]) && stage[key][facetName].length === 0) {
-                        delete stage[key][facetName];
-                    }
-                }
-                if (Object.keys(stage[key]).length === 0) {
-                    delete stage[key];
-                }
+            else if (sanitizeNestedPipelines(key, stage[key], changes)) {
+                // the kept stage's nested content was fully emptied by
+                // sanitization — drop the now-meaningless stage operator.
+                delete stage[key];
             }
         }
         if (Object.keys(stage).length === 0) {

--- a/plugins/dbviewer/api/parts/aggregation_guard.js
+++ b/plugins/dbviewer/api/parts/aggregation_guard.js
@@ -232,9 +232,59 @@ function findProtectedCollectionJoin(pipeline) {
     return null;
 }
 
+/**
+ * Aggregation stages that WRITE to a collection. DB Viewer is a read-only tool,
+ * so these must never run — including on the global-admin path, which otherwise
+ * skips the stage allow-list.
+ */
+const WRITE_STAGES = {
+    "$out": true,
+    "$merge": true
+};
+
+/**
+ * Recursively scan a pipeline for a write stage ($out / $merge) at any depth.
+ * @param {Array} pipeline - aggregation pipeline (not mutated)
+ * @returns {string|null} the write stage name if present, else null
+ */
+function findWriteStage(pipeline) {
+    if (!Array.isArray(pipeline)) {
+        return null;
+    }
+    for (var i = 0; i < pipeline.length; i++) {
+        var stage = pipeline[i];
+        if (!stage || typeof stage !== "object") {
+            continue;
+        }
+        for (var key in stage) {
+            if (WRITE_STAGES[key]) {
+                return key;
+            }
+            var val = stage[key];
+            if (key === "$facet" && val && typeof val === "object") {
+                for (var facetName in val) {
+                    var found = findWriteStage(val[facetName]);
+                    if (found) {
+                        return found;
+                    }
+                }
+            }
+            else if (val && typeof val === "object" && Array.isArray(val.pipeline)) {
+                var nested = findWriteStage(val.pipeline);
+                if (nested) {
+                    return nested;
+                }
+            }
+        }
+    }
+    return null;
+}
+
 module.exports = {
     whiteListedAggregationStages,
     PROTECTED_JOIN_COLLECTIONS,
+    WRITE_STAGES,
     escapeNotAllowedAggregationStages,
-    findProtectedCollectionJoin
+    findProtectedCollectionJoin,
+    findWriteStage
 };

--- a/plugins/dbviewer/api/parts/aggregation_guard.js
+++ b/plugins/dbviewer/api/parts/aggregation_guard.js
@@ -120,7 +120,9 @@ function sanitizePipeline(pipeline, changes) {
             continue;
         }
         for (var key in stage) {
-            if (!whiteListedAggregationStages[key]) {
+            // require an explicit `true` so inherited Object.prototype keys
+            // (constructor, __proto__, …) are never treated as allow-listed
+            if (whiteListedAggregationStages[key] !== true) {
                 changes[key] = true;
                 delete stage[key];
             }
@@ -207,7 +209,7 @@ function findProtectedCollectionJoin(pipeline) {
         }
         var targets = joinTargetsOf(stage);
         for (var t = 0; t < targets.length; t++) {
-            if (PROTECTED_JOIN_COLLECTIONS[targets[t]]) {
+            if (PROTECTED_JOIN_COLLECTIONS[targets[t]] === true) {
                 return targets[t];
             }
         }

--- a/plugins/dbviewer/api/parts/aggregation_guard.js
+++ b/plugins/dbviewer/api/parts/aggregation_guard.js
@@ -259,7 +259,7 @@ function findWriteStage(pipeline) {
             continue;
         }
         for (var key in stage) {
-            if (WRITE_STAGES[key]) {
+            if (WRITE_STAGES[key] === true) {
                 return key;
             }
             var val = stage[key];

--- a/plugins/dbviewer/api/parts/aggregation_guard.js
+++ b/plugins/dbviewer/api/parts/aggregation_guard.js
@@ -66,45 +66,110 @@ const whiteListedAggregationStages = {
 };
 
 /**
- * Sanitize every sub-pipeline a KEPT (whitelisted) stage carries, so a blocked
- * stage cannot hide nested inside an allowed pipeline-bearing stage. This is
- * driven by structure, not by a hard-coded stage name, so it keeps holding if
- * the allow-list ever gains another pipeline-bearing stage:
- *  - $facet exposes its sub-pipelines as the values of an object
- *    ({ <name>: [ ...stages ], ... }); each value is sanitized, and a value
- *    emptied by sanitization is dropped (Mongo rejects an empty $facet
- *    sub-pipeline). Today $facet is the only allow-listed such stage.
- *  - any stage that exposes a `.pipeline` array (e.g. $lookup / $unionWith, were
- *    they ever allow-listed) has that pipeline sanitized.
- * @param {string} key - the stage operator (e.g. "$facet")
- * @param {*} value - the stage's value
- * @param {object} changes - accumulator: keys are removed stage names
- * @returns {boolean} true if `value` ended up empty and the stage should be dropped
+ * Recognized aggregation STAGE operators (allow-listed plus the known blocked
+ * ones). Used to tell a nested aggregation sub-pipeline (an array of stage
+ * objects) apart from an ordinary expression array, so the sanitizer can
+ * descend into sub-pipelines wherever they appear — $facet's branch arrays, a
+ * stage's `.pipeline`, or any future nested-pipeline shape — without a
+ * hard-coded stage name and without mistaking an expression array for a
+ * pipeline.
  */
-function sanitizeNestedPipelines(key, value, changes) {
-    if (!value || typeof value !== "object") {
+const KNOWN_STAGE_OPERATORS = Object.assign({
+    "$lookup": true,
+    "$graphLookup": true,
+    "$unionWith": true,
+    "$out": true,
+    "$merge": true,
+    "$documents": true,
+    "$collStats": true,
+    "$indexStats": true,
+    "$currentOp": true,
+    "$listSessions": true,
+    "$listLocalSessions": true,
+    "$listSampledQueries": true,
+    "$listSearchIndexes": true,
+    "$planCacheStats": true,
+    "$changeStream": true,
+    "$changeStreamSplitLargeEvents": true,
+    "$mergeCursors": true,
+    "$sharedDataDistribution": true
+}, whiteListedAggregationStages);
+
+/**
+ * Does this array look like an aggregation sub-pipeline — i.e. a non-empty
+ * array whose every element is a stage object (an object carrying a recognized
+ * stage operator key)? Expression arrays (e.g. $concat's operands) do not match.
+ * @param {*} arr - candidate value
+ * @returns {boolean} true if it is a sub-pipeline
+ */
+function isSubPipeline(arr) {
+    if (!Array.isArray(arr) || arr.length === 0) {
         return false;
     }
-    if (key === "$facet") {
-        for (var facetName in value) {
-            if (Array.isArray(value[facetName])) {
-                sanitizePipeline(value[facetName], changes);
-                if (value[facetName].length === 0) {
-                    delete value[facetName];
-                }
+    for (var i = 0; i < arr.length; i++) {
+        var el = arr[i];
+        if (!el || typeof el !== "object" || Array.isArray(el)) {
+            return false;
+        }
+        var isStage = false;
+        for (var k in el) {
+            if (Object.prototype.hasOwnProperty.call(el, k) && KNOWN_STAGE_OPERATORS[k] === true) {
+                isStage = true;
+                break;
             }
         }
-        return Object.keys(value).length === 0;
+        if (!isStage) {
+            return false;
+        }
     }
-    if (Array.isArray(value.pipeline)) {
-        sanitizePipeline(value.pipeline, changes);
+    return true;
+}
+
+/**
+ * Walk a kept (allow-listed) stage's value and sanitize every nested
+ * sub-pipeline found anywhere within it — not just $facet branches or a
+ * `.pipeline` field — so a blocked stage cannot hide inside any (including
+ * future) nested-pipeline shape. A sub-pipeline that becomes empty after
+ * sanitization is removed from its parent object (Mongo rejects an empty $facet
+ * branch).
+ * @param {*} value - the stage value (or any nested node) to scan
+ * @param {object} changes - accumulator: keys are removed stage names
+ * @returns {void}
+ */
+function sanitizeNestedPipelines(value, changes) {
+    if (Array.isArray(value)) {
+        if (isSubPipeline(value)) {
+            sanitizePipeline(value, changes);
+        }
+        else {
+            for (var i = 0; i < value.length; i++) {
+                sanitizeNestedPipelines(value[i], changes);
+            }
+        }
+        return;
     }
-    return false;
+    if (value && typeof value === "object") {
+        for (var k in value) {
+            if (!Object.prototype.hasOwnProperty.call(value, k)) {
+                continue;
+            }
+            var child = value[k];
+            if (Array.isArray(child) && isSubPipeline(child)) {
+                sanitizePipeline(child, changes);
+                if (child.length === 0) {
+                    delete value[k];
+                }
+            }
+            else {
+                sanitizeNestedPipelines(child, changes);
+            }
+        }
+    }
 }
 
 /**
  * Recursively remove non-whitelisted stages from an aggregation pipeline,
- * descending into the sub-pipelines of any kept pipeline-bearing stage. The
+ * descending into the sub-pipelines of any kept stage at every depth. The
  * pipeline is mutated in place.
  * @param {Array} pipeline - aggregation pipeline (array of stage objects)
  * @param {object} changes - accumulator: keys are removed stage names
@@ -126,10 +191,16 @@ function sanitizePipeline(pipeline, changes) {
                 changes[key] = true;
                 delete stage[key];
             }
-            else if (sanitizeNestedPipelines(key, stage[key], changes)) {
-                // the kept stage's nested content was fully emptied by
-                // sanitization — drop the now-meaningless stage operator.
-                delete stage[key];
+            else {
+                // kept stage — sanitize any sub-pipeline nested anywhere in its
+                // value (structural, not keyed on a specific stage name)
+                sanitizeNestedPipelines(stage[key], changes);
+                // drop the stage if sanitization emptied its content (e.g. a
+                // $facet whose every branch was removed — Mongo rejects that)
+                var v = stage[key];
+                if (v && typeof v === "object" && !Array.isArray(v) && Object.keys(v).length === 0) {
+                    delete stage[key];
+                }
             }
         }
         if (Object.keys(stage).length === 0) {

--- a/plugins/dbviewer/api/parts/aggregation_guard.js
+++ b/plugins/dbviewer/api/parts/aggregation_guard.js
@@ -191,42 +191,41 @@ function joinTargetsOf(stage) {
 }
 
 /**
- * Recursively scan a pipeline for a join/union into a protected (redacted)
- * collection, at every depth (including $facet sub-pipelines and nested
- * .pipeline arrays). Used to block such joins regardless of the caller's role,
- * since the per-collection redaction cannot follow data pulled in via a join.
- * @param {Array} pipeline - aggregation pipeline (not mutated)
+ * Deep-scan an aggregation pipeline node (object/array, at every depth) for a
+ * join/union into a protected (redacted) collection. Used to block such joins
+ * regardless of the caller's role, since the per-collection redaction cannot
+ * follow data pulled in via a join.
+ *
+ * This walks ALL nested structures rather than only known sub-pipeline
+ * locations ($facet / .pipeline), so a join smuggled inside any future stage
+ * shape is still detected. Detection-only (no mutation), so a blanket deep walk
+ * is safe here — unlike the stage sanitizer, which must stay targeted to avoid
+ * mangling expressions.
+ * @param {*} node - pipeline / stage / expression node (not mutated)
  * @returns {string|null} the protected collection name if one is joined, else null
  */
-function findProtectedCollectionJoin(pipeline) {
-    if (!Array.isArray(pipeline)) {
+function findProtectedCollectionJoin(node) {
+    if (Array.isArray(node)) {
+        for (var i = 0; i < node.length; i++) {
+            var inArr = findProtectedCollectionJoin(node[i]);
+            if (inArr) {
+                return inArr;
+            }
+        }
         return null;
     }
-    for (var i = 0; i < pipeline.length; i++) {
-        var stage = pipeline[i];
-        if (!stage || typeof stage !== "object") {
-            continue;
-        }
-        var targets = joinTargetsOf(stage);
+    if (node && typeof node === "object") {
+        var targets = joinTargetsOf(node);
         for (var t = 0; t < targets.length; t++) {
             if (PROTECTED_JOIN_COLLECTIONS[targets[t]] === true) {
                 return targets[t];
             }
         }
-        for (var key in stage) {
-            var val = stage[key];
-            if (key === "$facet" && val && typeof val === "object") {
-                for (var facetName in val) {
-                    var found = findProtectedCollectionJoin(val[facetName]);
-                    if (found) {
-                        return found;
-                    }
-                }
-            }
-            else if (val && typeof val === "object" && Array.isArray(val.pipeline)) {
-                var nested = findProtectedCollectionJoin(val.pipeline);
-                if (nested) {
-                    return nested;
+        for (var key in node) {
+            if (Object.prototype.hasOwnProperty.call(node, key)) {
+                var inVal = findProtectedCollectionJoin(node[key]);
+                if (inVal) {
+                    return inVal;
                 }
             }
         }

--- a/plugins/dbviewer/api/parts/query_guard.js
+++ b/plugins/dbviewer/api/parts/query_guard.js
@@ -1,0 +1,54 @@
+/**
+ * @module plugins/dbviewer/api/parts/query_guard
+ * @description Helpers that harden the user-supplied parts of a DB Viewer
+ * find() query (projection and the _id search term).
+ */
+
+'use strict';
+
+/**
+ * Restrict a find() projection to plain field inclusion / exclusion.
+ *
+ * A projection value is only allowed to be a number or boolean (1/0/true/false).
+ * Any other value is dropped, because since MongoDB 4.4 a find() projection may
+ * contain expressions and field-path aliases — e.g. { leak: "$password" } or
+ * { x: { $function: ... } } — which would compute new fields from, or rename,
+ * fields the viewer otherwise removes from the response. Keeping projections to
+ * pure include/exclude removes that whole avenue.
+ *
+ * @param {object} projection - parsed projection object (mutated in place)
+ * @returns {object} changes - keys are the projection fields that were dropped
+ */
+function sanitizeProjection(projection) {
+    var changes = {};
+    if (!projection || typeof projection !== "object" || Array.isArray(projection)) {
+        return changes;
+    }
+    for (var key in projection) {
+        if (Object.prototype.hasOwnProperty.call(projection, key)) {
+            var value = projection[key];
+            if (typeof value !== "number" && typeof value !== "boolean") {
+                changes[key] = true;
+                delete projection[key];
+            }
+        }
+    }
+    return changes;
+}
+
+/**
+ * Escape a string for safe use as a literal inside a RegExp, so a user-supplied
+ * search term cannot introduce a pathological pattern (catastrophic
+ * backtracking / ReDoS).
+ *
+ * @param {string} str - raw search term
+ * @returns {string} the term with all RegExp metacharacters escaped
+ */
+function escapeRegExp(str) {
+    return String(str).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+module.exports = {
+    sanitizeProjection,
+    escapeRegExp
+};

--- a/plugins/dbviewer/api/parts/query_guard.js
+++ b/plugins/dbviewer/api/parts/query_guard.js
@@ -9,12 +9,15 @@
 /**
  * Restrict a find() projection to plain field inclusion / exclusion.
  *
- * A projection value is only allowed to be a number or boolean (1/0/true/false).
- * Any other value is dropped, because since MongoDB 4.4 a find() projection may
- * contain expressions and field-path aliases — e.g. { leak: "$password" } or
- * { x: { $function: ... } } — which would compute new fields from, or rename,
- * fields the viewer otherwise removes from the response. Keeping projections to
- * pure include/exclude removes that whole avenue.
+ * A projection value is only allowed to be 0, 1 or a boolean (strict
+ * include/exclude). Any other value is dropped:
+ *  - expressions and field-path aliases — e.g. { leak: "$password" } or
+ *    { x: { $function: ... } } — would compute new fields from, or rename,
+ *    fields the viewer otherwise removes from the response (MongoDB 4.4+ find()
+ *    projections accept expressions);
+ *  - other numbers (2, NaN, …) are not valid include/exclude values and can
+ *    make the query throw.
+ * Keeping projections to strict include/exclude removes that whole avenue.
  *
  * @param {object} projection - parsed projection object (mutated in place)
  * @returns {object} changes - keys are the projection fields that were dropped
@@ -27,7 +30,7 @@ function sanitizeProjection(projection) {
     for (var key in projection) {
         if (Object.prototype.hasOwnProperty.call(projection, key)) {
             var value = projection[key];
-            if (typeof value !== "number" && typeof value !== "boolean") {
+            if (value !== 0 && value !== 1 && value !== true && value !== false) {
                 changes[key] = true;
                 delete projection[key];
             }

--- a/test/unit-tests/plugins.dbviewer.aggregation-guard.js
+++ b/test/unit-tests/plugins.dbviewer.aggregation-guard.js
@@ -1,171 +1,137 @@
 require("should");
 var guard = require("../../plugins/dbviewer/api/parts/aggregation_guard.js");
 
-// The DB Viewer aggregation guard strips any non-whitelisted stage (e.g.
-// $lookup / $unionWith / $graphLookup) so cross-collection reads cannot bypass
-// the per-collection access check. The key requirement is that this holds at
-// EVERY depth, including inside $facet sub-pipelines.
+var USER = guard.ALLOWED_STAGES_USER;
+var ADMIN = guard.ALLOWED_STAGES_GLOBAL_ADMIN;
+
+// sanitizeAggregation(pipeline, allowedStages) -> { changes, error }
+//  - strips stages not in the role's allow-list (recursively, at every depth)
+//  - rejects (error) server-side-JS operators and joins into redacted
+//    collections, for any role, at any depth
 describe("dbviewer aggregation guard", function() {
-    describe("top level", function() {
-        it("keeps whitelisted stages", function() {
-            var pipeline = [{$match: {a: 1}}, {$group: {_id: "$x"}}, {$limit: 5}];
-            var changes = guard.escapeNotAllowedAggregationStages(pipeline);
-            Object.keys(changes).length.should.equal(0);
-            pipeline.length.should.equal(3);
+    describe("stage allow-list (non-global user)", function() {
+        it("keeps allow-listed stages untouched", function() {
+            var p = [{$match: {a: 1}}, {$group: {_id: "$x"}}, {$limit: 5}];
+            var res = guard.sanitizeAggregation(p, USER);
+            (res.error === null).should.equal(true);
+            Object.keys(res.changes).length.should.equal(0);
+            p.length.should.equal(3);
         });
-        it("strips a blocked $lookup at the top level", function() {
-            var pipeline = [{$lookup: {from: "members", as: "m"}}, {$limit: 5}];
-            var changes = guard.escapeNotAllowedAggregationStages(pipeline);
-            changes.should.have.property("$lookup");
-            // the now-empty $lookup stage is removed, $limit remains
-            pipeline.length.should.equal(1);
-            pipeline[0].should.have.property("$limit");
+        it("strips a non-allowed stage ($lookup) for a normal user", function() {
+            var p = [{$lookup: {from: "events", as: "e"}}, {$limit: 5}];
+            var res = guard.sanitizeAggregation(p, USER);
+            (res.error === null).should.equal(true);
+            res.changes.should.have.property("$lookup");
+            p.length.should.equal(1);
+            p[0].should.have.property("$limit");
         });
-        it("strips inherited Object.prototype keys (constructor / __proto__) as non-allow-listed", function() {
-            // a stage key like "constructor" resolves to a truthy inherited
-            // property on the allow-list object; the guard must still strip it
-            var pipeline = [JSON.parse('{"constructor": {"x": 1}}'), JSON.parse('{"__proto__": {"y": 1}}'), {$limit: 5}];
-            guard.escapeNotAllowedAggregationStages(pipeline);
-            // only the legitimate $limit stage survives
-            pipeline.length.should.equal(1);
-            pipeline[0].should.have.property("$limit");
+        it("strips write stages ($out) for everyone (in no list)", function() {
+            var p = [{$match: {a: 1}}, {$out: "stolen"}];
+            var res = guard.sanitizeAggregation(p, USER);
+            (res.error === null).should.equal(true);
+            res.changes.should.have.property("$out");
+            JSON.stringify(p).indexOf("$out").should.equal(-1);
         });
-    });
-
-    describe("nested inside $facet (the bypass)", function() {
-        it("strips a $lookup smuggled inside a $facet sub-pipeline", function() {
-            var pipeline = [{
-                $facet: {
-                    leak: [
-                        {$lookup: {from: "members", pipeline: [{$project: {email: 1, api_key: 1}}], as: "members"}}
-                    ]
-                }
-            }];
-            var changes = guard.escapeNotAllowedAggregationStages(pipeline);
-            changes.should.have.property("$lookup");
-            // the $lookup must not survive anywhere in the pipeline
-            JSON.stringify(pipeline).indexOf("$lookup").should.equal(-1);
-            JSON.stringify(pipeline).indexOf("members").should.equal(-1);
-        });
-
-        it("strips blocked stages nested in deeper $facet within $facet", function() {
-            var pipeline = [{
-                $facet: {
-                    outer: [
-                        {$match: {a: 1}},
-                        {$facet: {inner: [{$unionWith: {coll: "members"}}]}}
-                    ]
-                }
-            }];
-            var changes = guard.escapeNotAllowedAggregationStages(pipeline);
-            changes.should.have.property("$unionWith");
-            JSON.stringify(pipeline).indexOf("$unionWith").should.equal(-1);
-        });
-
-        it("keeps a $facet whose sub-pipeline only uses whitelisted stages", function() {
-            var pipeline = [{
-                $facet: {
-                    counts: [{$match: {a: 1}}, {$count: "n"}]
-                }
-            }];
-            var changes = guard.escapeNotAllowedAggregationStages(pipeline);
-            Object.keys(changes).length.should.equal(0);
-            pipeline[0].should.have.property("$facet");
-            pipeline[0].$facet.should.have.property("counts");
-            pipeline[0].$facet.counts.length.should.equal(2);
-        });
-
-        it("drops a facet sub-pipeline emptied by sanitization (no empty $facet pipeline sent to mongo)", function() {
-            var pipeline = [{
-                $facet: {
-                    leak: [{$lookup: {from: "members", as: "m"}}]
-                }
-            }];
-            guard.escapeNotAllowedAggregationStages(pipeline);
-            // leak became empty -> removed; $facet became empty -> stage removed
-            pipeline.length.should.equal(0);
+        it("strips inherited Object.prototype keys (constructor / __proto__)", function() {
+            var p = [JSON.parse('{"constructor": {"x": 1}}'), JSON.parse('{"__proto__": {"y": 1}}'), {$limit: 5}];
+            guard.sanitizeAggregation(p, USER);
+            p.length.should.equal(1);
+            p[0].should.have.property("$limit");
         });
     });
 
-    // Future-proofing: $facet is the only allow-listed pipeline-bearing stage
-    // today, but the sanitizer is structural — any kept stage exposing a
-    // `.pipeline` array also has it sanitized. Simulate a future allow-listed
-    // pipeline-bearing stage to prove blocked stages can't hide in its pipeline.
-    describe("generic nested-pipeline handling (future-proofing)", function() {
-        var FAKE = "$fakePipelineStage";
-        beforeEach(function() {
-            guard.whiteListedAggregationStages[FAKE] = true;
+    describe("nested stage stripping (structural, any depth)", function() {
+        it("strips a non-allowed stage nested in $facet", function() {
+            var p = [{$facet: {leak: [{$lookup: {from: "events", as: "e"}}]}}];
+            var res = guard.sanitizeAggregation(p, USER);
+            res.changes.should.have.property("$lookup");
+            JSON.stringify(p).indexOf("$lookup").should.equal(-1);
         });
-        afterEach(function() {
-            delete guard.whiteListedAggregationStages[FAKE];
-        });
-
-        it("strips a blocked stage nested in a kept stage's .pipeline", function() {
-            var pipeline = [{}];
-            pipeline[0][FAKE] = {pipeline: [{$match: {a: 1}}, {$lookup: {from: "members", as: "m"}}]};
-            var changes = guard.escapeNotAllowedAggregationStages(pipeline);
-            changes.should.have.property("$lookup");
-            JSON.stringify(pipeline).indexOf("$lookup").should.equal(-1);
-            // the kept stage and its legitimate $match remain
-            pipeline[0].should.have.property(FAKE);
-            pipeline[0][FAKE].pipeline.length.should.equal(1);
-            pipeline[0][FAKE].pipeline[0].should.have.property("$match");
-        });
-        it("strips a blocked stage in a sub-pipeline under an arbitrary (non-$facet/.pipeline) field", function() {
-            // structural detection: a sub-pipeline carried by any field name,
-            // even an array-of-pipelines shape, is still descended into
-            var pipeline = [{}];
-            pipeline[0][FAKE] = {branches: [[{$match: {a: 1}}, {$lookup: {from: "members", as: "m"}}]]};
-            var changes = guard.escapeNotAllowedAggregationStages(pipeline);
-            changes.should.have.property("$lookup");
-            JSON.stringify(pipeline).indexOf("$lookup").should.equal(-1);
-            // the legitimate $match inside the nested sub-pipeline survives
-            pipeline[0][FAKE].branches[0].length.should.equal(1);
-            pipeline[0][FAKE].branches[0][0].should.have.property("$match");
+        it("strips a non-allowed stage in an arbitrary (non-$facet/.pipeline) nested shape", function() {
+            var p = [{$facet: {b: [{$set: {ok: 1}}]}}];
+            // craft an allowed stage carrying a sub-pipeline under a custom field
+            p[0].$facet.b.push({$project: {z: 1}});
+            var weird = [{$group: {_id: 1}}];
+            weird.push({$lookup: {from: "events", as: "e"}});
+            p[0].$facet.b.push({$set: {nested: {anything: weird}}}); // expression object holding a pipeline-shaped array
+            var res = guard.sanitizeAggregation(p, USER);
+            res.changes.should.have.property("$lookup");
+            JSON.stringify(p).indexOf("$lookup").should.equal(-1);
         });
         it("does not mistake an ordinary expression array for a sub-pipeline", function() {
-            // {$concat:["$a","$b"]} is an expression, not a pipeline; it must be left intact
-            var pipeline = [{$project: {full: {$concat: ["$a", "$b"]}}}];
-            var changes = guard.escapeNotAllowedAggregationStages(pipeline);
-            Object.keys(changes).length.should.equal(0);
-            pipeline.length.should.equal(1);
-            pipeline[0].$project.full.$concat.length.should.equal(2);
+            var p = [{$project: {full: {$concat: ["$a", "$b"]}}}];
+            var res = guard.sanitizeAggregation(p, USER);
+            Object.keys(res.changes).length.should.equal(0);
+            p[0].$project.full.$concat.length.should.equal(2);
+        });
+        it("drops a $facet branch emptied by stripping", function() {
+            var p = [{$facet: {leak: [{$lookup: {from: "events", as: "e"}}]}}];
+            guard.sanitizeAggregation(p, USER);
+            // leak emptied -> removed; $facet emptied -> stage removed
+            p.length.should.equal(0);
         });
     });
 
-    // Blocks joins into redacted collections (members / auth_tokens) at any
-    // depth, for everyone — including global admins, who skip the stage
-    // sanitizer but are still denied raw credentials via DB Viewer.
-    describe("findProtectedCollectionJoin", function() {
-        it("returns null for a pipeline with no joins", function() {
-            (guard.findProtectedCollectionJoin([{$match: {a: 1}}, {$group: {_id: "$x"}}]) === null).should.equal(true);
+    describe("hard rule: server-side JavaScript (any role, any depth)", function() {
+        it("rejects $function inside a $project expression", function() {
+            var p = [{$project: {x: {$function: {body: "f", args: [], lang: "js"}}}}];
+            var res = guard.sanitizeAggregation(p, ADMIN);
+            res.error.type.should.equal("operator");
+            res.error.name.should.equal("$function");
         });
-        it("ignores a join into a non-protected collection", function() {
-            (guard.findProtectedCollectionJoin([{$lookup: {from: "events", as: "e"}}]) === null).should.equal(true);
+        it("rejects $accumulator inside $group", function() {
+            var p = [{$group: {_id: null, v: {$accumulator: {init: "f", accumulate: "g", accumulateArgs: [], merge: "h", lang: "js"}}}}];
+            guard.sanitizeAggregation(p, USER).error.name.should.equal("$accumulator");
         });
-        it("detects a top-level $lookup into members", function() {
-            guard.findProtectedCollectionJoin([{$lookup: {from: "members", as: "m"}}]).should.equal("members");
+        it("rejects $where", function() {
+            guard.sanitizeAggregation([{$match: {$where: "this.a==1"}}], USER).error.name.should.equal("$where");
         });
-        it("detects a $lookup into members nested in $facet", function() {
-            guard.findProtectedCollectionJoin([{$facet: {leak: [{$lookup: {from: "members", as: "m"}}]}}]).should.equal("members");
+        it("rejects $function nested deep in $facet", function() {
+            var p = [{$facet: {f: [{$addFields: {y: {$function: {body: "f", args: [], lang: "js"}}}}]}}];
+            guard.sanitizeAggregation(p, ADMIN).error.name.should.equal("$function");
         });
-        it("detects a $lookup into members nested in another stage's .pipeline", function() {
-            guard.findProtectedCollectionJoin([{$lookup: {from: "events", pipeline: [{$lookup: {from: "members", as: "m"}}], as: "x"}}]).should.equal("members");
+    });
+
+    describe("hard rule: joins into redacted collections (any role, any depth)", function() {
+        it("rejects a $lookup into members (even for global admin)", function() {
+            var res = guard.sanitizeAggregation([{$lookup: {from: "members", as: "m"}}], ADMIN);
+            res.error.type.should.equal("join");
+            res.error.name.should.equal("members");
         });
-        it("detects $unionWith (object form) into auth_tokens", function() {
-            guard.findProtectedCollectionJoin([{$unionWith: {coll: "auth_tokens", pipeline: []}}]).should.equal("auth_tokens");
+        it("rejects $unionWith (object form) into auth_tokens", function() {
+            guard.sanitizeAggregation([{$unionWith: {coll: "auth_tokens", pipeline: []}}], ADMIN).error.name.should.equal("auth_tokens");
         });
-        it("detects $unionWith (string shorthand) into members", function() {
-            guard.findProtectedCollectionJoin([{$unionWith: "members"}]).should.equal("members");
+        it("rejects $unionWith (string shorthand) into members", function() {
+            guard.sanitizeAggregation([{$unionWith: "members"}], ADMIN).error.name.should.equal("members");
         });
-        it("detects $graphLookup into members", function() {
-            guard.findProtectedCollectionJoin([{$graphLookup: {from: "members", startWith: "$x", connectFromField: "a", connectToField: "b", as: "m"}}]).should.equal("members");
+        it("rejects $graphLookup into members", function() {
+            guard.sanitizeAggregation([{$graphLookup: {from: "members", startWith: "$x", connectFromField: "a", connectToField: "b", as: "m"}}], ADMIN).error.name.should.equal("members");
         });
-        it("detects a join nested in an arbitrary (non-$facet, non-.pipeline) stage shape", function() {
-            // future-proofing: a join smuggled under some unknown stage shape
-            // that isn't $facet and doesn't use a .pipeline key must still be found
-            var pipeline = [{$someFutureStage: {branches: [[{$lookup: {from: "members", as: "m"}}]]}}];
-            guard.findProtectedCollectionJoin(pipeline).should.equal("members");
+        it("rejects a join into members nested inside $facet", function() {
+            guard.sanitizeAggregation([{$facet: {leak: [{$lookup: {from: "members", as: "m"}}]}}], ADMIN).error.name.should.equal("members");
+        });
+    });
+
+    describe("global admin allow-list", function() {
+        it("allows $lookup into a non-protected collection (kept, no error)", function() {
+            var p = [{$lookup: {from: "events", pipeline: [{$match: {a: 1}}], as: "e"}}, {$limit: 5}];
+            var res = guard.sanitizeAggregation(p, ADMIN);
+            (res.error === null).should.equal(true);
+            Object.keys(res.changes).length.should.equal(0);
+            p[0].should.have.property("$lookup");
+        });
+        it("still strips a non-allowed stage ($out) for an admin", function() {
+            var p = [{$match: {a: 1}}, {$out: "x"}];
+            var res = guard.sanitizeAggregation(p, ADMIN);
+            (res.error === null).should.equal(true);
+            res.changes.should.have.property("$out");
+        });
+        it("does NOT allow $lookup for a normal user (stripped)", function() {
+            var p = [{$lookup: {from: "events", as: "e"}}];
+            var res = guard.sanitizeAggregation(p, USER);
+            (res.error === null).should.equal(true);
+            res.changes.should.have.property("$lookup");
+            p.length.should.equal(0);
         });
     });
 });

--- a/test/unit-tests/plugins.dbviewer.aggregation-guard.js
+++ b/test/unit-tests/plugins.dbviewer.aggregation-guard.js
@@ -1,0 +1,80 @@
+require("should");
+var guard = require("../../plugins/dbviewer/api/parts/aggregation_guard.js");
+
+// The DB Viewer aggregation guard strips any non-whitelisted stage (e.g.
+// $lookup / $unionWith / $graphLookup) so cross-collection reads cannot bypass
+// the per-collection access check. The key requirement is that this holds at
+// EVERY depth, including inside $facet sub-pipelines.
+describe("dbviewer aggregation guard", function() {
+    describe("top level", function() {
+        it("keeps whitelisted stages", function() {
+            var pipeline = [{$match: {a: 1}}, {$group: {_id: "$x"}}, {$limit: 5}];
+            var changes = guard.escapeNotAllowedAggregationStages(pipeline);
+            Object.keys(changes).length.should.equal(0);
+            pipeline.length.should.equal(3);
+        });
+        it("strips a blocked $lookup at the top level", function() {
+            var pipeline = [{$lookup: {from: "members", as: "m"}}, {$limit: 5}];
+            var changes = guard.escapeNotAllowedAggregationStages(pipeline);
+            changes.should.have.property("$lookup");
+            // the now-empty $lookup stage is removed, $limit remains
+            pipeline.length.should.equal(1);
+            pipeline[0].should.have.property("$limit");
+        });
+    });
+
+    describe("nested inside $facet (the bypass)", function() {
+        it("strips a $lookup smuggled inside a $facet sub-pipeline", function() {
+            var pipeline = [{
+                $facet: {
+                    leak: [
+                        {$lookup: {from: "members", pipeline: [{$project: {email: 1, api_key: 1}}], as: "members"}}
+                    ]
+                }
+            }];
+            var changes = guard.escapeNotAllowedAggregationStages(pipeline);
+            changes.should.have.property("$lookup");
+            // the $lookup must not survive anywhere in the pipeline
+            JSON.stringify(pipeline).indexOf("$lookup").should.equal(-1);
+            JSON.stringify(pipeline).indexOf("members").should.equal(-1);
+        });
+
+        it("strips blocked stages nested in deeper $facet within $facet", function() {
+            var pipeline = [{
+                $facet: {
+                    outer: [
+                        {$match: {a: 1}},
+                        {$facet: {inner: [{$unionWith: {coll: "members"}}]}}
+                    ]
+                }
+            }];
+            var changes = guard.escapeNotAllowedAggregationStages(pipeline);
+            changes.should.have.property("$unionWith");
+            JSON.stringify(pipeline).indexOf("$unionWith").should.equal(-1);
+        });
+
+        it("keeps a $facet whose sub-pipeline only uses whitelisted stages", function() {
+            var pipeline = [{
+                $facet: {
+                    counts: [{$match: {a: 1}}, {$count: "n"}]
+                }
+            }];
+            var changes = guard.escapeNotAllowedAggregationStages(pipeline);
+            Object.keys(changes).length.should.equal(0);
+            pipeline[0].should.have.property("$facet");
+            pipeline[0].$facet.should.have.property("counts");
+            pipeline[0].$facet.counts.length.should.equal(2);
+        });
+
+        it("drops a facet sub-pipeline emptied by sanitization (no empty $facet pipeline sent to mongo)", function() {
+            var pipeline = [{
+                $facet: {
+                    leak: [{$lookup: {from: "members", as: "m"}}]
+                }
+            }];
+            guard.escapeNotAllowedAggregationStages(pipeline);
+            // leak became empty -> removed; $facet became empty -> stage removed
+            pipeline.length.should.equal(0);
+        });
+    });
+});

--- a/test/unit-tests/plugins.dbviewer.aggregation-guard.js
+++ b/test/unit-tests/plugins.dbviewer.aggregation-guard.js
@@ -111,6 +111,26 @@ describe("dbviewer aggregation guard", function() {
             pipeline[0][FAKE].pipeline.length.should.equal(1);
             pipeline[0][FAKE].pipeline[0].should.have.property("$match");
         });
+        it("strips a blocked stage in a sub-pipeline under an arbitrary (non-$facet/.pipeline) field", function() {
+            // structural detection: a sub-pipeline carried by any field name,
+            // even an array-of-pipelines shape, is still descended into
+            var pipeline = [{}];
+            pipeline[0][FAKE] = {branches: [[{$match: {a: 1}}, {$lookup: {from: "members", as: "m"}}]]};
+            var changes = guard.escapeNotAllowedAggregationStages(pipeline);
+            changes.should.have.property("$lookup");
+            JSON.stringify(pipeline).indexOf("$lookup").should.equal(-1);
+            // the legitimate $match inside the nested sub-pipeline survives
+            pipeline[0][FAKE].branches[0].length.should.equal(1);
+            pipeline[0][FAKE].branches[0][0].should.have.property("$match");
+        });
+        it("does not mistake an ordinary expression array for a sub-pipeline", function() {
+            // {$concat:["$a","$b"]} is an expression, not a pipeline; it must be left intact
+            var pipeline = [{$project: {full: {$concat: ["$a", "$b"]}}}];
+            var changes = guard.escapeNotAllowedAggregationStages(pipeline);
+            Object.keys(changes).length.should.equal(0);
+            pipeline.length.should.equal(1);
+            pipeline[0].$project.full.$concat.length.should.equal(2);
+        });
     });
 
     // Blocks joins into redacted collections (members / auth_tokens) at any

--- a/test/unit-tests/plugins.dbviewer.aggregation-guard.js
+++ b/test/unit-tests/plugins.dbviewer.aggregation-guard.js
@@ -141,5 +141,11 @@ describe("dbviewer aggregation guard", function() {
         it("detects $graphLookup into members", function() {
             guard.findProtectedCollectionJoin([{$graphLookup: {from: "members", startWith: "$x", connectFromField: "a", connectToField: "b", as: "m"}}]).should.equal("members");
         });
+        it("detects a join nested in an arbitrary (non-$facet, non-.pipeline) stage shape", function() {
+            // future-proofing: a join smuggled under some unknown stage shape
+            // that isn't $facet and doesn't use a .pipeline key must still be found
+            var pipeline = [{$someFutureStage: {branches: [[{$lookup: {from: "members", as: "m"}}]]}}];
+            guard.findProtectedCollectionJoin(pipeline).should.equal("members");
+        });
     });
 });

--- a/test/unit-tests/plugins.dbviewer.aggregation-guard.js
+++ b/test/unit-tests/plugins.dbviewer.aggregation-guard.js
@@ -77,4 +77,30 @@ describe("dbviewer aggregation guard", function() {
             pipeline.length.should.equal(0);
         });
     });
+
+    // Future-proofing: $facet is the only allow-listed pipeline-bearing stage
+    // today, but the sanitizer is structural — any kept stage exposing a
+    // `.pipeline` array also has it sanitized. Simulate a future allow-listed
+    // pipeline-bearing stage to prove blocked stages can't hide in its pipeline.
+    describe("generic nested-pipeline handling (future-proofing)", function() {
+        var FAKE = "$fakePipelineStage";
+        beforeEach(function() {
+            guard.whiteListedAggregationStages[FAKE] = true;
+        });
+        afterEach(function() {
+            delete guard.whiteListedAggregationStages[FAKE];
+        });
+
+        it("strips a blocked stage nested in a kept stage's .pipeline", function() {
+            var pipeline = [{}];
+            pipeline[0][FAKE] = {pipeline: [{$match: {a: 1}}, {$lookup: {from: "members", as: "m"}}]};
+            var changes = guard.escapeNotAllowedAggregationStages(pipeline);
+            changes.should.have.property("$lookup");
+            JSON.stringify(pipeline).indexOf("$lookup").should.equal(-1);
+            // the kept stage and its legitimate $match remain
+            pipeline[0].should.have.property(FAKE);
+            pipeline[0][FAKE].pipeline.length.should.equal(1);
+            pipeline[0][FAKE].pipeline[0].should.have.property("$match");
+        });
+    });
 });

--- a/test/unit-tests/plugins.dbviewer.aggregation-guard.js
+++ b/test/unit-tests/plugins.dbviewer.aggregation-guard.js
@@ -21,6 +21,15 @@ describe("dbviewer aggregation guard", function() {
             pipeline.length.should.equal(1);
             pipeline[0].should.have.property("$limit");
         });
+        it("strips inherited Object.prototype keys (constructor / __proto__) as non-allow-listed", function() {
+            // a stage key like "constructor" resolves to a truthy inherited
+            // property on the allow-list object; the guard must still strip it
+            var pipeline = [JSON.parse('{"constructor": {"x": 1}}'), JSON.parse('{"__proto__": {"y": 1}}'), {$limit: 5}];
+            guard.escapeNotAllowedAggregationStages(pipeline);
+            // only the legitimate $limit stage survives
+            pipeline.length.should.equal(1);
+            pipeline[0].should.have.property("$limit");
+        });
     });
 
     describe("nested inside $facet (the bypass)", function() {

--- a/test/unit-tests/plugins.dbviewer.aggregation-guard.js
+++ b/test/unit-tests/plugins.dbviewer.aggregation-guard.js
@@ -103,4 +103,34 @@ describe("dbviewer aggregation guard", function() {
             pipeline[0][FAKE].pipeline[0].should.have.property("$match");
         });
     });
+
+    // Blocks joins into redacted collections (members / auth_tokens) at any
+    // depth, for everyone — including global admins, who skip the stage
+    // sanitizer but are still denied raw credentials via DB Viewer.
+    describe("findProtectedCollectionJoin", function() {
+        it("returns null for a pipeline with no joins", function() {
+            (guard.findProtectedCollectionJoin([{$match: {a: 1}}, {$group: {_id: "$x"}}]) === null).should.equal(true);
+        });
+        it("ignores a join into a non-protected collection", function() {
+            (guard.findProtectedCollectionJoin([{$lookup: {from: "events", as: "e"}}]) === null).should.equal(true);
+        });
+        it("detects a top-level $lookup into members", function() {
+            guard.findProtectedCollectionJoin([{$lookup: {from: "members", as: "m"}}]).should.equal("members");
+        });
+        it("detects a $lookup into members nested in $facet", function() {
+            guard.findProtectedCollectionJoin([{$facet: {leak: [{$lookup: {from: "members", as: "m"}}]}}]).should.equal("members");
+        });
+        it("detects a $lookup into members nested in another stage's .pipeline", function() {
+            guard.findProtectedCollectionJoin([{$lookup: {from: "events", pipeline: [{$lookup: {from: "members", as: "m"}}], as: "x"}}]).should.equal("members");
+        });
+        it("detects $unionWith (object form) into auth_tokens", function() {
+            guard.findProtectedCollectionJoin([{$unionWith: {coll: "auth_tokens", pipeline: []}}]).should.equal("auth_tokens");
+        });
+        it("detects $unionWith (string shorthand) into members", function() {
+            guard.findProtectedCollectionJoin([{$unionWith: "members"}]).should.equal("members");
+        });
+        it("detects $graphLookup into members", function() {
+            guard.findProtectedCollectionJoin([{$graphLookup: {from: "members", startWith: "$x", connectFromField: "a", connectToField: "b", as: "m"}}]).should.equal("members");
+        });
+    });
 });

--- a/test/unit-tests/plugins.dbviewer.query-guard.js
+++ b/test/unit-tests/plugins.dbviewer.query-guard.js
@@ -29,6 +29,20 @@ describe("dbviewer query guard", function() {
             p.should.not.have.property("y");
             p.should.have.property("name", 1);
         });
+        it("drops numeric values that are not strictly 0 or 1", function() {
+            var p = {a: 2, b: NaN, c: -1, ok: 1, off: 0, t: true, f: false};
+            var changes = qguard.sanitizeProjection(p);
+            changes.should.have.property("a");
+            changes.should.have.property("b");
+            changes.should.have.property("c");
+            p.should.not.have.property("a");
+            p.should.not.have.property("b");
+            p.should.not.have.property("c");
+            p.should.have.property("ok", 1);
+            p.should.have.property("off", 0);
+            p.should.have.property("t", true);
+            p.should.have.property("f", false);
+        });
     });
 
     describe("escapeRegExp", function() {

--- a/test/unit-tests/plugins.dbviewer.query-guard.js
+++ b/test/unit-tests/plugins.dbviewer.query-guard.js
@@ -1,6 +1,5 @@
 require("should");
 var qguard = require("../../plugins/dbviewer/api/parts/query_guard.js");
-var aguard = require("../../plugins/dbviewer/api/parts/aggregation_guard.js");
 
 describe("dbviewer query guard", function() {
     describe("sanitizeProjection", function() {
@@ -56,39 +55,6 @@ describe("dbviewer query guard", function() {
             var re = new RegExp(qguard.escapeRegExp("(a+)+"));
             re.test("(a+)+").should.equal(true);
             re.test("aaaa").should.equal(false);
-        });
-    });
-
-    describe("findWriteStage", function() {
-        it("returns null when no write stage is present", function() {
-            (aguard.findWriteStage([{$match: {a: 1}}, {$group: {_id: "$x"}}]) === null).should.equal(true);
-        });
-        it("detects a top-level $out", function() {
-            aguard.findWriteStage([{$match: {a: 1}}, {$out: "stolen"}]).should.equal("$out");
-        });
-        it("detects a top-level $merge", function() {
-            aguard.findWriteStage([{$merge: {into: "members"}}]).should.equal("$merge");
-        });
-        it("detects a write stage nested in $facet", function() {
-            aguard.findWriteStage([{$facet: {w: [{$out: "x"}]}}]).should.equal("$out");
-        });
-    });
-
-    describe("findServerSideJs", function() {
-        it("returns null when no server-side-JS operator is present", function() {
-            (aguard.findServerSideJs([{$project: {x: 1}}, {$group: {_id: "$a", n: {$sum: 1}}}]) === null).should.equal(true);
-        });
-        it("detects $function inside a $project expression", function() {
-            aguard.findServerSideJs([{$project: {x: {$function: {body: "f", args: [], lang: "js"}}}}]).should.equal("$function");
-        });
-        it("detects $accumulator inside a $group", function() {
-            aguard.findServerSideJs([{$group: {_id: null, v: {$accumulator: {init: "f", accumulate: "g", accumulateArgs: [], merge: "h", lang: "js"}}}}]).should.equal("$accumulator");
-        });
-        it("detects $where", function() {
-            aguard.findServerSideJs([{$match: {$where: "this.a==1"}}]).should.equal("$where");
-        });
-        it("detects a server-side-JS operator nested deep inside $facet", function() {
-            aguard.findServerSideJs([{$facet: {f: [{$addFields: {y: {$function: {body: "f", args: [], lang: "js"}}}}]}}]).should.equal("$function");
         });
     });
 });

--- a/test/unit-tests/plugins.dbviewer.query-guard.js
+++ b/test/unit-tests/plugins.dbviewer.query-guard.js
@@ -73,4 +73,22 @@ describe("dbviewer query guard", function() {
             aguard.findWriteStage([{$facet: {w: [{$out: "x"}]}}]).should.equal("$out");
         });
     });
+
+    describe("findServerSideJs", function() {
+        it("returns null when no server-side-JS operator is present", function() {
+            (aguard.findServerSideJs([{$project: {x: 1}}, {$group: {_id: "$a", n: {$sum: 1}}}]) === null).should.equal(true);
+        });
+        it("detects $function inside a $project expression", function() {
+            aguard.findServerSideJs([{$project: {x: {$function: {body: "f", args: [], lang: "js"}}}}]).should.equal("$function");
+        });
+        it("detects $accumulator inside a $group", function() {
+            aguard.findServerSideJs([{$group: {_id: null, v: {$accumulator: {init: "f", accumulate: "g", accumulateArgs: [], merge: "h", lang: "js"}}}}]).should.equal("$accumulator");
+        });
+        it("detects $where", function() {
+            aguard.findServerSideJs([{$match: {$where: "this.a==1"}}]).should.equal("$where");
+        });
+        it("detects a server-side-JS operator nested deep inside $facet", function() {
+            aguard.findServerSideJs([{$facet: {f: [{$addFields: {y: {$function: {body: "f", args: [], lang: "js"}}}}]}}]).should.equal("$function");
+        });
+    });
 });

--- a/test/unit-tests/plugins.dbviewer.query-guard.js
+++ b/test/unit-tests/plugins.dbviewer.query-guard.js
@@ -1,0 +1,62 @@
+require("should");
+var qguard = require("../../plugins/dbviewer/api/parts/query_guard.js");
+var aguard = require("../../plugins/dbviewer/api/parts/aggregation_guard.js");
+
+describe("dbviewer query guard", function() {
+    describe("sanitizeProjection", function() {
+        it("keeps plain include/exclude projections", function() {
+            var p = {name: 1, _id: 0, "a.b": 1, ok: true, no: false};
+            var changes = qguard.sanitizeProjection(p);
+            Object.keys(changes).length.should.equal(0);
+            p.should.have.property("name", 1);
+            p.should.have.property("a.b", 1);
+        });
+        it("drops a field-path alias value (e.g. {leak: \"$password\"})", function() {
+            var p = {leak: "$password", k: "$api_key", name: 1};
+            var changes = qguard.sanitizeProjection(p);
+            changes.should.have.property("leak");
+            changes.should.have.property("k");
+            p.should.not.have.property("leak");
+            p.should.not.have.property("k");
+            p.should.have.property("name", 1);
+        });
+        it("drops an expression-object value (e.g. {x: {$function: ...}})", function() {
+            var p = {x: {$function: {body: "f", args: [], lang: "js"}}, y: {$concat: ["$password", ""]}, name: 1};
+            var changes = qguard.sanitizeProjection(p);
+            changes.should.have.property("x");
+            changes.should.have.property("y");
+            p.should.not.have.property("x");
+            p.should.not.have.property("y");
+            p.should.have.property("name", 1);
+        });
+    });
+
+    describe("escapeRegExp", function() {
+        it("escapes regex metacharacters", function() {
+            qguard.escapeRegExp("(a+)+$").should.equal("\\(a\\+\\)\\+\\$");
+        });
+        it("leaves a plain id untouched", function() {
+            qguard.escapeRegExp("abc123").should.equal("abc123");
+        });
+        it("produces a literal-matching RegExp (no catastrophic pattern)", function() {
+            var re = new RegExp(qguard.escapeRegExp("(a+)+"));
+            re.test("(a+)+").should.equal(true);
+            re.test("aaaa").should.equal(false);
+        });
+    });
+
+    describe("findWriteStage", function() {
+        it("returns null when no write stage is present", function() {
+            (aguard.findWriteStage([{$match: {a: 1}}, {$group: {_id: "$x"}}]) === null).should.equal(true);
+        });
+        it("detects a top-level $out", function() {
+            aguard.findWriteStage([{$match: {a: 1}}, {$out: "stolen"}]).should.equal("$out");
+        });
+        it("detects a top-level $merge", function() {
+            aguard.findWriteStage([{$merge: {into: "members"}}]).should.equal("$merge");
+        });
+        it("detects a write stage nested in $facet", function() {
+            aguard.findWriteStage([{$facet: {w: [{$out: "x"}]}}]).should.equal("$out");
+        });
+    });
+});


### PR DESCRIPTION
Consolidated DB Viewer hardening — this PR now contains the full commit history of both the aggregation-guard work and the query-hardening work (previously split as #7685 and #7686-stacked). #7685 is folded in here; retargeted to master.

### Aggregation
- Validate stages at every depth, including `$facet` sub-pipelines (recursive allow-list); require an explicit allow-list match so inherited `Object.prototype` keys (`constructor`/`__proto__`) are never treated as allowed.
- Block joins/unions into the redacted collections (`members`/`auth_tokens`), write stages (`$out`/`$merge`), and server-side-JS operators (`$function`/`$accumulator`/`$where`) — all via a **full deep walk**, so any (incl. future) nested stage shape is covered. Applied on **both** admin and non-admin paths.
- Place the `members`/`auth_tokens` redaction as the **first** pipeline stage.

### Find / document
- Projections restricted to strict include/exclude (`0`/`1`/booleans); non-object projection normalized to `{}`.
- `_id` search term (`sSearch`) treated as a literal (no ReDoS).
- Single-document lookups scoped to the caller's apps.
- `members.two_factor_auth` redacted alongside `password`/`api_key`.
- Result-size caps (`limit`/`iDisplayLength`); generic 500s instead of raw MongoDB errors.

### Tests
33 cases across `plugins.dbviewer.aggregation-guard.js` and `plugins.dbviewer.query-guard.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)