### PR TITLE
query validation: explicit confirm_delete_all + clear too-deep error

### DIFF
--- a/api/parts/data/exports.js
+++ b/api/parts/data/exports.js
@@ -513,9 +513,9 @@ exports.fromDatabase = function(options) {
     // query here at the boundary into the dispatch + DB find.
     var badOp = common.findUnsafeMongoOperator(options.query);
     if (badOp) {
-        log.d("Rejected user query" + common.reqInfo(options.params) + ": " + "Query contains disallowed operator: " + badOp);
+        log.d("Rejected user query" + common.reqInfo(options.params) + ": " + common.unsafeQueryError(badOp));
         if (options.params) {
-            common.returnMessage(options.params, 400, "Query contains disallowed operator: " + badOp);
+            common.returnMessage(options.params, 400, common.unsafeQueryError(badOp));
         }
         return;
     }

--- a/api/utils/common.js
+++ b/api/utils/common.js
@@ -2397,6 +2397,21 @@ common.UNSAFE_MONGO_OPERATORS = ["$where", "$function", "$accumulator"];
 common.UNSAFE_QUERY_TOO_DEEP = "$__nestedTooDeep";
 
 /**
+ * Turn a findUnsafeMongoOperator() result into a client-safe error message.
+ * Maps the too-deep sentinel to a clear message instead of leaking it as an
+ * "operator" name. Use this at every site that rejects on findUnsafeMongoOperator.
+ *
+ * @param {string} bad - the value returned by common.findUnsafeMongoOperator
+ * @returns {string} a client-safe error message
+ */
+common.unsafeQueryError = function(bad) {
+    if (bad === common.UNSAFE_QUERY_TOO_DEEP) {
+        return "Query is nested too deeply";
+    }
+    return "Query contains disallowed operator: " + bad;
+};
+
+/**
  * Recursively search an already-parsed query object for any operator in
  * common.UNSAFE_MONGO_OPERATORS. Returns the name of the first offending
  * operator found, or null if the query is clean.
@@ -2500,11 +2515,8 @@ common.parseUserQuery = function(raw) {
         return { error: "Query must be an object" };
     }
     var bad = common.findUnsafeMongoOperator(query);
-    if (bad === common.UNSAFE_QUERY_TOO_DEEP) {
-        return { error: "Query is nested too deeply" };
-    }
     if (bad) {
-        return { error: "Query contains disallowed operator: " + bad };
+        return { error: common.unsafeQueryError(bad) };
     }
     return { query: query };
 };

--- a/api/utils/requestProcessor.js
+++ b/api/utils/requestProcessor.js
@@ -543,7 +543,7 @@ const processRequest = (params) => {
                             // requires an explicit confirm_delete_all=true. This catches a
                             // query that was meant to match a subset but actually matches
                             // everyone, without blocking legitimate subset deletions.
-                            if (params.qstring.force && !params.qstring.confirm_delete_all) {
+                            if (params.qstring.force && params.qstring.confirm_delete_all !== true && params.qstring.confirm_delete_all !== "true") {
                                 common.db.collection("app_users" + params.qstring.app_id).estimatedDocumentCount(function(errTotal, total) {
                                     if (!errTotal && total >= 100 && count >= total * 0.9) {
                                         common.returnMessage(params, 400, 'This query matches ' + count + ' of ~' + total + ' app users (nearly all). If this is intended, retry with confirm_delete_all=true, or use clear app data instead.');

--- a/plugins/dbviewer/api/api.js
+++ b/plugins/dbviewer/api/api.js
@@ -234,8 +234,8 @@ var spawn = require('child_process').spawn,
             //viewer query cannot be abused to execute code on the server
             var badOp = common.findUnsafeMongoOperator(filter) || common.findUnsafeMongoOperator(sort);
             if (badOp) {
-                log.d("Rejected user query" + common.reqInfo(params) + ": " + "Query contains disallowed operator: " + badOp);
-                common.returnMessage(params, 400, "Query contains disallowed operator: " + badOp);
+                log.d("Rejected user query" + common.reqInfo(params) + ": " + common.unsafeQueryError(badOp));
+                common.returnMessage(params, 400, common.unsafeQueryError(badOp));
                 return false;
             }
             //restrict the projection to plain field include/exclude — drop any

--- a/plugins/push/api/api-message.js
+++ b/plugins/push/api/api-message.js
@@ -85,7 +85,7 @@ async function validate(args, draft = false, params = null) {
     // first enter from the request.
     let badOp = common.findUnsafeMongoOperator(msg.filter.user) || common.findUnsafeMongoOperator(msg.filter.drill);
     if (badOp) {
-        log.d("Rejected user query" + common.reqInfo(params) + ": " + "Query contains disallowed operator: " + badOp);
+        log.d("Rejected user query" + common.reqInfo(params) + ": " + common.unsafeQueryError(badOp));
         throw new ValidationError('Query contains disallowed operator: ' + badOp);
     }
 

--- a/plugins/push/api/api-tx.js
+++ b/plugins/push/api/api-tx.js
@@ -51,7 +51,7 @@ async function check(params, push) {
     let txFilter = new Filter(data.filter);
     let badOp = common.findUnsafeMongoOperator(txFilter.user) || common.findUnsafeMongoOperator(txFilter.drill);
     if (badOp) {
-        log.d("Rejected user query" + common.reqInfo(params) + ": " + "Query contains disallowed operator: " + badOp);
+        log.d("Rejected user query" + common.reqInfo(params) + ": " + common.unsafeQueryError(badOp));
         throw new ValidationError('Query contains disallowed operator: ' + badOp);
     }
 

--- a/plugins/push/api/legacy.js
+++ b/plugins/push/api/legacy.js
@@ -135,7 +135,7 @@ async function validate(params, skipMpl, skipAppsPlatforms) {
     // they first enter from the request.
     var badOp = common.findUnsafeMongoOperator(data.userConditions) || common.findUnsafeMongoOperator(data.drillConditions);
     if (badOp) {
-        log.d("Rejected user query" + common.reqInfo(params) + ": " + "Query contains disallowed operator: " + badOp);
+        log.d("Rejected user query" + common.reqInfo(params) + ": " + common.unsafeQueryError(badOp));
         return [{error: 'Query contains disallowed operator: ' + badOp}];
     }
 

--- a/plugins/remote-config/api/api.js
+++ b/plugins/remote-config/api/api.js
@@ -518,7 +518,7 @@ plugins.setConfigs("remote-config", {
         // here, where it first enters from the request.
         var badOp = common.findUnsafeMongoOperator(config);
         if (badOp) {
-            log.d("Rejected user query" + common.reqInfo(params) + ": " + "Query contains disallowed operator: " + badOp);
+            log.d("Rejected user query" + common.reqInfo(params) + ": " + common.unsafeQueryError(badOp));
             common.returnMessage(params, 400, 'Query contains disallowed operator: ' + badOp);
             return true;
         }


### PR DESCRIPTION
Follow-up to #7694 / #7695 addressing review comments raised on the 24.05 backport (#7696) that also apply to master.

- **`/i/app_users/delete` near-total guard**: require an explicit `confirm_delete_all` of `true` (or `"true"`). Previously any truthy value (e.g. the string `"false"`) bypassed the guard.
- **Too-deep sentinel leak**: add `common.unsafeQueryError(bad)` which maps the internal `UNSAFE_QUERY_TOO_DEEP` sentinel to a clear *"Query is nested too deeply"* message. `parseUserQuery` and all direct `findUnsafeMongoOperator` callers (dbviewer, exports, remote-config, push ×3) now use it, so `$__nestedTooDeep` is no longer surfaced to logs/clients.

No behavior change for valid queries. Cherry-pick of the same fix applied to the 24.05 backport (#7696).
