### PR TITLE
fix(push,consolidate): scope operations to the request app

### DIFF
--- a/plugins/consolidate/api/api.js
+++ b/plugins/consolidate/api/api.js
@@ -1,6 +1,7 @@
 const plugins = require('../../pluginManager.js');
 const common = require('../../../api/utils/common.js');
 const { processRequest } = require('../../../api/utils/requestProcessor');
+const rights = require('../../../api/utils/rights.js');
 
 //write api call
 plugins.register("/sdk/pre", function(ob) {
@@ -88,7 +89,7 @@ plugins.register("/i", async function(ob) {
 
 });
 
-plugins.register('/i/apps/update/plugins/consolidate', async function({app, config}) {
+plugins.register('/i/apps/update/plugins/consolidate', async function({params, app, config}) {
     try {
         console.log('Updating app %s config: %j', app._id, config);
         const addedSourceApps = config.selectedApps;
@@ -96,6 +97,17 @@ plugins.register('/i/apps/update/plugins/consolidate', async function({app, conf
 
         if (!addedSourceApps || !initialSourceApps) {
             return "Nothing changed";
+        }
+
+        // Apply the config only to source apps the member has access to (the same set
+        // the App Management UI offers). Global admins pass.
+        const member = params && params.member;
+        if (!member || !member.global_admin) {
+            const allowedApps = (member && rights.getUserApps(member)) || [];
+            const unauthorized = addedSourceApps.filter((id) => allowedApps.indexOf(id + "") === -1);
+            if (unauthorized.length) {
+                throw new Error('No access to source app(s): ' + unauthorized.join(', '));
+            }
         }
 
         const removedSourceApps = addedSourceApps

--- a/plugins/push/api/api-tx.js
+++ b/plugins/push/api/api-tx.js
@@ -60,6 +60,12 @@ async function check(params, push) {
         throw new PushError('No such message or it doesn\'t have API trigger', ERROR.DATA_COUNTLY);
     }
 
+    // Ensure the message belongs to the request app before use, consistent with the
+    // other message handlers that scope their lookups by app.
+    if (!message.app || message.app.toString() !== params.app._id.toString()) {
+        throw new PushError('No such message or it doesn\'t have API trigger', ERROR.DATA_COUNTLY);
+    }
+
     let trigger = message.triggerFind(TriggerKind.API);
     if (!trigger) {
         throw new PushError('Message is not api', ERROR.DATA_COUNTLY);


### PR DESCRIPTION
## Summary

- **push** — `check()` ([api-tx.js](plugins/push/api/api-tx.js)) now verifies the loaded message belongs to the request app before building the audience, consistent with the other message handlers that scope their lookups by app.
- **consolidate** — `/i/apps/update/plugins/consolidate` applies the config only to source apps the member has access to (`rights.getUserApps`), the same set the App Management UI offers. Global admins are unaffected, so no legitimate UI flow changes.

`node --check` passes on both files.