### PR TITLE
hooks: scope global internal events to global-admin hooks

### DIFF
--- a/api/parts/mgmt/users.js
+++ b/api/parts/mgmt/users.js
@@ -286,9 +286,15 @@ usersApi.createUser = async function(params) {
                         mail.sendToNewMemberLink(member[0], prid);
                     });
 
+                    // Broadcast a credential-free copy of the new member to
+                    // event listeners (e.g. hooks): the member's password hash
+                    // and api_key must never be forwarded into a hook payload.
+                    var createdMemberEventData = Object.assign({}, member[0]);
+                    delete createdMemberEventData.password;
+                    delete createdMemberEventData.api_key;
                     plugins.dispatch("/i/users/create", {
                         params: params,
-                        data: member[0]
+                        data: createdMemberEventData
                     });
                     delete member[0].password;
 

--- a/api/parts/mgmt/users.js
+++ b/api/parts/mgmt/users.js
@@ -564,10 +564,17 @@ usersApi.updateUser = async function(params) {
             common.db.collection('members').findOne({ '_id': common.db.ObjectID(params.qstring.args.user_id) }, function(err2, member) {
                 if (member && !err2) {
                     updatedMember._id = params.qstring.args.user_id;
+                    // never forward credentials into event payloads (e.g. hooks)
+                    var updatedMemberEventData = Object.assign({}, updatedMember);
+                    delete updatedMemberEventData.password;
+                    delete updatedMemberEventData.api_key;
+                    var memberBeforeEventData = Object.assign({}, memberBefore);
+                    delete memberBeforeEventData.password;
+                    delete memberBeforeEventData.api_key;
                     plugins.dispatch("/i/users/update", {
                         params: params,
-                        data: updatedMember,
-                        member: memberBefore
+                        data: updatedMemberEventData,
+                        member: memberBeforeEventData
                     });
                     if (params.qstring.args.send_notification && passwordNoHash) {
                         mail.sendToUpdatedMember(member, passwordNoHash);
@@ -622,10 +629,14 @@ usersApi.deleteUser = async function(params) {
         else {
             const user = await common.db.collection('members').findOne({ '_id': common.db.ObjectID(userIds[i]) });
             const promisifiedDispatch = function(prms, data) {
+                // never forward credentials into event payloads (e.g. hooks)
+                var safeData = Object.assign({}, data);
+                delete safeData.password;
+                delete safeData.api_key;
                 return new Promise((resolve, reject) => {
                     plugins.dispatch("/i/users/delete", {
                         params: prms,
-                        data,
+                        data: safeData,
                     }, async(__, otherPluginResults) => {
                         const rejectReasons = otherPluginResults.reduce((acc, result) => {
                             if (result.status === "rejected") {
@@ -819,6 +830,10 @@ usersApi.deleteOwnAccount = function(params) {
             };
 
             if (member) {
+                // never forward credentials into event payloads (e.g. hooks)
+                var memberEventData = Object.assign({}, member);
+                delete memberEventData.password;
+                delete memberEventData.api_key;
                 if (member.global_admin) {
                     common.db.collection('members').count({'global_admin': true}, function(err2, count) {
                         if (err2) {
@@ -831,7 +846,7 @@ usersApi.deleteOwnAccount = function(params) {
                         else {
                             plugins.dispatch("/i/users/delete", {
                                 params: params,
-                                data: member
+                                data: memberEventData
                             }, dispatchDeleteCallback);
                         }
                     });
@@ -839,7 +854,7 @@ usersApi.deleteOwnAccount = function(params) {
                 else {
                     plugins.dispatch("/i/users/delete", {
                         params: params,
-                        data: member
+                        data: memberEventData
                     }, dispatchDeleteCallback);
                 }
             }

--- a/plugins/hooks/api/api.js
+++ b/plugins/hooks/api/api.js
@@ -1,4 +1,5 @@
 const Triggers = require('./parts/triggers/index.js');
+const InternalEventTrigger = require('./parts/triggers/internal_event.js');
 const Effects = require('./parts/effects/index.js');
 const asyncLib = require('async');
 const EventEmitter = require('events');
@@ -307,6 +308,18 @@ plugins.register("/i/hook/save", function(ob) {
                 // Null check for hookConfig
                 if (!(common.validateArgs(hookConfig, CheckHookProperties(hookConfig)))) {
                     common.returnMessage(params, 400, 'Not enough args');
+                    return true;
+                }
+
+                // Only global admins may create or update hooks that subscribe
+                // to global (non app-scoped) internal events such as
+                // /i/users/* or /systemlogs — these carry instance-wide data.
+                if (!params.member.global_admin
+                    && hookConfig.trigger
+                    && hookConfig.trigger.type === "InternalEventTrigger"
+                    && hookConfig.trigger.configuration
+                    && InternalEventTrigger.GLOBAL_EVENT_TYPES[hookConfig.trigger.configuration.eventType]) {
+                    common.returnMessage(params, 403, "User does not have right to subscribe to this event");
                     return true;
                 }
 

--- a/plugins/hooks/api/parts/triggers/internal_event.js
+++ b/plugins/hooks/api/parts/triggers/internal_event.js
@@ -2,6 +2,41 @@ const plugins = require('../../../../pluginManager.js');
 const common = require('../../../../../api/utils/common.js');
 const utils = require('../../utils.js');
 const log = common.log('hooks:internalEventTrigger');
+
+// Event types that are global (not scoped to a single app): new-member events,
+// the master tick, and the system-log stream. These carry instance-wide data
+// and must only be delivered to hooks owned by a global admin.
+const GLOBAL_EVENT_TYPES = {
+    "/i/users/create": true,
+    "/i/users/update": true,
+    "/i/users/delete": true,
+    "/master": true,
+    "/systemlogs": true
+};
+
+/**
+ * Whether the hook's owner (createdBy) is a global admin. Used to gate the
+ * global, non app-scoped event types so an app-scoped hook created by a
+ * non-global member cannot receive instance-wide data (e.g. new-member objects
+ * or the system-log stream). A hook with no resolvable owner is treated as not
+ * authorized.
+ * @param {object} rule - hook rule
+ * @returns {Promise<boolean>} true if the owner is a global admin
+ */
+async function isRuleOwnerGlobalAdmin(rule) {
+    if (!rule || !rule.createdBy) {
+        return false;
+    }
+    try {
+        const owner = await common.db.collection("members").findOne({_id: common.db.ObjectID(rule.createdBy + "")}, {projection: {global_admin: 1}});
+        return !!(owner && owner.global_admin);
+    }
+    catch (e) {
+        log.e("Failed to resolve hook owner for global-event scope check", e);
+        return false;
+    }
+}
+
 /**
  * Internal event trigger
  */
@@ -75,7 +110,13 @@ class InternalEventTrigger {
         if (!rules.length) {
             return;
         }
-        rules.forEach((rule) => {
+        for (const rule of rules) {
+            // global (non app-scoped) events must only reach hooks owned by a
+            // global admin — an app-scoped hook from a non-global member must
+            // not receive instance-wide member/system data.
+            if (GLOBAL_EVENT_TYPES[eventType] && !await isRuleOwnerGlobalAdmin(rule)) {
+                continue;
+            }
             switch (eventType) {
             case "/cohort/enter":
             case "/cohort/exit": {
@@ -234,7 +275,7 @@ class InternalEventTrigger {
                 break;
             }
             }
-        });
+        }
     }
 
     /**

--- a/plugins/hooks/api/parts/triggers/internal_event.js
+++ b/plugins/hooks/api/parts/triggers/internal_event.js
@@ -306,6 +306,10 @@ class InternalEventTrigger {
     }
 }
 
+// exposed so the save handler can reject non-global-admins creating/updating
+// hooks that subscribe to these global event types
+InternalEventTrigger.GLOBAL_EVENT_TYPES = GLOBAL_EVENT_TYPES;
+
 module.exports = InternalEventTrigger;
 const InternalEvents = [
     "/i/apps/create",

--- a/plugins/hooks/api/parts/triggers/internal_event.js
+++ b/plugins/hooks/api/parts/triggers/internal_event.js
@@ -21,20 +21,33 @@ const GLOBAL_EVENT_TYPES = {
  * or the system-log stream). A hook with no resolvable owner is treated as not
  * authorized.
  * @param {object} rule - hook rule
+ * @param {Map} [cache] - optional owner-id -> boolean cache, scoped to one
+ *        event dispatch, so each distinct owner is resolved only once
  * @returns {Promise<boolean>} true if the owner is a global admin
  */
-async function isRuleOwnerGlobalAdmin(rule) {
+async function isRuleOwnerGlobalAdmin(rule, cache) {
     if (!rule || !rule.createdBy) {
         return false;
     }
+    const ownerId = rule.createdBy + "";
+    // memoize per process() call so each distinct owner is resolved once per
+    // event dispatch (avoids an N+1 lookup when many hooks share owners)
+    if (cache && cache.has(ownerId)) {
+        return cache.get(ownerId);
+    }
+    let result = false;
     try {
-        const owner = await common.db.collection("members").findOne({_id: common.db.ObjectID(rule.createdBy + "")}, {projection: {global_admin: 1}});
-        return !!(owner && owner.global_admin);
+        const owner = await common.db.collection("members").findOne({_id: common.db.ObjectID(ownerId)}, {projection: {global_admin: 1}});
+        result = !!(owner && owner.global_admin);
     }
     catch (e) {
-        log.e("Failed to resolve hook owner for global-event scope check", e);
-        return false;
+        log.e("Failed to resolve hook owner for global-event scope check (hook " + (rule._id || "?") + ", createdBy " + ownerId + ")", e);
+        result = false;
     }
+    if (cache) {
+        cache.set(ownerId, result);
+    }
+    return result;
 }
 
 /**
@@ -110,11 +123,14 @@ class InternalEventTrigger {
         if (!rules.length) {
             return;
         }
+        // cache of owner-id -> isGlobalAdmin, scoped to this dispatch, so a
+        // global event reaching many hooks resolves each owner only once
+        const ownerGlobalAdminCache = new Map();
         for (const rule of rules) {
             // global (non app-scoped) events must only reach hooks owned by a
-            // global admin — an app-scoped hook from a non-global member must
+            // global admin: an app-scoped hook from a non-global member must
             // not receive instance-wide member/system data.
-            if (GLOBAL_EVENT_TYPES[eventType] && !await isRuleOwnerGlobalAdmin(rule)) {
+            if (GLOBAL_EVENT_TYPES[eventType] && !await isRuleOwnerGlobalAdmin(rule, ownerGlobalAdminCache)) {
                 continue;
             }
             switch (eventType) {

--- a/plugins/hooks/frontend/public/javascripts/countly.views.js
+++ b/plugins/hooks/frontend/public/javascripts/countly.views.js
@@ -485,6 +485,15 @@
             }
         },
         mounted: function() {
+            // global (non app-scoped) internal events carry instance-wide data
+            // and may only be subscribed to by global admins; hide them for
+            // everyone else (the server also rejects them on save).
+            if (!countlyGlobal.member.global_admin) {
+                var globalEventTypes = {"/i/users/create": true, "/i/users/update": true, "/i/users/delete": true, "/master": true, "/systemlogs": true};
+                this.internalEventOptions = this.internalEventOptions.filter(function(option) {
+                    return !globalEventTypes[option.value];
+                });
+            }
             this.getCohortOptioins();
             this.getHookOptions();
             this.getAlertOptions();


### PR DESCRIPTION
Hardening of the Hooks `InternalEventTrigger`.

### Background
The trigger delivered the **global** (non app-scoped) event types — `/i/users/create`, `/i/users/update`, `/i/users/delete`, `/master`, `/systemlogs` — to any matching hook **without** checking the hook's scope (unlike `/crashes/new`, `/i/apps/*`, `/i/app_users/*`, which scope by `apps`). So a hook created by a non-global member with app-level hooks rights could subscribe to these and receive instance-wide data. Worse, `/i/users/create` dispatched the new member object **before** the password was stripped, and the `api_key` was never stripped — so the payload carried the member's password hash and api_key.

### Changes
1. **Owner-scoped delivery.** The global event types are now delivered only to hooks whose owner (`createdBy`) is a global admin; a hook with no resolvable owner is treated as not authorized. (Applies to existing hooks too, since it's enforced at delivery.)
2. **Credential redaction.** The `/i/users/create` event payload is now a copy with `password` and `api_key` removed, so member credentials are never forwarded into a hook.

Defense in depth: (1) stops a non-global hook from receiving these events at all; (2) ensures even a legitimately global-admin-owned hook never forwards member credentials to an external effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)