### PR TITLE
fix(dbviewer): don't double app_viewdata prefix for unmapped view collections

### DIFF
--- a/plugins/dbviewer/api/api.js
+++ b/plugins/dbviewer/api/api.js
@@ -751,7 +751,12 @@ var spawn = require('child_process').spawn,
 
         }
         if (isView) {
-            pretty = "app_viewdata" + getCollectionName(name);
+            var viewEntry = getCollectionName(name);
+            //getCollectionName returns the input unchanged when there is no mapping,
+            //prepending it then would double the prefix (app_viewdataapp_viewdata...)
+            if (viewEntry !== name) {
+                pretty = "app_viewdata" + viewEntry;
+            }
         }
         else if (!isEvent) {
             for (let i in apps) {


### PR DESCRIPTION
## Problem

`parseCollectionName()` prepended `app_viewdata` to whatever `getCollectionName()` returned for view collections — but that helper returns its input **unchanged** when the collection has no map entry (unified `app_viewdata` collection, deleted apps, omitted segments, pre-19.02 `app_viewdata<appId>` leftovers). That doubled the prefix, producing phantom display names like `app_viewdataapp_viewdata...` in the dbviewer UI (no such collections actually exist).

## Fix

Only prepend the `app_viewdata` prefix when `getCollectionName()` actually returned a mapped pretty name (i.e. the value changed), matching how the events branch already handles unmapped hashes.

Backport of Countly/countly-platform#484 (dbviewer portion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
