### PR TITLE
fix(core): don't show no-access page to users who have app access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 
 ## Version 25.03.xx
+Fixes:
+- [core] Don't show the "no access" or initial-setup page to users who already have app access — redirect them to their default app instead
+
 Enterprise Fixes:
 - [journey_engine] Avoid throwing on duplicate events and prevent overwriting existing event map entries during event creation
 

--- a/frontend/express/public/core/onboarding/javascripts/countly.views.js
+++ b/frontend/express/public/core/onboarding/javascripts/countly.views.js
@@ -289,6 +289,12 @@
     });
 
     app.route('/initial-setup', 'initial-setup', function() {
+        if (!_.isEmpty(countlyGlobal.apps)) {
+            // Apps already exist; the initial-setup dead-end shouldn't be shown
+            // (e.g. reached via a stale restored route). Send to the default app.
+            app.navigate("/" + (countlyGlobal.defaultApp && countlyGlobal.defaultApp._id ? countlyGlobal.defaultApp._id : ""), true);
+            return;
+        }
         this.renderWhenReady(new CV.views.BackboneWrapper({
             component: appSetupView,
             vuex: [{ clyModel: countlyOnboarding }],

--- a/plugins/plugins/frontend/public/javascripts/countly.views.js
+++ b/plugins/plugins/frontend/public/javascripts/countly.views.js
@@ -1359,6 +1359,13 @@
     });
 
     app.route('/account-settings/no-access', 'account-settings', function() {
+        if (!_.isEmpty(countlyGlobal.apps)) {
+            // The member actually has app access; don't render the no-access
+            // dead-end (e.g. reached via a stale restored route). Send them to
+            // their default app instead.
+            app.navigate("/" + (countlyGlobal.defaultApp && countlyGlobal.defaultApp._id ? countlyGlobal.defaultApp._id : ""), true);
+            return;
+        }
         var view = getAccountView();
         view.params = {noaccess: true};
         this.renderWhenReady(view);


### PR DESCRIPTION
## Problem

Users who **do** have app access could still land on the **"You do not have any access to any app, contact administrator."** page — the same page shown to brand-new users with no access. Global admins could similarly land on the **initial-setup** page. It was intermittent and survived re-login.

## Root cause

1. A user logs in with no access (e.g. SSO auto-provisioning) → routed to `/account-settings/no-access` (or a global admin with no apps → `/initial-setup`).
2. That route is stored as the **last-visited page** and restored on the next login.
3. The user is later granted access.
4. On the next login the dead-end route is restored, and its view renders **purely from the route** — it never re-checks that `countlyGlobal.apps` is now populated.

The app id is present in the URL and the app is fully usable (the sidebar loads, and a direct app link works). Only the landing route was stale.

## Fix

Guard both dead-end routes so an authorized member (apps present) is redirected to their default app instead of being shown the page:

- **`plugins/plugins` account-settings route** — `/account-settings/no-access`
- **core onboarding route** — `/initial-setup`

This is route-level and precise: it catches the dead-end no matter how it was reached, with no fragile URL string-matching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)