### PR TITLE
compare: scope /o/compare/apps to per-app compare permission

### DIFF
--- a/plugins/compare/api/api.js
+++ b/plugins/compare/api/api.js
@@ -8,7 +8,7 @@ var exported = {},
     crypto = require('crypto'),
     async = require('async'),
     log = common.log('compare:api'),
-    { validateRead, getUserApps } = require('../../../api/utils/rights.js');
+    { validateRead, getAdminApps, getUserAppsForFeaturePermission } = require('../../../api/utils/rights.js');
 
 const FEATURE_NAME = 'compare';
 
@@ -154,16 +154,19 @@ const FEATURE_NAME = 'compare';
         params.qstring.app_id = appsToFetch[0];
 
         validateRead(params, FEATURE_NAME, function() {
-            const userApps = getUserApps(params.member);
             if (!params.member.global_admin) {
+                // every requested app must be one the member can read with the
+                // compare feature, not merely an app they belong to; admin apps
+                // include the feature implicitly
+                var allowedApps = (getAdminApps(params.member) || [])
+                    .concat(getUserAppsForFeaturePermission(params.member, FEATURE_NAME, 'r') || []);
+                // legacy members (no permission object) are not covered by
+                // getUserAppsForFeaturePermission, so fall back to their user_of
+                if (typeof params.member.permission === "undefined" && Array.isArray(params.member.user_of)) {
+                    allowedApps = allowedApps.concat(params.member.user_of);
+                }
                 for (var i = 0; i < appsToFetch.length; i++) {
-                    if (params.member && userApps) {
-                        if (userApps.indexOf(appsToFetch[i]) === -1) {
-                            common.returnMessage(params, 401, 'User does not have view rights for one or more apps provided in apps parameter');
-                            return true;
-                        }
-                    }
-                    else {
+                    if (allowedApps.indexOf(appsToFetch[i]) === -1) {
                         common.returnMessage(params, 401, 'User does not have view rights for one or more apps provided in apps parameter');
                         return true;
                     }

--- a/plugins/compare/tests.js
+++ b/plugins/compare/tests.js
@@ -237,4 +237,71 @@ describe('Testing Compare Plugin', function() {
         });
 
     });
+
+    describe("Testing Compare Apps per-app permission", function() {
+        var API_KEY_ADMIN = "";
+        var BASE_APP_ID = "";
+        var victimAppId = "";
+        var scopedApiKey = "";
+        var scopedUserId = "";
+        var uniq = Date.now();
+
+        before(function() {
+            API_KEY_ADMIN = testUtils.get("API_KEY_ADMIN");
+            BASE_APP_ID = testUtils.get("APP_ID");
+        });
+
+        it('should create a victim app and a user with compare read on the base app only', function(done) {
+            request.get('/i/apps/create?api_key=' + API_KEY_ADMIN + '&args=' + encodeURIComponent(JSON.stringify({name: "CompareVictimApp", type: "mobile"})))
+                .expect(200)
+                .end(function(err, res) {
+                    if (err) {
+                        return done(err);
+                    }
+                    victimAppId = res.body._id;
+                    var perm = { _: {a: [], u: [BASE_APP_ID]}, c: {}, r: {}, u: {}, d: {} };
+                    ["c", "r", "u", "d"].forEach(function(t) {
+                        perm[t][BASE_APP_ID] = {all: false, allowed: {compare: true}};
+                    });
+                    var userParams = {full_name: "compareuser" + uniq, username: "compareuser" + uniq, password: "p4ssw0rD!", email: "compareuser" + uniq + "@mail.test", permission: perm};
+                    request.get('/i/users/create?api_key=' + API_KEY_ADMIN + '&args=' + encodeURIComponent(JSON.stringify(userParams)))
+                        .expect(200)
+                        .end(function(err2, res2) {
+                            if (err2) {
+                                return done(err2);
+                            }
+                            scopedApiKey = res2.body.api_key;
+                            scopedUserId = res2.body._id;
+                            should.exist(scopedApiKey);
+                            done();
+                        });
+                });
+        });
+
+        it('should reject comparing apps when one app lacks compare permission', function(done) {
+            request.get('/o/compare/apps?period=30days&apps=' + encodeURIComponent(JSON.stringify([BASE_APP_ID, victimAppId])) + '&api_key=' + scopedApiKey)
+                .expect(401)
+                .end(function(err) {
+                    return done(err);
+                });
+        });
+
+        it('should allow comparing only apps the member can read with compare', function(done) {
+            request.get('/o/compare/apps?period=30days&apps=' + encodeURIComponent(JSON.stringify([BASE_APP_ID])) + '&api_key=' + scopedApiKey)
+                .expect(200)
+                .end(function(err) {
+                    return done(err);
+                });
+        });
+
+        after(function(done) {
+            request.get('/i/users/delete?api_key=' + API_KEY_ADMIN + '&args=' + encodeURIComponent(JSON.stringify({user_ids: [scopedUserId]})))
+                .end(function() {
+                    request.get('/i/apps/delete?api_key=' + API_KEY_ADMIN + '&args=' + encodeURIComponent(JSON.stringify({app_id: victimAppId})))
+                        .end(function() {
+                            done();
+                        });
+                });
+        });
+    });
 });


### PR DESCRIPTION
## Summary

`/o/compare/apps` validated the `compare` feature only on the first app in the `apps` list, then checked the remaining apps against plain membership (`getUserApps`). This brings it in line with how the `alerts` and `hooks` plugins scope multi-app reads.

Every requested app must now be one the member can read with the `compare` feature:
- admin apps (`getAdminApps`), plus
- apps where the member has `compare` read (`getUserAppsForFeaturePermission(member, 'compare', 'r')`), plus
- for legacy members without a `permission` object, their `user_of` apps (same fallback the alerts endpoint uses).

If any requested app is not in that set, the request is rejected.

## Notes

- Global admins are unaffected (skipped, as before).
- The single-app `/o/compare/events` path is unaffected (already scoped via `app_id`).
- Same scoping approach as the earlier times-of-day change (#7612).

`node --check` and eslint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)