### PR TITLE
tests: assert /o/export/db rejects session store and system index col…

### DIFF
--- a/test/2.api/18.query.read.endpoints.js
+++ b/test/2.api/18.query.read.endpoints.js
@@ -103,6 +103,24 @@ describe('Testing query-validated read endpoints (happy path)', function() {
                     done();
                 });
         });
+
+        it('should not export the session store collection', function(done) {
+            request
+                .get('/o/export/db?api_key=' + API_KEY_ADMIN + '&app_id=' + APP_ID + '&collection=sessions_&type=json&filter=' + emptyQuery)
+                .expect(401)
+                .end(function(err) {
+                    return done(err);
+                });
+        });
+
+        it('should not export system index metadata', function(done) {
+            request
+                .get('/o/export/db?api_key=' + API_KEY_ADMIN + '&app_id=' + APP_ID + '&collection=system.indexes&type=json&filter=' + emptyQuery)
+                .expect(401)
+                .end(function(err) {
+                    return done(err);
+                });
+        });
     });
 
     describe('GET /o (method=all_apps)', function() {

--- a/test/2.api/18.query.read.endpoints.js
+++ b/test/2.api/18.query.read.endpoints.js
@@ -1,4 +1,5 @@
 var request = require('supertest');
+var should = require('should');
 var testUtils = require("../testUtils");
 request = request(testUtils.url);
 
@@ -108,8 +109,13 @@ describe('Testing query-validated read endpoints (happy path)', function() {
             request
                 .get('/o/export/db?api_key=' + API_KEY_ADMIN + '&app_id=' + APP_ID + '&collection=sessions_&type=json&filter=' + emptyQuery)
                 .expect(401)
-                .end(function(err) {
-                    return done(err);
+                .end(function(err, res) {
+                    if (err) {
+                        return done(err);
+                    }
+                    var ob = JSON.parse(res.text);
+                    ob.should.have.property('result', 'User does not have access right for this collection');
+                    done();
                 });
         });
 
@@ -117,8 +123,13 @@ describe('Testing query-validated read endpoints (happy path)', function() {
             request
                 .get('/o/export/db?api_key=' + API_KEY_ADMIN + '&app_id=' + APP_ID + '&collection=system.indexes&type=json&filter=' + emptyQuery)
                 .expect(401)
-                .end(function(err) {
-                    return done(err);
+                .end(function(err, res) {
+                    if (err) {
+                        return done(err);
+                    }
+                    var ob = JSON.parse(res.text);
+                    ob.should.have.property('result', 'User does not have access right for this collection');
+                    done();
                 });
         });
     });


### PR DESCRIPTION
…lections

Regression coverage for the DB Viewer-aligned collection restrictions: the session store (sessions_) and system index metadata are not exportable.