### PR TITLE
Scope multi-app and feature endpoints to per-app permission (backport to 24.05)

### DIFF
--- a/api/utils/requestProcessor.js
+++ b/api/utils/requestProcessor.js
@@ -7,7 +7,7 @@ const Promise = require('bluebird');
 const url = require('url');
 const common = require('./common.js');
 const countlyCommon = require('../lib/countly.common.js');
-const { validateAppAdmin, validateUser, validateRead, validateUserForRead, validateUserForWrite, validateGlobalAdmin, dbUserHasAccessToCollection, validateUpdate, validateDelete, validateCreate } = require('./rights.js');
+const { validateAppAdmin, validateUser, validateRead, validateUserForRead, validateUserForWrite, validateGlobalAdmin, dbUserHasAccessToCollection, validateUpdate, validateDelete, validateCreate, getAdminApps, getUserAppsForFeaturePermission } = require('./rights.js');
 const authorize = require('./authorizer.js');
 const taskmanager = require('./taskmanager.js');
 const plugins = require('../../plugins/pluginManager.js');
@@ -1983,6 +1983,21 @@ const processRequest = (params) => {
                         if (params.qstring.app_ids && params.qstring.app_ids !== "") {
                             var ll = params.qstring.app_ids.split(",");
                             if (ll.length > 1) {
+                                // validateRead only checked the single app_id; every app
+                                // in the multi-app list must also be one the member can read
+                                if (!params.member.global_admin) {
+                                    var allowedTaskApps = (getAdminApps(params.member) || [])
+                                        .concat(getUserAppsForFeaturePermission(params.member, 'core', 'r') || []);
+                                    if (typeof params.member.permission === "undefined" && Array.isArray(params.member.user_of)) {
+                                        allowedTaskApps = allowedTaskApps.concat(params.member.user_of);
+                                    }
+                                    for (var taskAppIdx = 0; taskAppIdx < ll.length; taskAppIdx++) {
+                                        if (allowedTaskApps.indexOf(ll[taskAppIdx]) === -1) {
+                                            common.returnMessage(params, 401, 'User does not have access to one or more of the requested apps');
+                                            return;
+                                        }
+                                    }
+                                }
                                 params.qstring.query.app_id = {$in: ll};
                             }
                         }

--- a/api/utils/requestProcessor.js
+++ b/api/utils/requestProcessor.js
@@ -1981,7 +1981,9 @@ const processRequest = (params) => {
                         params.qstring.query.subtask = {$exists: false};
                         params.qstring.query.app_id = params.qstring.app_id;
                         if (params.qstring.app_ids && params.qstring.app_ids !== "") {
-                            var ll = params.qstring.app_ids.split(",");
+                            var ll = params.qstring.app_ids.split(",").map(function(id) {
+                                return id.trim();
+                            }).filter(Boolean);
                             if (ll.length > 1) {
                                 // validateRead only checked the single app_id; every app
                                 // in the multi-app list must also be one the member can read

--- a/plugins/crashes/api/api.js
+++ b/plugins/crashes/api/api.js
@@ -1376,7 +1376,7 @@ plugins.setConfigs("crashes", {
             });
             break;
         case 'view':
-            validateUpdate(obParams, function(params) {
+            validateUpdate(obParams, FEATURE_NAME, function(params) {
                 var crashes = params.qstring.args.crashes || [params.qstring.args.crash_id];
                 common.db.collection('app_crashgroups' + params.qstring.app_id).find({'_id': {$in: crashes}}).toArray(function(crashGroupsErr, groups) {
                     if (groups) {

--- a/plugins/hooks/api/api.js
+++ b/plugins/hooks/api/api.js
@@ -684,7 +684,16 @@ plugins.register("/i/hook/test", function(ob) {
                 return true;
             }
 
-            // trigger process            
+            // a user may only test a hook for apps they could actually manage;
+            // validateCreate above only checked the request app_id, so re-check
+            // every app the hook targets to keep test from running effects (or
+            // probing data) against apps the member has no hooks rights on
+            if (!params.member.global_admin && !memberHasRightForAllApps(rights.hasCreateRight, params.member, hookConfig.apps)) {
+                common.returnMessage(params, 403, "User does not have right");
+                return;
+            }
+
+            // trigger process
             log.d(JSON.stringify(hookConfig), "[hook test config]");
             const results = [];
 

--- a/plugins/hooks/api/api.js
+++ b/plugins/hooks/api/api.js
@@ -677,6 +677,7 @@ plugins.register("/i/hook/test", function(ob) {
 
             if (!(common.validateArgs(hookConfig, CheckHookProperties(hookConfig)))) {
                 common.returnMessage(params, 403, "hook config invalid");
+                return;
             }
 
             if (hookConfig && hookConfig.effects && !validateEffects(hookConfig.effects)) {

--- a/plugins/reports/api/api.js
+++ b/plugins/reports/api/api.js
@@ -5,7 +5,7 @@ var common = require('../../../api/utils/common.js'),
     log = require('../../../api/utils/log')('reports:api'),
     ejs = require("ejs"),
     plugins = require('../../pluginManager.js'),
-    { validateCreate, validateRead, validateUpdate, validateDelete, getUserApps, } = require('../../../api/utils/rights.js');
+    { validateCreate, validateRead, validateUpdate, validateDelete, getAdminApps, getUserAppsForFeaturePermission } = require('../../../api/utils/rights.js');
 
 const FEATURE_NAME = 'reports';
 
@@ -265,16 +265,18 @@ const FEATURE_NAME = 'reports';
                         return;
                     }
 
-                    let userApps = getUserApps(params.member);
-                    let notPermitted = false;
-                    for (var i = 0; i < props.apps.length; i++) {
-                        if (userApps.indexOf(props.apps[i]) === -1) {
-                            notPermitted = true;
+                    if (!params.member.global_admin) {
+                        let allowedApps = (getAdminApps(params.member) || [])
+                            .concat(getUserAppsForFeaturePermission(params.member, FEATURE_NAME, 'r') || []);
+                        if (typeof params.member.permission === "undefined" && Array.isArray(params.member.user_of)) {
+                            allowedApps = allowedApps.concat(params.member.user_of);
                         }
-                    }
-
-                    if (notPermitted && !params.member.global_admin) {
-                        return common.returnMessage(params, 401, 'User does not have right to access this information');
+                        let notPermitted = props.apps.some(function(appId) {
+                            return allowedApps.indexOf(appId) === -1;
+                        });
+                        if (notPermitted) {
+                            return common.returnMessage(params, 401, 'User does not have right to access this information');
+                        }
                     }
                 }
 
@@ -341,15 +343,18 @@ const FEATURE_NAME = 'reports';
                         if (!Array.isArray(props.apps) || props.apps.length === 0) {
                             return common.returnMessage(params, 400, 'Invalid or missing apps');
                         }
-                        let userApps = getUserApps(params.member);
-                        let notPermitted = false;
-                        for (var i = 0; i < props.apps.length; i++) {
-                            if (userApps.indexOf(props.apps[i]) === -1) {
-                                notPermitted = true;
+                        if (!params.member.global_admin) {
+                            let allowedApps = (getAdminApps(params.member) || [])
+                                .concat(getUserAppsForFeaturePermission(params.member, FEATURE_NAME, 'r') || []);
+                            if (typeof params.member.permission === "undefined" && Array.isArray(params.member.user_of)) {
+                                allowedApps = allowedApps.concat(params.member.user_of);
                             }
-                        }
-                        if (notPermitted && !params.member.global_admin) {
-                            return common.returnMessage(params, 401, 'User does not have right to access this information');
+                            let notPermitted = props.apps.some(function(appId) {
+                                return allowedApps.indexOf(appId) === -1;
+                            });
+                            if (notPermitted) {
+                                return common.returnMessage(params, 401, 'User does not have right to access this information');
+                            }
                         }
                     }
 

--- a/plugins/server-stats/api/api.js
+++ b/plugins/server-stats/api/api.js
@@ -465,7 +465,10 @@ function getServerStatsApps(member) {
                             });
                         }
                         else {
-                            //access denied
+                            //the member cannot read server-stats for the selected app;
+                            //reject explicitly rather than returning an all-zero card
+                            common.returnMessage(params, 401, "User does not have access to selected app");
+                            return;
                         }
                     }
                     else {

--- a/plugins/server-stats/api/api.js
+++ b/plugins/server-stats/api/api.js
@@ -27,7 +27,9 @@ function getServerStatsApps(member) {
     if (typeof member.permission === "undefined" && Array.isArray(member.user_of)) {
         apps = apps.concat(member.user_of);
     }
-    return apps;
+    // an app can be both administered and feature-granted; de-duplicate so the
+    // $in filters and membership loops do not carry repeated ids
+    return Array.from(new Set(apps));
 }
 
 (function() {

--- a/plugins/server-stats/api/api.js
+++ b/plugins/server-stats/api/api.js
@@ -1,4 +1,4 @@
-const { getUserApps } = require('../../../api/utils/rights.js');
+const { getAdminApps, getUserAppsForFeaturePermission } = require('../../../api/utils/rights.js');
 
 var plugins = require('../../pluginManager.js'),
     common = require('../../../api/utils/common.js'),
@@ -11,6 +11,24 @@ var log = common.log('data-points:api');
 const FEATURE_NAME = 'server-stats';
 
 const internalEventsSkipped = ["[CLY]_orientation"];
+
+/**
+ * Apps a non-global member may see server-stats for: those they administer or
+ * have server-stats read on. Plain app membership is not sufficient, otherwise
+ * a member could read data-point counts for apps they were not granted the
+ * server-stats feature on.
+ * @param {object} member - request member object
+ * @returns {Array} list of app ids the member may read server-stats for
+ */
+function getServerStatsApps(member) {
+    var apps = (getAdminApps(member) || [])
+        .concat(getUserAppsForFeaturePermission(member, FEATURE_NAME, 'r') || []);
+    // legacy members (no permission object) predate per-feature permissions
+    if (typeof member.permission === "undefined" && Array.isArray(member.user_of)) {
+        apps = apps.concat(member.user_of);
+    }
+    return apps;
+}
 
 (function() {
 
@@ -276,7 +294,7 @@ const internalEventsSkipped = ["[CLY]_orientation"];
 
         validateUser(params, function() {
             if (!params.member.global_admin) {
-                var apps = getUserApps(params.member) || [];
+                var apps = getServerStatsApps(params.member);
                 for (let i = 0; i < periodsToFetch.length; i++) {
                     for (let j = 0; j < apps.length; j++) {
                         if (params.qstring.selected_app && params.qstring.selected_app !== "") {
@@ -353,7 +371,7 @@ const internalEventsSkipped = ["[CLY]_orientation"];
             //global admins see the instance-wide top apps; everyone else is
             //restricted to the apps they are allowed to access, so datapoint
             //totals for other apps are not disclosed
-            var appList = params.member.global_admin ? null : (getUserApps(params.member) || []);
+            var appList = params.member.global_admin ? null : getServerStatsApps(params.member);
             stats.getTop(common.db, params, function(res) {
                 common.returnOutput(params, res);
             }, appList);
@@ -439,7 +457,7 @@ const internalEventsSkipped = ["[CLY]_orientation"];
                 let filter = {"m": {$in: periodsToFetch} };
                 if (!params.member.global_admin) {
                     filter._id = {"$in": []};
-                    const hasUserApps = getUserApps(params.member) || [];
+                    const hasUserApps = getServerStatsApps(params.member);
                     if (params.qstring.selected_app) {
                         if (hasUserApps.indexOf(params.qstring.selected_app) > -1) {
                             periodsToFetch.forEach((period) => {

--- a/test/2.api/18.query.read.endpoints.js
+++ b/test/2.api/18.query.read.endpoints.js
@@ -120,4 +120,69 @@ describe('Testing query-validated read endpoints (happy path)', function() {
                 });
         });
     });
+
+    describe('GET /o/tasks/all multi-app permission', function() {
+        var victimAppId = "";
+        var scopedApiKey = "";
+        var scopedUserId = "";
+        var uniq = Date.now();
+
+        it('should create a second app and a user scoped to the base app only', function(done) {
+            request
+                .get('/i/apps/create?api_key=' + API_KEY_ADMIN + '&args=' + encodeURIComponent(JSON.stringify({name: "TasksVictimApp", type: "mobile"})))
+                .expect(200)
+                .end(function(err, res) {
+                    if (err) {
+                        return done(err);
+                    }
+                    victimAppId = res.body._id;
+                    var perm = { _: {a: [], u: [APP_ID]}, c: {}, r: {}, u: {}, d: {} };
+                    ["c", "r", "u", "d"].forEach(function(t) {
+                        perm[t][APP_ID] = {all: false, allowed: {core: true}};
+                    });
+                    var userParams = {full_name: "tasksuser" + uniq, username: "tasksuser" + uniq, password: "p4ssw0rD!", email: "tasksuser" + uniq + "@mail.test", permission: perm};
+                    request
+                        .get('/i/users/create?api_key=' + API_KEY_ADMIN + '&args=' + encodeURIComponent(JSON.stringify(userParams)))
+                        .expect(200)
+                        .end(function(err2, res2) {
+                            if (err2) {
+                                return done(err2);
+                            }
+                            scopedApiKey = res2.body.api_key;
+                            scopedUserId = res2.body._id;
+                            done();
+                        });
+                });
+        });
+
+        it('should reject an app_ids list containing an unauthorized app', function(done) {
+            request
+                .get('/o/tasks/all?api_key=' + scopedApiKey + '&app_id=' + APP_ID + '&app_ids=' + APP_ID + ',' + victimAppId + '&query=' + emptyQuery)
+                .expect(401)
+                .end(function(err) {
+                    return done(err);
+                });
+        });
+
+        it('should allow an app_ids list of only authorized apps', function(done) {
+            request
+                .get('/o/tasks/all?api_key=' + scopedApiKey + '&app_id=' + APP_ID + '&app_ids=' + APP_ID + ',' + APP_ID + '&query=' + emptyQuery)
+                .expect(200)
+                .end(function(err) {
+                    return done(err);
+                });
+        });
+
+        after(function(done) {
+            request
+                .get('/i/users/delete?api_key=' + API_KEY_ADMIN + '&args=' + encodeURIComponent(JSON.stringify({user_ids: [scopedUserId]})))
+                .end(function() {
+                    request
+                        .get('/i/apps/delete?api_key=' + API_KEY_ADMIN + '&args=' + encodeURIComponent(JSON.stringify({app_id: victimAppId})))
+                        .end(function() {
+                            done();
+                        });
+                });
+        });
+    });
 });


### PR DESCRIPTION
Backport of #7737 to `release.24.05`.

## Summary

Aligns several endpoints with the per-app feature-permission model used by `alerts`/`hooks`/`compare`. Each served app-scoped data after validating only the first app id, or after a plain app-membership check.

- **`/o/tasks/all`** — the multi-app `app_ids` list is validated against the apps the member can read with the `core` feature, not only the single `app_id`.
- **reports `create`/`update`** — target apps of a core report are validated against the member's reports-readable apps (+ admin apps) instead of plain membership.
- **server-stats `data-points`/`top`/`punch-card`** — the per-member app set is now the apps the member administers or has `server-stats` read on.
- **crashes `view`** — pass `FEATURE_NAME` to `validateUpdate` (it was missing).
- **hooks `/i/hook/test`** — re-check every app the hook config targets (same `memberHasRightForAllApps` guard save/delete use), so test cannot run effects or probe data for apps the member has no hooks rights on.

Global admins and single-app paths are unaffected; legacy members keep their `user_of` fallback.

Conflicts resolved for the 24.05 tree (no `getBaseAppFilter`/`pdf` imports there). `node --check` and eslint pass on all files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)