### PR TITLE
dbviewer: block cross-db $lookup form in protected-join guard

### DIFF
--- a/plugins/dbviewer/api/api.js
+++ b/plugins/dbviewer/api/api.js
@@ -403,16 +403,16 @@ var spawn = require('child_process').spawn,
         * @param {object} changes - object referencing removed stages from pipeline
         * */
         function aggregate(collection, aggregation, changes) {
-            if (params.qstring.iDisplayLength) {
-                var iDisplayLength = parseInt(params.qstring.iDisplayLength, 10);
-                if (!isNaN(iDisplayLength) && iDisplayLength > 0) {
-                    aggregation.push({ "$limit": Math.min(iDisplayLength, MAX_DBVIEWER_LIMIT) });
-                }
-            }
             if (!Array.isArray(aggregation)) {
                 common.returnMessage(params, 500, "The aggregation pipeline must be of the type array");
             }
             else {
+                if (params.qstring.iDisplayLength) {
+                    var iDisplayLength = parseInt(params.qstring.iDisplayLength, 10);
+                    if (!isNaN(iDisplayLength) && iDisplayLength > 0) {
+                        aggregation.push({ "$limit": Math.min(iDisplayLength, MAX_DBVIEWER_LIMIT) });
+                    }
+                }
                 if (collection === 'members') {
                     // Insert the redaction as the very first stage so no
                     // user-supplied stage — including a leading $match using

--- a/plugins/dbviewer/api/api.js
+++ b/plugins/dbviewer/api/api.js
@@ -404,7 +404,8 @@ var spawn = require('child_process').spawn,
         * */
         function aggregate(collection, aggregation, changes) {
             if (!Array.isArray(aggregation)) {
-                common.returnMessage(params, 500, "The aggregation pipeline must be of the type array");
+                common.returnMessage(params, 400, "The aggregation pipeline must be of the type array");
+                return;
             }
             else {
                 if (params.qstring.iDisplayLength) {

--- a/plugins/dbviewer/api/parts/aggregation_guard.js
+++ b/plugins/dbviewer/api/parts/aggregation_guard.js
@@ -96,6 +96,23 @@ const KNOWN_STAGE_OPERATORS = Object.assign({
 }, ALLOWED_STAGES_GLOBAL_ADMIN);
 
 /**
+ * Extract the collection name from a join "from"/"coll" reference, which may be
+ * a plain string ("members") or the cross-database object form
+ * ({ db, coll }). Returns [] when no collection name can be determined.
+ * @param {*} from - a $lookup.from / $graphLookup.from / $unionWith.coll value
+ * @returns {string[]} the referenced collection name(s)
+ */
+function collectionOf(from) {
+    if (typeof from === "string") {
+        return [from];
+    }
+    if (from && typeof from === "object" && typeof from.coll === "string") {
+        return [from.coll];
+    }
+    return [];
+}
+
+/**
  * Collection names a single stage joins / unions from.
  * @param {object} stage - one aggregation stage
  * @returns {string[]} target collection names referenced by join/union operators
@@ -105,18 +122,18 @@ function joinTargetsOf(stage) {
     if (!stage || typeof stage !== "object") {
         return targets;
     }
-    if (stage.$lookup && typeof stage.$lookup === "object" && typeof stage.$lookup.from === "string") {
-        targets.push(stage.$lookup.from);
+    if (stage.$lookup && typeof stage.$lookup === "object") {
+        targets = targets.concat(collectionOf(stage.$lookup.from));
     }
-    if (stage.$graphLookup && typeof stage.$graphLookup === "object" && typeof stage.$graphLookup.from === "string") {
-        targets.push(stage.$graphLookup.from);
+    if (stage.$graphLookup && typeof stage.$graphLookup === "object") {
+        targets = targets.concat(collectionOf(stage.$graphLookup.from));
     }
     if (stage.$unionWith) {
         if (typeof stage.$unionWith === "string") {
             targets.push(stage.$unionWith);
         }
-        else if (typeof stage.$unionWith === "object" && typeof stage.$unionWith.coll === "string") {
-            targets.push(stage.$unionWith.coll);
+        else if (typeof stage.$unionWith === "object") {
+            targets = targets.concat(collectionOf(stage.$unionWith.coll));
         }
     }
     return targets;

--- a/test/unit-tests/plugins.dbviewer.aggregation-guard.js
+++ b/test/unit-tests/plugins.dbviewer.aggregation-guard.js
@@ -115,6 +115,11 @@ describe("dbviewer aggregation guard", function() {
             res.error.type.should.equal("join");
             res.error.name.should.equal("members");
         });
+        it("rejects a $graphLookup into members via the cross-db object form {db, coll}", function() {
+            var res = guard.sanitizeAggregation([{$graphLookup: {from: {db: "countly", coll: "members"}, startWith: "$x", connectFromField: "a", connectToField: "b", as: "m"}}], ADMIN);
+            res.error.type.should.equal("join");
+            res.error.name.should.equal("members");
+        });
     });
 
     describe("global admin allow-list", function() {

--- a/test/unit-tests/plugins.dbviewer.aggregation-guard.js
+++ b/test/unit-tests/plugins.dbviewer.aggregation-guard.js
@@ -110,6 +110,11 @@ describe("dbviewer aggregation guard", function() {
         it("rejects a join into members nested inside $facet", function() {
             guard.sanitizeAggregation([{$facet: {leak: [{$lookup: {from: "members", as: "m"}}]}}], ADMIN).error.name.should.equal("members");
         });
+        it("rejects a $lookup into members via the cross-db object form {db, coll}", function() {
+            var res = guard.sanitizeAggregation([{$lookup: {from: {db: "countly", coll: "members"}, as: "m"}}], ADMIN);
+            res.error.type.should.equal("join");
+            res.error.name.should.equal("members");
+        });
     });
 
     describe("global admin allow-list", function() {


### PR DESCRIPTION
Follow-up to #7686 (review finding). The DB Viewer protected-collection join guard only recognized the string form of `$lookup.from`, so the cross-database object form — `{from: {db, coll}}` — slipped past the check and could join into `members`/`auth_tokens`.

### Fix
- `joinTargetsOf` now extracts the collection name from both the string and the `{db, coll}` object forms (via a `collectionOf` helper), for `$lookup`/`$graphLookup`/`$unionWith`, so the hard-rule join guard holds regardless of syntax.
- Minor: `aggregate()` checks `Array.isArray` before pushing the `iDisplayLength` `$limit`, so a non-array pipeline returns a controlled error.

### Tests
Adds a regression test for the `{db, coll}` cross-db form (28 guard tests pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)