### PR TITLE
security(push): bump @grpc/grpc-js to 1.11.4 (fix 2 high-severity DoS alerts)

### DIFF
--- a/plugins/push/package-lock.json
+++ b/plugins/push/package-lock.json
@@ -170,9 +170,9 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.11.1.tgz",
-      "integrity": "sha512-gyt/WayZrVPH2w/UTLansS7F9Nwld472JxxaETamrM8HNlsa+jSLNyKAZmhxI2Me4c3mQHFiS1wWHDY1g1Kthw==",
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.11.4.tgz",
+      "integrity": "sha512-ca9hn7kfwbJssq1TTjE6CiCnfpESHl600mVQsmaTVEQD8kD14UmCsx4rkfuWYncIvTBUbEJb3agQGkYh65VGKA==",
       "optional": true,
       "dependencies": {
         "@grpc/proto-loader": "^0.7.13",
@@ -2229,9 +2229,9 @@
       }
     },
     "@grpc/grpc-js": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.11.1.tgz",
-      "integrity": "sha512-gyt/WayZrVPH2w/UTLansS7F9Nwld472JxxaETamrM8HNlsa+jSLNyKAZmhxI2Me4c3mQHFiS1wWHDY1g1Kthw==",
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.11.4.tgz",
+      "integrity": "sha512-ca9hn7kfwbJssq1TTjE6CiCnfpESHl600mVQsmaTVEQD8kD14UmCsx4rkfuWYncIvTBUbEJb3agQGkYh65VGKA==",
       "optional": true,
       "requires": {
         "@grpc/proto-loader": "^0.7.13",


### PR DESCRIPTION
## What

Bumps the push plugin's transitive dependency `@grpc/grpc-js` from **1.11.1 → 1.11.4** in `plugins/push/package-lock.json`.

## Why

Resolves the two open high-severity Dependabot alerts (both DoS), the only open alerts on the repo:

- [#342](https://github.com/Countly/countly-server/security/dependabot/342) — `@grpc/grpc-js`: a malformed request can cause a server crash
- [#341](https://github.com/Countly/countly-server/security/dependabot/341) — `@grpc/grpc-js`: an incoming malformed compressed message can cause a client/server crash

Vulnerable range `>= 1.11.0, < 1.11.4`; patched in `1.11.4`.

## Why it won't break anything

- **Dependency chain:** `firebase-admin@12.1.0` → `google-gax@4.3.9` → `@grpc/grpc-js@^1.10.9`. The bump to 1.11.4 stays well within that declared range, so firebase-admin/google-gax remain fully compatible.
- **Patch-level change** within the same minor (1.11.x). The two upstream commits are pure crash-hardening fixes — no public API changes, no dependency-range or engine changes (`@grpc/proto-loader ^0.7.13`, `@js-sdsl/ordered-map ^4.4.2`, `node >=12.10.0` all unchanged).
- **Marked `optional: true`** — only used for the FCM HTTP/2 transport.
- **Lockfile-only, minimal diff** (6 lines), v2 format preserved (no v2→v3 churn).
- **Verified:** `npm ci` against the edited lockfile succeeds and installs exactly `1.11.4`, with the registry integrity hash validated against the downloaded tarball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)