### PR TITLE
reject unsafe mongo query operators on /o/tasks and /o/slipping

### DIFF
--- a/api/utils/requestProcessor.js
+++ b/api/utils/requestProcessor.js
@@ -1847,17 +1847,13 @@ const processRequest = (params) => {
                 switch (paths[3]) {
                 case 'all':
                     validateRead(params, 'core', () => {
-                        if (!params.qstring.query) {
-                            params.qstring.query = {};
+                        var parsedQuery = common.parseUserQuery(params.qstring.query);
+                        if (parsedQuery.error) {
+                            log.d("Rejected user query" + common.reqInfo(params) + ": " + parsedQuery.error);
+                            common.returnMessage(params, 400, parsedQuery.error);
+                            return;
                         }
-                        if (typeof params.qstring.query === "string") {
-                            try {
-                                params.qstring.query = JSON.parse(params.qstring.query);
-                            }
-                            catch (ex) {
-                                params.qstring.query = {};
-                            }
-                        }
+                        params.qstring.query = parsedQuery.query;
                         if (params.qstring.query.$or) {
                             params.qstring.query.$and = [
                                 {"$or": Object.assign([], params.qstring.query.$or) },
@@ -1890,17 +1886,13 @@ const processRequest = (params) => {
                     break;
                 case 'count':
                     validateRead(params, 'core', () => {
-                        if (!params.qstring.query) {
-                            params.qstring.query = {};
+                        var parsedQuery = common.parseUserQuery(params.qstring.query);
+                        if (parsedQuery.error) {
+                            log.d("Rejected user query" + common.reqInfo(params) + ": " + parsedQuery.error);
+                            common.returnMessage(params, 400, parsedQuery.error);
+                            return;
                         }
-                        if (typeof params.qstring.query === "string") {
-                            try {
-                                params.qstring.query = JSON.parse(params.qstring.query);
-                            }
-                            catch (ex) {
-                                params.qstring.query = {};
-                            }
-                        }
+                        params.qstring.query = parsedQuery.query;
                         if (params.qstring.query.$or) {
                             params.qstring.query.$and = [
                                 {"$or": Object.assign([], params.qstring.query.$or) },
@@ -1925,17 +1917,13 @@ const processRequest = (params) => {
                     break;
                 case 'list':
                     validateRead(params, 'core', () => {
-                        if (!params.qstring.query) {
-                            params.qstring.query = {};
+                        var parsedQuery = common.parseUserQuery(params.qstring.query);
+                        if (parsedQuery.error) {
+                            log.d("Rejected user query" + common.reqInfo(params) + ": " + parsedQuery.error);
+                            common.returnMessage(params, 400, parsedQuery.error);
+                            return;
                         }
-                        if (typeof params.qstring.query === "string") {
-                            try {
-                                params.qstring.query = JSON.parse(params.qstring.query);
-                            }
-                            catch (ex) {
-                                params.qstring.query = {};
-                            }
-                        }
+                        params.qstring.query = parsedQuery.query;
                         params.qstring.query.$and = [];
                         if (params.qstring.query.creator && params.qstring.query.creator === params.member._id) {
                             params.qstring.query.$and.push({"creator": params.member._id + ""});

--- a/plugins/slipping-away-users/api/api.js
+++ b/plugins/slipping-away-users/api/api.js
@@ -82,7 +82,7 @@ catch (ex) {
         if (parsedQuery.error) {
             log.d("Rejected user query" + common.reqInfo(params) + ": " + parsedQuery.error);
             common.returnMessage(params, 400, parsedQuery.error);
-            return;
+            return true;
         }
         let user_query = parsedQuery.query;
 

--- a/plugins/slipping-away-users/api/api.js
+++ b/plugins/slipping-away-users/api/api.js
@@ -2,6 +2,7 @@
 
 const plugins = require('../../pluginManager'),
     common = require('../../../api/utils/common.js'),
+    log = common.log('slipping-away-users:api'),
     BPromise = require('bluebird'),
     moment = require('moment-timezone'),
     { validateRead } = require('../../../api/utils/rights.js');
@@ -77,15 +78,13 @@ catch (ex) {
     plugins.register("/o/slipping", function(ob) {
         const params = ob.params;
         const app_id = params.qstring.app_id;
-        let user_query = params.qstring.query || {};
-        if (typeof user_query === "string") {
-            try {
-                user_query = JSON.parse(user_query);
-            }
-            catch (e) {
-                console.log(e);
-            }
+        const parsedQuery = common.parseUserQuery(params.qstring.query);
+        if (parsedQuery.error) {
+            log.d("Rejected user query" + common.reqInfo(params) + ": " + parsedQuery.error);
+            common.returnMessage(params, 400, parsedQuery.error);
+            return;
         }
+        let user_query = parsedQuery.query;
 
         if (cohorts) {
             var cohortQuery = cohorts.preprocessQuery(user_query);


### PR DESCRIPTION
Follow-up to the merged reject-unsafe-query work (#7695). The `/o/slipping` endpoint (slipping-away-users plugin) still raw-parsed `params.qstring.query` and merged it into per-period `app_users<app_id>.count` conditions without validation, so `$where`/`$function`/`$accumulator` could reach Mongo. Now routed through `common.parseUserQuery` (reject 400). No change for valid queries.