### PR TITLE
tests: cover the endpoints touched by per-app permission scoping

### DIFF
--- a/plugins/crashes/tests.js
+++ b/plugins/crashes/tests.js
@@ -1363,6 +1363,25 @@ describe('Testing Crashes', function() {
         });
     });
 
+    describe('Mark crash as viewed', function() {
+        it('should success', function(done) {
+            var args = {
+                crash_id: CRASHES[2]
+            };
+            request
+                .get('/i/crashes/view?args=' + JSON.stringify(args) + '&app_id=' + APP_ID + '&api_key=' + API_KEY_ADMIN)
+                .expect(200)
+                .end(function(err, res) {
+                    if (err) {
+                        return done(err);
+                    }
+                    var ob = JSON.parse(res.text);
+                    ob.should.have.property('result', 'Success');
+                    setTimeout(done, 10 * testUtils.testScalingFactor);
+                });
+        });
+    });
+
     /*
     describe('Check public crash', function() {
         it('should be found', function(done) {

--- a/plugins/server-stats/tests/api.js
+++ b/plugins/server-stats/tests/api.js
@@ -263,6 +263,15 @@ describe('Testing data points plugin', function() {
                 });
         });
 
+        it('should reject punch-card for an app the scoped user cannot read', function(done) {
+            request
+                .get('/o/server-stats/punch-card?period=30days&selected_app=' + APP_ID + '&api_key=' + scopedApiKey)
+                .expect(401)
+                .end(function(err) {
+                    return done(err);
+                });
+        });
+
         after(function(done) {
             request
                 .get('/i/users/delete?api_key=' + API_KEY_ADMIN + '&args=' + encodeURIComponent(JSON.stringify({user_ids: [scopedUserId]})))


### PR DESCRIPTION
- hooks: reject /i/hook/test for a config targeting another app (regression)
- server-stats: reject punch-card for an app the scoped user cannot read
- crashes: happy-path for /i/crashes view (confirms the FEATURE_NAME fix keeps the mark-as-viewed action working)