### PR TITLE
Fix legacy (no-wv) Feedback widget close on mobile

### DIFF
--- a/plugins/star-rating/frontend/public/templates/feedback-popup.html
+++ b/plugins/star-rating/frontend/public/templates/feedback-popup.html
@@ -718,7 +718,12 @@
                         }
                     }
                     else {
-                        if (window.parent && typeof window.parent.postMessage === 'function') {
+                        if (platform !== 'Web') {
+                            // Legacy widgets (no wv) on mobile must trigger a real navigation so the
+                            // mobile SDK can intercept and close. postMessage is only for the web SDK.
+                            window.location.href = 'https://countly_action_event?cly_widget_command=1&close=1';
+                        }
+                        else if (window.parent && typeof window.parent.postMessage === 'function') {
                             var d = JSON.stringify({ close: true });
                             window.parent.postMessage(d, parentOrigin);
                         }


### PR DESCRIPTION
## Fix: legacy Feedback widget close on mobile (Rating widget)

### Problem
Legacy **Rating** widgets without a `wv` (widget version) parameter sent their close signal via `postMessage` **even on mobile**, and without the `cly_widget_command` identifier (`{close: true}` only). Mobile SDKs (Android/iOS) only intercept a real **URL navigation**, not `postMessage`, so tapping close on these legacy widgets did nothing on phones.

### Fix
`plugins/star-rating/frontend/public/templates/feedback-popup.html` — in the no-`wv` branch of `closeHandler`, navigate on mobile like the modern (`wv`) widgets:
```js
else {                       // legacy widget (no wv)
    if (platform !== 'Web') {
        window.location.href = 'https://countly_action_event?cly_widget_command=1&close=1';
    }
    else if (window.parent && typeof window.parent.postMessage === 'function') {
        var d = JSON.stringify({ close: true });   // unchanged legacy web behaviour
        window.parent.postMessage(d, parentOrigin);
    }
}
```
(`platform !== 'Web'` is used rather than the `isWebSDK` var, which is only declared inside the `wv` branch — using it here would hit a `var`-hoisting `undefined` and misfire on web.)

The web `postMessage` path is unchanged (legacy preservation); only the missing mobile navigation is added.

### Notes
- This is the CE/`master` copy of `star-rating`, which is what the enterprise build consumes via the `core` submodule; a parallel change is in `countly-platform`'s own `star-rating` copy.
- JS syntax check of the edited handler passes; a real Android/iOS smoke test of a legacy rating-widget close is recommended before release.
- No Jira ticket provided; share the key and I'll rename branch/PRs.

https://claude.ai/code/session_015nUig7QXdAEYMhS16eSsu1

---
_Generated by [Claude Code](https://claude.ai/code/session_015nUig7QXdAEYMhS16eSsu1)_