### PR TITLE
reject unsafe mongo query operators on /o/tasks and /o/slipping (backport 24.05)

### DIFF
--- a/plugins/slipping-away-users/api/api.js
+++ b/plugins/slipping-away-users/api/api.js
@@ -82,7 +82,7 @@ catch (ex) {
         if (parsedQuery.error) {
             log.d("Rejected user query" + common.reqInfo(params) + ": " + parsedQuery.error);
             common.returnMessage(params, 400, parsedQuery.error);
-            return;
+            return true;
         }
         let user_query = parsedQuery.query;
 

--- a/plugins/slipping-away-users/api/api.js
+++ b/plugins/slipping-away-users/api/api.js
@@ -2,6 +2,7 @@
 
 const plugins = require('../../pluginManager'),
     common = require('../../../api/utils/common.js'),
+    log = common.log('slipping-away-users:api'),
     BPromise = require('bluebird'),
     moment = require('moment-timezone'),
     { validateRead } = require('../../../api/utils/rights.js');
@@ -77,15 +78,13 @@ catch (ex) {
     plugins.register("/o/slipping", function(ob) {
         const params = ob.params;
         const app_id = params.qstring.app_id;
-        let user_query = params.qstring.query || {};
-        if (typeof user_query === "string") {
-            try {
-                user_query = JSON.parse(user_query);
-            }
-            catch (e) {
-                console.log(e);
-            }
+        const parsedQuery = common.parseUserQuery(params.qstring.query);
+        if (parsedQuery.error) {
+            log.d("Rejected user query" + common.reqInfo(params) + ": " + parsedQuery.error);
+            common.returnMessage(params, 400, parsedQuery.error);
+            return;
         }
+        let user_query = parsedQuery.query;
 
         if (cohorts) {
             var cohortQuery = cohorts.preprocessQuery(user_query);


### PR DESCRIPTION
Backport of the /o/slipping fix to release.24.05. Routes the slipping-away-users query through `common.parseUserQuery` (reject 400) instead of raw-parsing it into `app_users<app_id>.count` conditions. Follow-up to the merged #7696.