### PR TITLE
reject unsafe mongo query operators (backport 24.05)

### DIFF
--- a/api/parts/data/exports.js
+++ b/api/parts/data/exports.js
@@ -514,9 +514,9 @@ exports.fromDatabase = function(options) {
     // query here at the boundary into the dispatch + DB find.
     var badOp = common.findUnsafeMongoOperator(options.query);
     if (badOp) {
-        log.d("Rejected user query" + common.reqInfo(options.params) + ": " + "Query contains disallowed operator: " + badOp);
+        log.d("Rejected user query" + common.reqInfo(options.params) + ": " + common.unsafeQueryError(badOp));
         if (options.params) {
-            common.returnMessage(options.params, 400, "Query contains disallowed operator: " + badOp);
+            common.returnMessage(options.params, 400, common.unsafeQueryError(badOp));
         }
         return;
     }

--- a/api/parts/data/exports.js
+++ b/api/parts/data/exports.js
@@ -507,6 +507,20 @@ exports.fromDatabase = function(options) {
     options.projection = options.projection || {};
     options.writeHeaders = true;
 
+    // Reject (never modify) export queries that contain disallowed Mongo
+    // operators ($where/$function/$accumulator). options.query is dispatched to
+    // /drill/preprocess_query and then run against the database; the dispatch
+    // hook no longer strips these operators, so validate the already-parsed
+    // query here at the boundary into the dispatch + DB find.
+    var badOp = common.findUnsafeMongoOperator(options.query);
+    if (badOp) {
+        log.d("Rejected user query" + common.reqInfo(options.params) + ": " + "Query contains disallowed operator: " + badOp);
+        if (options.params) {
+            common.returnMessage(options.params, 400, "Query contains disallowed operator: " + badOp);
+        }
+        return;
+    }
+
     if (options.params && options.params.qstring && options.params.qstring.formatFields) {
         options.mapper = options.params.qstring.formatFields;
     }

--- a/api/parts/data/fetch.js
+++ b/api/parts/data/fetch.js
@@ -8,6 +8,7 @@ const { getAdminApps, getUserApps } = require('../../utils/rights.js');
 /** @lends module:api/parts/data/fetch */
 var fetch = {},
     common = require('./../../utils/common.js'),
+    log = common.log('core:api'),
     moment = require('moment-timezone'),
     async = require('async'),
     countlyModel = require('../../lib/countly.model.js'),
@@ -515,13 +516,13 @@ fetch.fetchAllApps = function(params) {
     var filter = {};
 
     if (params.qstring.filter) {
-        try {
-            filter = JSON.parse(params.qstring.filter);
-            common.stripUnsafeMongoOperators(filter);
+        var parsed = common.parseUserQuery(params.qstring.filter);
+        if (parsed.error) {
+            log.d("Rejected user query" + common.reqInfo(params) + ": " + parsed.error);
+            common.returnMessage(params, 400, parsed.error);
+            return;
         }
-        catch (ex) {
-            filter = {};
-        }
+        filter = parsed.query;
     }
 
     if (!params.member.global_admin) {

--- a/api/parts/mgmt/app_users.js
+++ b/api/parts/mgmt/app_users.js
@@ -121,7 +121,6 @@ usersApi.update = function(app_id, query, update, params, callback) {
         callback = params;
         params = {};
     }
-    common.stripUnsafeMongoOperators(query);
     plugins.dispatch("/drill/preprocess_query", {
         query: query
     });
@@ -178,7 +177,6 @@ usersApi.delete = function(app_id, query, params, callback) {
             query = {};
         }
     }
-    common.stripUnsafeMongoOperators(query);
     plugins.dispatch("/drill/preprocess_query", {
         query: query
     });
@@ -303,7 +301,6 @@ usersApi.search = function(app_id, query, project, sort, limit, skip, callback) 
             query = {};
         }
     }
-    common.stripUnsafeMongoOperators(query);
 
     plugins.dispatch("/drill/preprocess_query", {
         query: query
@@ -364,7 +361,6 @@ usersApi.count = function(app_id, query, callback) {
             query = {};
         }
     }
-    common.stripUnsafeMongoOperators(query);
 
     plugins.dispatch("/drill/preprocess_query", {
         query: query
@@ -1036,7 +1032,6 @@ usersApi.export = function(app_id, query, params, callback) {
         });
     }
 
-    common.stripUnsafeMongoOperators(query);
     plugins.dispatch("/drill/preprocess_query", {
         query: query
     });
@@ -1292,22 +1287,17 @@ usersApi.loyalty = function(params) {
     const collectionName = 'app_users' + params.qstring.app_id;
     let query = params.qstring.query || {};
 
-    if (typeof query === "string") {
-        try {
-            query = JSON.parse(query);
-            common.stripUnsafeMongoOperators(query);
-            plugins.dispatch("/drill/preprocess_query", {
-                query: query,
-                params
-            });
-        }
-        catch (error) {
-            query = {};
-        }
+    var parsedQuery = common.parseUserQuery(query);
+    if (parsedQuery.error) {
+        log.d("Rejected user query" + common.reqInfo(params) + ": " + parsedQuery.error);
+        common.returnMessage(params, 400, parsedQuery.error);
+        return;
     }
-    else {
-        common.stripUnsafeMongoOperators(query);
-    }
+    query = parsedQuery.query;
+    plugins.dispatch("/drill/preprocess_query", {
+        query: query,
+        params
+    });
 
     if (cohorts) {
         var cohortQuery = cohorts.preprocessQuery(query);

--- a/api/parts/mgmt/cms.js
+++ b/api/parts/mgmt/cms.js
@@ -198,12 +198,14 @@ cmsApi.getEntriesWithUpdate = function(params) {
 
     var query = { '_id': { '$regex': `^${params.qstring._id}` } };
 
-    try {
-        params.qstring.query = JSON.parse(params.qstring.query);
-        common.stripUnsafeMongoOperators(params.qstring.query);
-    }
-    catch (ex) {
-        params.qstring.query = null;
+    if (params.qstring.query) {
+        var parsed = common.parseUserQuery(params.qstring.query);
+        if (parsed.error) {
+            log.d("Rejected user query" + common.reqInfo(params) + ": " + parsed.error);
+            common.returnMessage(params, 400, parsed.error);
+            return false;
+        }
+        params.qstring.query = parsed.query;
     }
 
     if (params.qstring.query) {
@@ -283,12 +285,14 @@ cmsApi.getEntries = function(params) {
 
     var query = { '_id': { '$regex': `^${params.qstring._id}` } };
 
-    try {
-        params.qstring.query = JSON.parse(params.qstring.query);
-        common.stripUnsafeMongoOperators(params.qstring.query);
-    }
-    catch (ex) {
-        params.qstring.query = null;
+    if (params.qstring.query) {
+        var parsed = common.parseUserQuery(params.qstring.query);
+        if (parsed.error) {
+            log.d("Rejected user query" + common.reqInfo(params) + ": " + parsed.error);
+            common.returnMessage(params, 400, parsed.error);
+            return false;
+        }
+        params.qstring.query = parsed.query;
     }
 
     if (params.qstring.query) {

--- a/api/utils/common.js
+++ b/api/utils/common.js
@@ -2639,55 +2639,159 @@ common.checkPromise = function(func, count, interval) {
 };
 
 /**
- * Recursively remove MongoDB operators that allow arbitrary JavaScript
- * execution or comparison-bypass against trusted server state from a
- * user-supplied query object. Strips:
+ * MongoDB query operators that allow arbitrary server-side JavaScript
+ * execution. These have no legitimate use in a user-supplied query and
+ * are rejected outright (never stripped) wherever a query enters the API.
  *
  *   $where        — evaluates a JS function on every doc; supports
  *                   `while(true){}` DoS and timing-based exfiltration.
- *   $expr         — evaluates aggregation expressions against the doc;
- *                   can be chained with $function/$accumulator below.
  *   $function     — Mongo 4.4+ server-side JS execution.
  *   $accumulator  — server-side JS aggregation execution.
  *
- * Use this anywhere a request body / query string is passed straight
- * into MongoDB find/update/delete/count/aggregate as the filter. It is
- * a defence-in-depth helper, not a substitute for a strict allowlist
- * of fields.
- *
- * @param {*} query - user-supplied query (any depth)
- * @returns {*} the same query with the dangerous operators removed
+ * $expr is intentionally NOT listed: it executes no JS by itself and has
+ * legitimate uses (e.g. cross-field comparisons). The walk below still
+ * descends into a $expr sub-expression, so a $function/$accumulator/$where
+ * nested inside $expr is still detected.
  */
-common.stripUnsafeMongoOperators = function(query) {
-    var BLOCKED = ["$where", "$expr", "$function", "$accumulator"];
+common.UNSAFE_MONGO_OPERATORS = ["$where", "$function", "$accumulator"];
+
+/**
+ * Sentinel returned by findUnsafeMongoOperator when a query is nested deeper
+ * than the recursion cap. Not a real operator; treated as a rejection.
+ */
+common.UNSAFE_QUERY_TOO_DEEP = "$__nestedTooDeep";
+
+/**
+ * Recursively search an already-parsed query object for any operator in
+ * common.UNSAFE_MONGO_OPERATORS. Returns the name of the first offending
+ * operator found, or null if the query is clean.
+ *
+ * Only object KEYS are inspected — operators are always keys, never
+ * values — so a string value that merely contains "$where" is not a false
+ * positive. Detection runs on the decoded object, so it cannot be evaded
+ * by JSON unicode-escaping the operator key (e.g. "$where").
+ *
+ * @param {*} query - parsed query (any depth)
+ * @returns {string|null} the offending operator name, or null
+ */
+common.findUnsafeMongoOperator = function(query) {
+    var BLOCKED = common.UNSAFE_MONGO_OPERATORS;
+    // Cap recursion so a deeply nested payload cannot overflow the stack
+    // (a DoS in the very check meant to block DoS). Real queries are shallow;
+    // anything past this depth is rejected via the TOO_DEEP sentinel.
+    var MAX_DEPTH = 100;
+    var found = null;
     /**
-     * Recursive walk that strips blocked operators in-place.
+     * Recursive walk that records the first blocked operator key (or the
+     * too-deep sentinel).
      * @param {*} v - current node
+     * @param {number} depth - current recursion depth
      * @returns {void}
      */
-    function walk(v) {
-        if (!v || typeof v !== "object") {
+    function walk(v, depth) {
+        if (found || !v || typeof v !== "object") {
+            return;
+        }
+        if (depth > MAX_DEPTH) {
+            found = common.UNSAFE_QUERY_TOO_DEEP;
             return;
         }
         if (Array.isArray(v)) {
-            for (var ai = 0; ai < v.length; ai++) {
-                walk(v[ai]);
+            for (var ai = 0; ai < v.length && !found; ai++) {
+                walk(v[ai], depth + 1);
             }
             return;
         }
         for (var bi = 0; bi < BLOCKED.length; bi++) {
             if (Object.prototype.hasOwnProperty.call(v, BLOCKED[bi])) {
-                delete v[BLOCKED[bi]];
+                found = BLOCKED[bi];
+                return;
             }
         }
         for (var k in v) {
+            if (found) {
+                break;
+            }
             if (Object.prototype.hasOwnProperty.call(v, k)) {
-                walk(v[k]);
+                walk(v[k], depth + 1);
             }
         }
     }
-    walk(query);
-    return query;
+    walk(query, 0);
+    return found;
+};
+
+/**
+ * Parse and validate a user-supplied MongoDB query received at an API
+ * endpoint. Accepts either a JSON string (as queries arrive on the wire)
+ * or an already-parsed object. The query is validated as a decoded object
+ * and is NEVER modified — it is either accepted exactly as submitted or
+ * rejected as a whole:
+ *
+ *   - empty / null / undefined        -> { query: {} }
+ *   - invalid JSON string             -> { error: "Invalid query JSON" }
+ *   - not an object                   -> { error: "Query must be an object" }
+ *   - contains a disallowed operator  -> { error: "Query contains disallowed operator: $where" }
+ *   - otherwise                       -> { query: <parsed object> }
+ *
+ * Callers run result.query exactly as submitted, or return result.error to
+ * the client. The query is never silently rewritten, so its meaning cannot
+ * change between what the caller sent and what runs.
+ *
+ * Note: this uses JSON.parse. Endpoints that accept extended JSON (EJSON,
+ * e.g. dbviewer with ObjectIds) should parse with EJSON themselves and
+ * then validate the parsed object via common.findUnsafeMongoOperator.
+ *
+ * @param {string|object} raw - the raw query parameter
+ * @returns {{query: object}|{error: string}} result
+ */
+common.parseUserQuery = function(raw) {
+    var query = raw;
+    if (typeof raw === "string") {
+        if (raw.length === 0) {
+            return { query: {} };
+        }
+        try {
+            query = JSON.parse(raw);
+        }
+        catch (ex) {
+            return { error: "Invalid query JSON" };
+        }
+    }
+    if (query === null || typeof query === "undefined") {
+        return { query: {} };
+    }
+    if (typeof query !== "object" || Array.isArray(query)) {
+        return { error: "Query must be an object" };
+    }
+    var bad = common.findUnsafeMongoOperator(query);
+    if (bad === common.UNSAFE_QUERY_TOO_DEEP) {
+        return { error: "Query is nested too deeply" };
+    }
+    if (bad) {
+        return { error: "Query contains disallowed operator: " + bad };
+    }
+    return { query: query };
+};
+
+/**
+ * Build a short, log-safe label identifying the request's endpoint, for use in
+ * log messages (e.g. query-rejection logs). Returns the request path plus the
+ * `method` query param when present, e.g. " [/i/app_users/delete]" or
+ * " [/o method=logs]", or "" when no context is available. The query string is
+ * dropped (apart from method) so request api_key etc. are not written to logs.
+ *
+ * @param {object} [params] - request params object (may be null/undefined)
+ * @returns {string} bracketed endpoint label with a leading space, or ""
+ */
+common.reqInfo = function(params) {
+    var ctx = "";
+    if (params) {
+        var reqPath = params.href ? ("" + params.href).split("?")[0] : "";
+        var reqMethod = (params.qstring && params.qstring.method) ? " method=" + params.qstring.method : "";
+        ctx = (reqPath + reqMethod).trim();
+    }
+    return ctx ? " [" + ctx + "]" : "";
 };
 
 common.clearClashingQueryOperations = function(query) {

--- a/api/utils/common.js
+++ b/api/utils/common.js
@@ -2662,6 +2662,21 @@ common.UNSAFE_MONGO_OPERATORS = ["$where", "$function", "$accumulator"];
 common.UNSAFE_QUERY_TOO_DEEP = "$__nestedTooDeep";
 
 /**
+ * Turn a findUnsafeMongoOperator() result into a client-safe error message.
+ * Maps the too-deep sentinel to a clear message instead of leaking it as an
+ * "operator" name. Use this at every site that rejects on findUnsafeMongoOperator.
+ *
+ * @param {string} bad - the value returned by common.findUnsafeMongoOperator
+ * @returns {string} a client-safe error message
+ */
+common.unsafeQueryError = function(bad) {
+    if (bad === common.UNSAFE_QUERY_TOO_DEEP) {
+        return "Query is nested too deeply";
+    }
+    return "Query contains disallowed operator: " + bad;
+};
+
+/**
  * Recursively search an already-parsed query object for any operator in
  * common.UNSAFE_MONGO_OPERATORS. Returns the name of the first offending
  * operator found, or null if the query is clean.
@@ -2765,11 +2780,8 @@ common.parseUserQuery = function(raw) {
         return { error: "Query must be an object" };
     }
     var bad = common.findUnsafeMongoOperator(query);
-    if (bad === common.UNSAFE_QUERY_TOO_DEEP) {
-        return { error: "Query is nested too deeply" };
-    }
     if (bad) {
-        return { error: "Query contains disallowed operator: " + bad };
+        return { error: common.unsafeQueryError(bad) };
     }
     return { query: query };
 };

--- a/api/utils/requestProcessor.js
+++ b/api/utils/requestProcessor.js
@@ -647,7 +647,7 @@ const processRequest = (params) => {
                             // requires an explicit confirm_delete_all=true. This catches a
                             // query that was meant to match a subset but actually matches
                             // everyone, without blocking legitimate subset deletions.
-                            if (params.qstring.force && !params.qstring.confirm_delete_all) {
+                            if (params.qstring.force && params.qstring.confirm_delete_all !== true && params.qstring.confirm_delete_all !== "true") {
                                 common.db.collection("app_users" + params.qstring.app_id).estimatedDocumentCount(function(errTotal, total) {
                                     if (!errTotal && total >= 100 && count >= total * 0.9) {
                                         common.returnMessage(params, 400, 'This query matches ' + count + ' of ~' + total + ' app users (nearly all). If this is intended, retry with confirm_delete_all=true, or use clear app data instead.');

--- a/api/utils/requestProcessor.js
+++ b/api/utils/requestProcessor.js
@@ -579,15 +579,14 @@ const processRequest = (params) => {
                         common.returnMessage(params, 400, 'Missing parameter "query"');
                         return false;
                     }
-                    else if (typeof params.qstring.query === "string") {
-                        try {
-                            params.qstring.query = JSON.parse(params.qstring.query);
-                        }
-                        catch (ex) {
-                            console.log("Could not parse query", params.qstring.query);
-                            common.returnMessage(params, 400, 'Could not parse parameter "query": ' + params.qstring.query);
+                    else {
+                        let parsedQuery = common.parseUserQuery(params.qstring.query);
+                        if (parsedQuery.error) {
+                            log.d("Rejected user query" + common.reqInfo(params) + ": " + parsedQuery.error);
+                            common.returnMessage(params, 400, parsedQuery.error);
                             return false;
                         }
+                        params.qstring.query = parsedQuery.query;
                     }
                     validateUserForWrite(params, function() {
                         countlyApi.mgmt.appUsers.count(params.qstring.app_id, params.qstring.query, function(err, count) {
@@ -620,15 +619,14 @@ const processRequest = (params) => {
                         common.returnMessage(params, 400, 'Missing parameter "query"');
                         return false;
                     }
-                    else if (typeof params.qstring.query === "string") {
-                        try {
-                            params.qstring.query = JSON.parse(params.qstring.query);
-                        }
-                        catch (ex) {
-                            console.log("Could not parse query", params.qstring.query);
-                            common.returnMessage(params, 400, 'Could not parse parameter "query": ' + params.qstring.query);
+                    else {
+                        let parsedQuery = common.parseUserQuery(params.qstring.query);
+                        if (parsedQuery.error) {
+                            log.d("Rejected user query" + common.reqInfo(params) + ": " + parsedQuery.error);
+                            common.returnMessage(params, 400, parsedQuery.error);
                             return false;
                         }
+                        params.qstring.query = parsedQuery.query;
                     }
                     if (!Object.keys(params.qstring.query).length) {
                         common.returnMessage(params, 400, 'Parameter "query" cannot be empty, it would delete all users. Use clear app instead');
@@ -644,14 +642,27 @@ const processRequest = (params) => {
                                 common.returnMessage(params, 400, 'This query would delete more than one user');
                                 return false;
                             }
-                            countlyApi.mgmt.appUsers.delete(params.qstring.app_id, params.qstring.query, params, function(err2) {
-                                if (err2) {
-                                    common.returnMessage(params, 400, err2);
-                                }
-                                else {
-                                    common.returnMessage(params, 200, 'User deleted');
-                                }
-                            });
+                            // Bulk (force) safety net: a force delete whose query matches
+                            // (almost) all users in the app is treated as suspicious and
+                            // requires an explicit confirm_delete_all=true. This catches a
+                            // query that was meant to match a subset but actually matches
+                            // everyone, without blocking legitimate subset deletions.
+                            if (params.qstring.force && !params.qstring.confirm_delete_all) {
+                                common.db.collection("app_users" + params.qstring.app_id).estimatedDocumentCount(function(errTotal, total) {
+                                    if (!errTotal && total >= 100 && count >= total * 0.9) {
+                                        common.returnMessage(params, 400, 'This query matches ' + count + ' of ~' + total + ' app users (nearly all). If this is intended, retry with confirm_delete_all=true, or use clear app data instead.');
+                                        return;
+                                    }
+                                    countlyApi.mgmt.appUsers.delete(params.qstring.app_id, params.qstring.query, params, function(err2) {
+                                        common.returnMessage(params, err2 ? 400 : 200, err2 || 'User deleted');
+                                    });
+                                });
+                            }
+                            else {
+                                countlyApi.mgmt.appUsers.delete(params.qstring.app_id, params.qstring.query, params, function(err2) {
+                                    common.returnMessage(params, err2 ? 400 : 200, err2 || 'User deleted');
+                                });
+                            }
                         });
                     });
                     break;
@@ -729,15 +740,14 @@ const processRequest = (params) => {
                                     common.returnMessage(params, 400, 'Missing parameter "query"');
                                     return false;
                                 }
-                                else if (typeof params.qstring.query === "string") {
-                                    try {
-                                        params.qstring.query = JSON.parse(params.qstring.query);
-                                    }
-                                    catch (ex) {
-                                        console.log("Could not parse query", params.qstring.query);
-                                        common.returnMessage(params, 400, 'Could not parse parameter "query": ' + params.qstring.query);
+                                else {
+                                    let parsedQuery = common.parseUserQuery(params.qstring.query);
+                                    if (parsedQuery.error) {
+                                        log.d("Rejected user query" + common.reqInfo(params) + ": " + parsedQuery.error);
+                                        common.returnMessage(params, 400, parsedQuery.error);
                                         return false;
                                     }
+                                    params.qstring.query = parsedQuery.query;
                                 }
 
                                 var my_name = "";

--- a/plugins/compliance-hub/api/api.js
+++ b/plugins/compliance-hub/api/api.js
@@ -1,6 +1,7 @@
 var plugin = {},
     crypto = require('crypto'),
     common = require('../../../api/utils/common.js'),
+    log = common.log('compliance:api'),
     countlyCommon = require('../../../api/lib/countly.common.js'),
     appUsers = require('../../../api/parts/mgmt/app_users.js'),
     fetch = require('../../../api/parts/data/fetch.js'),
@@ -139,16 +140,13 @@ const FEATURE_NAME = 'compliance_hub';
                 return true;
             }
             validateRead(params, FEATURE_NAME, function() {
-                var query = params.qstring.query || {};
-                if (typeof query === "string" && query.length) {
-                    try {
-                        query = JSON.parse(query);
-                    }
-                    catch (ex) {
-                        query = {};
-                    }
+                var parsed = common.parseUserQuery(params.qstring.query);
+                if (parsed.error) {
+                    log.d("Rejected user query" + common.reqInfo(params) + ": " + parsed.error);
+                    common.returnMessage(params, 400, parsed.error);
+                    return;
                 }
-                common.stripUnsafeMongoOperators(query);
+                var query = parsed.query;
                 // Force scope to the request's app_id even though this lookup
                 // is in app_users<app_id>; defense-in-depth in case a future
                 // refactor changes the collection.
@@ -165,16 +163,13 @@ const FEATURE_NAME = 'compliance_hub';
                 return true;
             }
             validateRead(params, FEATURE_NAME, function() {
-                var query = params.qstring.query || {};
-                if (typeof query === "string" && query.length) {
-                    try {
-                        query = JSON.parse(query);
-                    }
-                    catch (ex) {
-                        query = {};
-                    }
+                var parsed = common.parseUserQuery(params.qstring.query);
+                if (parsed.error) {
+                    log.d("Rejected user query" + common.reqInfo(params) + ": " + parsed.error);
+                    common.returnMessage(params, 400, parsed.error);
+                    return;
                 }
-                common.stripUnsafeMongoOperators(query);
+                var query = parsed.query;
                 query.app_id = params.app_id.toString();
                 common.db.collection("consent_history").countDocuments(query, function(err, total) {
                     if (err) {
@@ -184,16 +179,13 @@ const FEATURE_NAME = 'compliance_hub';
                         params.qstring.query = params.qstring.query || params.qstring.filter || {};
                         params.qstring.project = params.qstring.project || params.qstring.projection || {};
 
-                        params.qstring.query = params.qstring.query || {};
-                        if (typeof params.qstring.query === "string" && params.qstring.query.length) {
-                            try {
-                                params.qstring.query = JSON.parse(params.qstring.query);
-                            }
-                            catch (ex) {
-                                params.qstring.query = {};
-                            }
+                        var parsedSearch = common.parseUserQuery(params.qstring.query);
+                        if (parsedSearch.error) {
+                            log.d("Rejected user query" + common.reqInfo(params) + ": " + parsedSearch.error);
+                            common.returnMessage(params, 400, parsedSearch.error);
+                            return;
                         }
-                        common.stripUnsafeMongoOperators(params.qstring.query);
+                        params.qstring.query = parsedSearch.query;
 
                         if (params.qstring.sSearch && params.qstring.sSearch !== "") {
                             try {
@@ -295,6 +287,13 @@ const FEATURE_NAME = 'compliance_hub';
                     }
                     else if (total > 0) {
                         params.qstring.query = params.qstring.query || params.qstring.filter || {};
+                        var parsedC = common.parseUserQuery(params.qstring.query);
+                        if (parsedC.error) {
+                            log.d("Rejected user query" + common.reqInfo(params) + ": " + parsedC.error);
+                            common.returnMessage(params, 400, parsedC.error);
+                            return;
+                        }
+                        params.qstring.query = parsedC.query;
                         params.qstring.project = params.qstring.project || params.qstring.projection || {"did": 1, "d": 1, "av": 1, "consent": 1, "lac": 1, "uid": 1, "appUserExport": 1};
 
                         if (params.qstring.sSearch && params.qstring.sSearch !== "") {

--- a/plugins/crashes/api/api.js
+++ b/plugins/crashes/api/api.js
@@ -990,13 +990,13 @@ plugins.setConfigs("crashes", {
                     var columns = ["name", "os", "reports", "lastTs", "users", "latest_version"];
                     var filter = {};
                     if (params.qstring.query && params.qstring.query !== "") {
-                        try {
-                            filter = JSON.parse(params.qstring.query);
-                            common.stripUnsafeMongoOperators(filter);
+                        var parsed = common.parseUserQuery(params.qstring.query);
+                        if (parsed.error) {
+                            log.d("Rejected user query" + common.reqInfo(params) + ": " + parsed.error);
+                            common.returnMessage(params, 400, parsed.error);
+                            return;
                         }
-                        catch (ex) {
-                            console.log("Cannot parse crashes query", params.qstring.query);
-                        }
+                        filter = parsed.query;
                     }
                     if (params.qstring.sSearch && params.qstring.sSearch !== "") {
                         var reg;

--- a/plugins/dbviewer/api/api.js
+++ b/plugins/dbviewer/api/api.js
@@ -212,11 +212,15 @@ var spawn = require('child_process').spawn,
                 filter = {};
             }
 
-            //strip server-side-JS Mongo operators ($where/$expr/$function/
-            //$accumulator) from the user-supplied filter and sort so the db
+            //reject server-side-JS Mongo operators ($where/$function/
+            //$accumulator) in the user-supplied filter and sort so the db
             //viewer query cannot be abused to execute code on the server
-            common.stripUnsafeMongoOperators(filter);
-            common.stripUnsafeMongoOperators(sort);
+            var badOp = common.findUnsafeMongoOperator(filter) || common.findUnsafeMongoOperator(sort);
+            if (badOp) {
+                log.d("Rejected user query" + common.reqInfo(params) + ": " + "Query contains disallowed operator: " + badOp);
+                common.returnMessage(params, 400, "Query contains disallowed operator: " + badOp);
+                return false;
+            }
             //restrict the projection to plain field include/exclude — drop any
             //expression / field-path alias (e.g. {x:"$password"})
             sanitizeProjection(projection);

--- a/plugins/dbviewer/api/api.js
+++ b/plugins/dbviewer/api/api.js
@@ -217,8 +217,8 @@ var spawn = require('child_process').spawn,
             //viewer query cannot be abused to execute code on the server
             var badOp = common.findUnsafeMongoOperator(filter) || common.findUnsafeMongoOperator(sort);
             if (badOp) {
-                log.d("Rejected user query" + common.reqInfo(params) + ": " + "Query contains disallowed operator: " + badOp);
-                common.returnMessage(params, 400, "Query contains disallowed operator: " + badOp);
+                log.d("Rejected user query" + common.reqInfo(params) + ": " + common.unsafeQueryError(badOp));
+                common.returnMessage(params, 400, common.unsafeQueryError(badOp));
                 return false;
             }
             //restrict the projection to plain field include/exclude — drop any

--- a/plugins/logger/api/api.js
+++ b/plugins/logger/api/api.js
@@ -325,17 +325,17 @@ plugins.setConfigs("logger", {
         if (params.qstring.method === 'logs') {
             var filter = {};
             if (typeof params.qstring.filter !== "undefined") {
-                try {
-                    filter = JSON.parse(params.qstring.filter);
+                // Reject Mongo $where / $function / $accumulator in
+                // user-supplied filter — they enable server-side JS execution
+                // (DoS, blind-timing exfiltration).
+                var parsed = common.parseUserQuery(params.qstring.filter);
+                if (parsed.error) {
+                    log.d("Rejected user query" + common.reqInfo(params) + ": " + parsed.error);
+                    common.returnMessage(params, 400, parsed.error);
+                    return true;
                 }
-                catch (ex) {
-                    filter = {};
-                }
+                filter = parsed.query;
             }
-            // Reject Mongo $where / $expr / $function / $accumulator in
-            // user-supplied filter — they enable server-side JS execution
-            // (DoS, blind-timing exfiltration).
-            common.stripUnsafeMongoOperators(filter);
 
             validateRead(params, FEATURE_NAME, function(parameters) {
                 common.db.collection('logs' + parameters.app_id).find(filter).limit(1000).toArray(function(err, items) {

--- a/plugins/push/api/api-message.js
+++ b/plugins/push/api/api-message.js
@@ -78,6 +78,17 @@ async function validate(args, draft = false, params = null) {
         }
     }
 
+    // Reject (never modify) audience/drill queries that contain disallowed
+    // Mongo operators ($where/$function/$accumulator). These queries are later
+    // dispatched to /drill/preprocess_query and run against the database; the
+    // dispatch hook no longer strips them, so they must be validated where they
+    // first enter from the request.
+    let badOp = common.findUnsafeMongoOperator(msg.filter.user) || common.findUnsafeMongoOperator(msg.filter.drill);
+    if (badOp) {
+        log.d("Rejected user query" + common.reqInfo(params) + ": " + "Query contains disallowed operator: " + badOp);
+        throw new ValidationError('Query contains disallowed operator: ' + badOp);
+    }
+
     let app = await common.db.collection('apps').findOne(msg.app);
     if (app) {
         msg.info.appName = app.name;

--- a/plugins/push/api/api-message.js
+++ b/plugins/push/api/api-message.js
@@ -85,7 +85,7 @@ async function validate(args, draft = false, params = null) {
     // first enter from the request.
     let badOp = common.findUnsafeMongoOperator(msg.filter.user) || common.findUnsafeMongoOperator(msg.filter.drill);
     if (badOp) {
-        log.d("Rejected user query" + common.reqInfo(params) + ": " + "Query contains disallowed operator: " + badOp);
+        log.d("Rejected user query" + common.reqInfo(params) + ": " + common.unsafeQueryError(badOp));
         throw new ValidationError('Query contains disallowed operator: ' + badOp);
     }
 

--- a/plugins/push/api/api-tx.js
+++ b/plugins/push/api/api-tx.js
@@ -51,7 +51,7 @@ async function check(params, push) {
     let txFilter = new Filter(data.filter);
     let badOp = common.findUnsafeMongoOperator(txFilter.user) || common.findUnsafeMongoOperator(txFilter.drill);
     if (badOp) {
-        log.d("Rejected user query" + common.reqInfo(params) + ": " + "Query contains disallowed operator: " + badOp);
+        log.d("Rejected user query" + common.reqInfo(params) + ": " + common.unsafeQueryError(badOp));
         throw new ValidationError('Query contains disallowed operator: ' + badOp);
     }
 

--- a/plugins/push/api/api-tx.js
+++ b/plugins/push/api/api-tx.js
@@ -43,6 +43,18 @@ async function check(params, push) {
         throw new ValidationError(data.errors);
     }
 
+    // Reject (never modify) audience/drill queries that contain disallowed Mongo
+    // operators ($where/$function/$accumulator). This request-supplied filter
+    // overrides the cached message's filter and is dispatched to
+    // /drill/preprocess_query and run against the database; the dispatch hook no
+    // longer strips them, so validate where it first enters from the request.
+    let txFilter = new Filter(data.filter);
+    let badOp = common.findUnsafeMongoOperator(txFilter.user) || common.findUnsafeMongoOperator(txFilter.drill);
+    if (badOp) {
+        log.d("Rejected user query" + common.reqInfo(params) + ": " + "Query contains disallowed operator: " + badOp);
+        throw new ValidationError('Query contains disallowed operator: ' + badOp);
+    }
+
     let message = await plugins.getPluginsApis().push.cache.read(data._id.toString());
     if (!message) {
         throw new PushError('No such message or it doesn\'t have API trigger', ERROR.DATA_COUNTLY);

--- a/plugins/push/api/legacy.js
+++ b/plugins/push/api/legacy.js
@@ -135,7 +135,7 @@ async function validate(params, skipMpl, skipAppsPlatforms) {
     // they first enter from the request.
     var badOp = common.findUnsafeMongoOperator(data.userConditions) || common.findUnsafeMongoOperator(data.drillConditions);
     if (badOp) {
-        log.d("Rejected user query" + common.reqInfo(params) + ": " + "Query contains disallowed operator: " + badOp);
+        log.d("Rejected user query" + common.reqInfo(params) + ": " + common.unsafeQueryError(badOp));
         return [{error: 'Query contains disallowed operator: ' + badOp}];
     }
 

--- a/plugins/push/api/legacy.js
+++ b/plugins/push/api/legacy.js
@@ -128,6 +128,17 @@ async function validate(params, skipMpl, skipAppsPlatforms) {
 
     data = data.obj;
 
+    // Reject (never modify) audience/drill queries that contain disallowed Mongo
+    // operators ($where/$function/$accumulator). These conditions become the
+    // message filter that is dispatched to /drill/preprocess_query and run against
+    // the database; the dispatch hook no longer strips them, so validate where
+    // they first enter from the request.
+    var badOp = common.findUnsafeMongoOperator(data.userConditions) || common.findUnsafeMongoOperator(data.drillConditions);
+    if (badOp) {
+        log.d("Rejected user query" + common.reqInfo(params) + ": " + "Query contains disallowed operator: " + badOp);
+        return [{error: 'Query contains disallowed operator: ' + badOp}];
+    }
+
     data.autoOnEntry = params.qstring.args.autoOnEntry;
 
     log.d('validating args %j, data %j', params.qstring.args, data);

--- a/plugins/remote-config/api/api.js
+++ b/plugins/remote-config/api/api.js
@@ -518,7 +518,7 @@ plugins.setConfigs("remote-config", {
         // here, where it first enters from the request.
         var badOp = common.findUnsafeMongoOperator(config);
         if (badOp) {
-            log.d("Rejected user query" + common.reqInfo(params) + ": " + "Query contains disallowed operator: " + badOp);
+            log.d("Rejected user query" + common.reqInfo(params) + ": " + common.unsafeQueryError(badOp));
             common.returnMessage(params, 400, 'Query contains disallowed operator: ' + badOp);
             return true;
         }

--- a/plugins/remote-config/api/api.js
+++ b/plugins/remote-config/api/api.js
@@ -510,6 +510,19 @@ plugins.setConfigs("remote-config", {
             return true;
         }
 
+        // Reject (never modify) configs whose condition query contains disallowed
+        // Mongo operators ($where/$function/$accumulator). The stored
+        // condition.condition is later JSON.parsed and dispatched to
+        // /drill/preprocess_query and run against the database; the dispatch hook
+        // no longer strips them, so the whole parsed config payload is validated
+        // here, where it first enters from the request.
+        var badOp = common.findUnsafeMongoOperator(config);
+        if (badOp) {
+            log.d("Rejected user query" + common.reqInfo(params) + ": " + "Query contains disallowed operator: " + badOp);
+            common.returnMessage(params, 400, 'Query contains disallowed operator: ' + badOp);
+            return true;
+        }
+
         var maximumParametersAllowed = plugins.getConfig("remote-config").maximum_allowed_parameters;
         var maximumConditionsAllowed = plugins.getConfig("remote-config").conditions_per_paramaeters;
 
@@ -1165,6 +1178,21 @@ plugins.setConfigs("remote-config", {
             return true;
         }
 
+        // Reject (never modify) condition queries that contain disallowed Mongo
+        // operators ($where/$function/$accumulator). The stored condition.condition
+        // is later JSON.parsed and dispatched to /drill/preprocess_query and run
+        // against the database; the dispatch hook no longer strips them, so they
+        // must be validated where they first enter from the request.
+        var parsedCondition = common.parseUserQuery(condition.condition);
+        if (parsedCondition.error) {
+            if (params.internal) {
+                return parsedCondition.error;
+            }
+            log.d("Rejected user query" + common.reqInfo(params) + ": " + parsedCondition.error);
+            common.returnMessage(params, 400, parsedCondition.error);
+            return true;
+        }
+
         if (typeof condition.condition !== typeof '') {
             condition.condition = JSON.stringify(condition.condition);
         }
@@ -1349,6 +1377,21 @@ plugins.setConfigs("remote-config", {
                 return 'Invalid parameter: condition';
             }
             common.returnMessage(params, 400, 'Invalid parameter: condition');
+            return true;
+        }
+
+        // Reject (never modify) condition queries that contain disallowed Mongo
+        // operators ($where/$function/$accumulator). The stored condition.condition
+        // is later JSON.parsed and dispatched to /drill/preprocess_query and run
+        // against the database; the dispatch hook no longer strips them, so they
+        // must be validated where they first enter from the request.
+        var parsedCondition = common.parseUserQuery(condition.condition);
+        if (parsedCondition.error) {
+            if (params.internal) {
+                return parsedCondition.error;
+            }
+            log.d("Rejected user query" + common.reqInfo(params) + ": " + parsedCondition.error);
+            common.returnMessage(params, 400, parsedCondition.error);
             return true;
         }
 

--- a/plugins/systemlogs/api/api.js
+++ b/plugins/systemlogs/api/api.js
@@ -1,5 +1,6 @@
 var pluginOb = {},
     common = require('../../../api/utils/common.js'),
+    systemlog = common.log('systemlogs:api'),
     countlyCommon = require('../../../api/lib/countly.common.js'),
     plugins = require('../../pluginManager.js'),
     { validateGlobalAdmin } = require('../../../api/utils/rights.js');
@@ -95,14 +96,13 @@ plugins.setConfigs("systemlogs", {
         if (params.qstring.method === 'systemlogs') {
             var query = {};
             if (typeof params.qstring.query === "string") {
-                try {
-                    query = JSON.parse(params.qstring.query);
-                    common.stripUnsafeMongoOperators(query);
+                var parsed = common.parseUserQuery(params.qstring.query);
+                if (parsed.error) {
+                    systemlog.d("Rejected user query" + common.reqInfo(params) + ": " + parsed.error);
+                    common.returnMessage(params, 400, parsed.error);
+                    return true;
                 }
-                catch (ex) {
-                    console.log("Can't parse systemlogs query");
-                    query = {};
-                }
+                query = parsed.query;
             }
             if (params.qstring.sSearch && params.qstring.sSearch !== "") {
                 var reg;

--- a/test/unit-tests/api.utils.common.js
+++ b/test/unit-tests/api.utils.common.js
@@ -358,4 +358,83 @@ describe("Common API utility functions", function() {
                 .should.not.equal(common.getAppUserId({ key: "k" }, deviceId));
         });
     });
+
+    describe("findUnsafeMongoOperator", function() {
+        it("returns null for a clean query", function() {
+            should.equal(common.findUnsafeMongoOperator({ lac: { $lt: 1777320900 } }), null);
+            should.equal(common.findUnsafeMongoOperator({}), null);
+            should.equal(common.findUnsafeMongoOperator({ uid: { $in: ["1", "2"] } }), null);
+        });
+        it("detects the JS-execution operators at the top level", function() {
+            common.findUnsafeMongoOperator({ $where: "1==1" }).should.equal("$where");
+            common.findUnsafeMongoOperator({ $function: {} }).should.equal("$function");
+            common.findUnsafeMongoOperator({ $accumulator: {} }).should.equal("$accumulator");
+        });
+        it("detects operators nested at any depth (arrays, $and)", function() {
+            common.findUnsafeMongoOperator({ $and: [{ uid: { $ne: null } }, { $where: "x" }] }).should.equal("$where");
+        });
+        it("allows $expr but still detects a JS operator wrapped inside it", function() {
+            // $expr alone is permitted (no JS execution)
+            should.equal(common.findUnsafeMongoOperator({ $expr: { $lt: ["$lac", 1777320900] } }), null);
+            // but a $function nested inside $expr is still caught
+            common.findUnsafeMongoOperator({ $expr: { $function: { body: "...", lang: "js" } } }).should.equal("$function");
+        });
+        it("inspects keys only, not values (no false positive on string values)", function() {
+            should.equal(common.findUnsafeMongoOperator({ note: "see the $where docs" }), null);
+            should.equal(common.findUnsafeMongoOperator({ url: { $eq: "http://x/$function" } }), null);
+        });
+    });
+
+    describe("parseUserQuery", function() {
+        it("parses a JSON string into an object", function() {
+            var r = common.parseUserQuery('{"uid":{"$in":["1"]}}');
+            should.not.exist(r.error);
+            r.query.should.eql({ uid: { $in: ["1"] } });
+        });
+        it("treats empty / null / undefined as an empty query", function() {
+            common.parseUserQuery("").query.should.eql({});
+            common.parseUserQuery(null).query.should.eql({});
+            common.parseUserQuery(undefined).query.should.eql({});
+        });
+        it("rejects invalid JSON", function() {
+            common.parseUserQuery("{not json").error.should.equal("Invalid query JSON");
+        });
+        it("rejects non-object JSON values (arrays, scalars)", function() {
+            common.parseUserQuery("[]").error.should.equal("Query must be an object");
+            common.parseUserQuery("[{}]").error.should.equal("Query must be an object");
+            common.parseUserQuery([]).error.should.equal("Query must be an object");
+            common.parseUserQuery("5").error.should.equal("Query must be an object");
+        });
+        it("rejects pathologically deep nesting instead of overflowing the stack", function() {
+            var deep = {};
+            var cur = deep;
+            for (var i = 0; i < 5000; i++) {
+                cur.a = {};
+                cur = cur.a;
+            }
+            common.parseUserQuery(deep).error.should.equal("Query is nested too deeply");
+        });
+        it("accepts an already-parsed object", function() {
+            var r = common.parseUserQuery({ lac: { $lt: 1 } });
+            should.not.exist(r.error);
+            r.query.should.eql({ lac: { $lt: 1 } });
+        });
+        it("rejects a disallowed operator with the operator name", function() {
+            common.parseUserQuery('{"$where":"1==1"}').error.should.equal("Query contains disallowed operator: $where");
+        });
+        it("cannot be evaded by JSON unicode-escaping the operator key", function() {
+            // \\u0024 decodes to '$' — JSON.parse yields a real {$where:...} key
+            common.parseUserQuery('{"\\u0024where":"sleep(5000)||true"}').error.should.equal("Query contains disallowed operator: $where");
+        });
+        it("allows a legitimate $expr query over multiple timestamp fields", function() {
+            var q = '{"$and":[{"$expr":{"$lt":[{"$max":["$ls","$lac","$last_sync"]},1777320900]}},{"uid":{"$ne":null}}]}';
+            var r = common.parseUserQuery(q);
+            should.not.exist(r.error);
+            r.query.$and.length.should.equal(2);
+        });
+        it("rejects a JS operator wrapped in $expr", function() {
+            common.parseUserQuery('{"$expr":{"$function":{"body":"x","lang":"js"}}}').error
+                .should.equal("Query contains disallowed operator: $function");
+        });
+    });
 });


### PR DESCRIPTION
Backport of Countly/countly-server#7694 to **release.24.05**.

Validate user-supplied Mongo queries at the API boundary instead of stripping operators in place.

- Allow `$expr`; reject `$where` / `$function` / `$accumulator` at any depth (incl. nested inside `$expr`).
- Queries are never modified — a request runs exactly as submitted or returns `400`.
- Adds `common.parseUserQuery` / `common.findUnsafeMongoOperator` / `common.reqInfo`; validation applied at the endpoints that accept a query, with rejection logged at the call site (endpoint in the message).
- Near-total `/i/app_users/delete` guard: `force` still allowed, but matching ~all users requires `confirm_delete_all=true`.

Cherry-picked cleanly onto release.24.05 (only the root CLAUDE.md, which doesn't exist on this branch, was dropped). Unit tests included.

Companion (lockstep): Countly/countly-enterprise-plugins backport branch `backport/reject-unsafe-query-operators-24.05`.
