### PR TITLE
Align /o/export/db with DB Viewer field handling (backport to 24.05)

### DIFF
--- a/api/parts/data/exports.js
+++ b/api/parts/data/exports.js
@@ -533,7 +533,8 @@ exports.redactExportDoc = function(collection, doc) {
     var fields = EXPORT_REDACTIONS[collection];
     for (var i = 0; i < fields.length; i++) {
         if (fields[i] === "_id") {
-            // _id is always returned by the driver, so mask rather than delete
+            // _id is normally present (fromDatabase keeps it unless explicitly
+            // excluded via projection), so mask its value rather than deleting it
             if (typeof doc._id !== "undefined") {
                 doc._id = "***redacted***";
             }

--- a/api/parts/data/exports.js
+++ b/api/parts/data/exports.js
@@ -501,6 +501,50 @@ function isObjectId(id) {
 * @param {string} [options.filename] - name of the file to output, by default auto generated
 * @param {function} options.output - callback function where to pass data, by default outputs as file based on type
 */
+
+/**
+* Credential fields stripped from privileged collections on export, mirroring
+* the DB Viewer read paths so the same data cannot be obtained through export.
+*/
+var EXPORT_REDACTIONS = {
+    "members": ["password", "api_key", "two_factor_auth"],
+    "auth_tokens": ["_id"]
+};
+
+/**
+* Whether documents from the given collection require credential redaction on export
+* @param {string} collection - collection name
+* @returns {boolean} true if the collection is redacted on export
+*/
+exports.redactsExportCollection = function(collection) {
+    return Object.prototype.hasOwnProperty.call(EXPORT_REDACTIONS, collection);
+};
+
+/**
+* Remove/mask credential fields from a document before it is written to an export
+* @param {string} collection - collection the document belongs to
+* @param {object} doc - document to redact (mutated and returned)
+* @returns {object} the redacted document
+*/
+exports.redactExportDoc = function(collection, doc) {
+    if (!doc || !exports.redactsExportCollection(collection)) {
+        return doc;
+    }
+    var fields = EXPORT_REDACTIONS[collection];
+    for (var i = 0; i < fields.length; i++) {
+        if (fields[i] === "_id") {
+            // _id is always returned by the driver, so mask rather than delete
+            if (typeof doc._id !== "undefined") {
+                doc._id = "***redacted***";
+            }
+        }
+        else {
+            delete doc[fields[i]];
+        }
+    }
+    return doc;
+};
+
 exports.fromDatabase = function(options) {
     options.db = options.db || common.db;
     options.query = options.query || {};
@@ -567,6 +611,15 @@ exports.fromDatabase = function(options) {
                 options.query._id = common.db.ObjectID(options.query._id);
             }
             var cursor = options.db.collection(options.collection).find(options.query, {"projection": options.projection});
+            // Strip credential material from privileged collections before it
+            // can reach an export file, mirroring the DB Viewer read paths. This
+            // runs at the cursor level so it applies regardless of output type
+            // (json/csv/xls) and regardless of the caller supplied projection.
+            if (exports.redactsExportCollection(options.collection)) {
+                cursor = cursor.map(function(doc) {
+                    return exports.redactExportDoc(options.collection, doc);
+                });
+            }
             if (options.sort) {
                 cursor.sort(options.sort);
             }

--- a/api/utils/requestProcessor.js
+++ b/api/utils/requestProcessor.js
@@ -2206,10 +2206,13 @@ const processRequest = (params) => {
                             common.returnMessage(params, 400, 'Missing parameter "collection"');
                             return false;
                         }
+                        // query params can be parsed into arrays/objects; force a
+                        // plain string before any substring check or access lookup
+                        params.qstring.collection = params.qstring.collection + "";
                         // keep the db export surface aligned with DB Viewer: internal
                         // index metadata and the dashboard session store are not exportable
                         if (params.qstring.collection.indexOf("system.indexes") !== -1 || params.qstring.collection.indexOf("sessions_") !== -1) {
-                            common.returnMessage(params, 403, 'User does not have access right for this collection');
+                            common.returnMessage(params, 401, 'User does not have access right for this collection');
                             return false;
                         }
                         if (typeof params.qstring.filter === "string") {

--- a/api/utils/requestProcessor.js
+++ b/api/utils/requestProcessor.js
@@ -2206,6 +2206,12 @@ const processRequest = (params) => {
                             common.returnMessage(params, 400, 'Missing parameter "collection"');
                             return false;
                         }
+                        // keep the db export surface aligned with DB Viewer: internal
+                        // index metadata and the dashboard session store are not exportable
+                        if (params.qstring.collection.indexOf("system.indexes") !== -1 || params.qstring.collection.indexOf("sessions_") !== -1) {
+                            common.returnMessage(params, 403, 'User does not have access right for this collection');
+                            return false;
+                        }
                         if (typeof params.qstring.filter === "string") {
                             try {
                                 params.qstring.query = JSON.parse(params.qstring.filter, common.reviver);

--- a/test/unit-tests/api.exports.redaction.js
+++ b/test/unit-tests/api.exports.redaction.js
@@ -1,0 +1,51 @@
+require("should");
+var exporter = require("../../api/parts/data/exports.js");
+
+describe("export credential redaction", function() {
+    describe("redactsExportCollection", function() {
+        it("flags privileged collections", function() {
+            exporter.redactsExportCollection("members").should.equal(true);
+            exporter.redactsExportCollection("auth_tokens").should.equal(true);
+        });
+        it("does not flag ordinary collections", function() {
+            exporter.redactsExportCollection("app_users5f0000000000000000000000").should.equal(false);
+            exporter.redactsExportCollection("events_data").should.equal(false);
+            exporter.redactsExportCollection("drill_events").should.equal(false);
+        });
+    });
+
+    describe("redactExportDoc", function() {
+        it("strips credential fields from members docs", function() {
+            var doc = {
+                _id: "abc",
+                email: "a@b.com",
+                full_name: "A B",
+                password: "hashed-secret",
+                api_key: "deadbeef",
+                two_factor_auth: {secret: "TOTP"}
+            };
+            var out = exporter.redactExportDoc("members", doc);
+            out.should.have.property("email", "a@b.com");
+            out.should.have.property("full_name", "A B");
+            out.should.not.have.property("password");
+            out.should.not.have.property("api_key");
+            out.should.not.have.property("two_factor_auth");
+        });
+        it("masks the token id on auth_tokens docs", function() {
+            var doc = {_id: "raw-token-value", owner: "u1", purpose: "LoggedInAuth"};
+            var out = exporter.redactExportDoc("auth_tokens", doc);
+            out.should.have.property("_id", "***redacted***");
+            out.should.have.property("owner", "u1");
+        });
+        it("leaves ordinary collections untouched", function() {
+            var doc = {_id: "x", did: "device-1", uid: "1", custom: {plan: "pro"}};
+            var out = exporter.redactExportDoc("app_users5f0000000000000000000000", doc);
+            out.should.have.property("_id", "x");
+            out.should.have.property("did", "device-1");
+            out.should.have.property("custom");
+        });
+        it("tolerates a null/undefined doc", function() {
+            (exporter.redactExportDoc("members", null) === null).should.equal(true);
+        });
+    });
+});


### PR DESCRIPTION
Backport of #7727 to `release.24.05`.

## Summary

Brings the shared database export path (`/o/export/db`) in line with how the DB Viewer already treats the same collections, so the two surfaces behave consistently.

- Skip internal index metadata (`system.indexes`) and the dashboard session store (`sessions_`) on export. DB Viewer already hides these from browsing; the export path now does the same.
- Redact credential fields on export to match DB Viewer's read paths:
  - `members` → drop `password`, `api_key`, `two_factor_auth`
  - `auth_tokens` → mask `_id`

Redaction is applied at the cursor level through a small reusable helper (`redactExportDoc`), so it covers every output format (json/csv/xls) regardless of the caller-supplied projection.

## Notes

- Not a behavior change for normal data-table exports.
- DB Viewer can still export `members`/`auth_tokens`; the exported rows now match what the UI already shows (secrets removed).
- Only `system.indexes` / `sessions_` lose export support, and those were never browsable in DB Viewer to begin with.

## Tests

Adds `test/unit-tests/api.exports.redaction.js` covering the redaction helper. `node --check` and eslint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)