### PR TITLE
fix(ingestion): resolve SDK app by two indexed lookups, not $or (avoids apps collscan)

### DIFF
--- a/api/utils/common.js
+++ b/api/utils/common.js
@@ -463,6 +463,52 @@ common.recordAppKeyUsage = function(app, usedKey) {
     }
 };
 
+/**
+* Resolve an app by an incoming SDK app key for the ingestion/fetch hot path.
+* Looks up the accepted-keys array first, then falls back to the current-key
+* field. This is deliberately two single-field index lookups rather than one
+* {$or:[{key},{keys.key}]} query: MongoDB cannot reliably serve such an $or via
+* index union, so on this hot path it degrades to a full collection scan of the
+* apps collection. Each lookup here is an indexed equality, and the readBatcher
+* caches both (including misses), so the DB sees at most one query per shape per
+* cache period.
+*
+* The keys.key lookup matches every app once its accepted-keys array exists
+* (createApp/updateApp populate it, plus a one-time startup backfill), and also
+* matches a rotated-away old key during its grace period. The key fallback keeps
+* apps that predate the array — or that have not been backfilled yet — fully
+* resolvable, so correctness never depends on the backfill having run.
+* @param {string} appKey - incoming SDK app key
+* @param {function} callback - callback(err, app) with the resolved app or null
+* @returns {void}
+*/
+common.resolveAppByKey = function(appKey, callback) {
+    var key = appKey + "";
+    common.readBatcher.getOne("apps", {"keys.key": key}, function(err, app) {
+        if (app) {
+            return callback(err, app);
+        }
+        common.readBatcher.getOne("apps", {"key": key}, function(err2, app2) {
+            if (app2) {
+                return callback(err2, app2);
+            }
+            return callback(err2 || err, null);
+        });
+    });
+};
+
+/**
+* Invalidate any cached apps entry that resolveAppByKey may have loaded for an
+* incoming SDK key, covering both lookup shapes (keys.key and key).
+* @param {string} appKey - incoming SDK app key
+* @returns {void}
+*/
+common.invalidateAppByKey = function(appKey) {
+    var key = appKey + "";
+    common.readBatcher.invalidate("apps", {"keys.key": key}, {}, false);
+    common.readBatcher.invalidate("apps", {"key": key}, {}, false);
+};
+
 common.sha512Hash = function(str, addSalt) {
     var salt = (addSalt) ? new Date().getTime() : '';
     return crypto.createHmac('sha512', salt + '').update(str + '').digest('hex');

--- a/api/utils/requestProcessor.js
+++ b/api/utils/requestProcessor.js
@@ -3517,7 +3517,7 @@ const validateAppForWriteAPI = (params, done, try_times) => {
         return done ? done() : false;
     }
 
-    common.readBatcher.getOne("apps", {$or: [{'key': params.qstring.app_key + ""}, {'keys.key': params.qstring.app_key + ""}]}, (err, app) => {
+    common.resolveAppByKey(params.qstring.app_key, (err, app) => {
         if (!app) {
             common.returnMessage(params, 400, 'App does not exist');
             params.cancelRequest = "App not found or no Database connection";
@@ -3566,10 +3566,10 @@ const validateAppForWriteAPI = (params, done, try_times) => {
                 if (err1) {
                     console.log("Failed to update apps collection " + err1);
                 }
-                //invalidate using the same query the request loaded the app
-                //with (current key OR an accepted old key), so the cache entry
-                //for old-key requests is also cleared
-                common.readBatcher.invalidate("apps", {$or: [{"key": params.qstring.app_key + ""}, {"keys.key": params.qstring.app_key + ""}]}, {}, false);
+                //invalidate both cache shapes the request may have loaded the
+                //app with (accepted-keys lookup, then current-key fallback), so
+                //the cache entry for old-key requests is also cleared
+                common.invalidateAppByKey(params.qstring.app_key);
             });
         }
 
@@ -3677,7 +3677,7 @@ const validateAppForFetchAPI = (params, done, try_times) => {
     if (ignorePossibleDevices(params)) {
         return done ? done() : false;
     }
-    common.readBatcher.getOne("apps", {$or: [{'key': params.qstring.app_key + ""}, {'keys.key': params.qstring.app_key + ""}]}, (err, app) => {
+    common.resolveAppByKey(params.qstring.app_key, (err, app) => {
         if (!app) {
             common.returnMessage(params, 400, 'App does not exist');
             params.cancelRequest = "App not found or no Database connection";

--- a/frontend/express/app.js
+++ b/frontend/express/app.js
@@ -1981,6 +1981,33 @@ Promise.all([plugins.dbConnection(countlyConfig), plugins.dbConnection("countly_
     //startup (idempotent) so existing apps are covered after an upgrade with no
     //migration script; createApp also ensures it for new apps.
     countlyDb.collection('apps').createIndex({"keys.key": 1}, { background: true }, function() {});
+    //backfill the accepted-keys array for apps that predate key rotation, so the
+    //SDK app lookup resolves them via the indexed keys.key field on its first
+    //query instead of falling back to the current-key field. Idempotent (only
+    //touches apps missing the array, and is guarded again per-app at write time)
+    //and self-disabling once filled, so it is safe to run on every startup; this
+    //process runs in low replica count and the apps collection is small, so no
+    //migration script or cross-process coordination is needed. App resolution
+    //stays correct before this completes via the current-key fallback in
+    //common.resolveAppByKey, so it does not need to gate startup.
+    countlyDb.collection('apps').find({ keys: { $exists: false } }, { projection: { key: 1, created_at: 1, last_data: 1 } }).toArray(function(ferr, legacyApps) {
+        if (ferr) {
+            console.log("Failed to read apps for accepted-keys backfill", ferr);
+            return;
+        }
+        var nowSec = Math.floor(Date.now() / 1000);
+        (legacyApps || []).forEach(function(legacyApp) {
+            countlyDb.collection('apps').updateOne(
+                { _id: legacyApp._id, keys: { $exists: false } },
+                { $set: { keys: [{ key: legacyApp.key, added_at: legacyApp.created_at || nowSec, last_data: legacyApp.last_data || 0 }] } },
+                function(uerr) {
+                    if (uerr) {
+                        console.log("Failed to backfill accepted-keys array for app", legacyApp._id, uerr);
+                    }
+                }
+            );
+        });
+    });
     countlyDb.collection('members').createIndex({"api_key": 1}, { unique: true }, function() {});
     countlyDb.collection('members').createIndex({ email: 1 }, { unique: true }, function() {});
     countlyDb.collection('jobs').createIndex({ finished: 1 }, function() {});


### PR DESCRIPTION
## Problem

The app-key-rotation feature changed the per-request SDK app lookup in `validateAppForWriteAPI` / `validateAppForFetchAPI` from a single equality on the unique `key` index to an `$or` over `key` and the multikey `keys.key`:

```js
common.readBatcher.getOne("apps", {$or: [{key: app_key}, {"keys.key": app_key}]}, …)
```

MongoDB cannot reliably serve that `$or` via index union — with the multikey branch the planner can pick a full `COLLSCAN` of `apps` even though both fields are indexed. The `readBatcher` only throttles this query (≈one per app per `batch_read_period`); it never eliminates it, so on a high-volume hot path across many apps and processes the residual collection-scan rate is significant.

## Fix

Resolve the app with **two single-field indexed lookups** instead of one `$or`, via a new `common.resolveAppByKey`:

1. `{"keys.key": app_key}` — matches every app whose accepted-keys array is populated, and a rotated-away old key during its grace period.
2. fallback `{key: app_key}` — keeps apps that predate the array (or aren't backfilled yet) resolvable.

Each is an indexed equality the `readBatcher` caches independently (including misses), so the planner has no `$or` to mis-plan. A matching `common.invalidateAppByKey` clears both cache shapes.

A one-time, idempotent backfill of the accepted-keys array for legacy apps runs at frontend startup (next to the existing `keys.key` index ensure):

- `{keys: {$exists: false}}` filter + per-app `_id` guard → self-disabling and safe to run redundantly; no migration script, no cross-process coordination.
- Correctness never depends on it completing: the `{key}` fallback resolves not-yet-backfilled apps, so the backfill does not gate startup.

## Correctness

App-key uniqueness is enforced across every app's current `key` and every accepted `keys.key`, so `{keys.key}` can never resolve to a different app than `{key}` would. Identity is unchanged (`app_user_id` still derives from the frozen `id_key`).

## Notes / out of scope

- The management-side `$or` in `api/parts/mgmt/apps.js` (uniqueness check on app create/update) is not on the ingestion hot path and is intentionally left unchanged.

Backport of Countly/countly-platform#513.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
