### PR TITLE
fix(views): stop over-counting weekly unique for repeat same-week views (release.24.05)

### DIFF
--- a/plugins/views/api/api.js
+++ b/plugins/views/api/api.js
@@ -2190,7 +2190,13 @@ const escapedViewSegments = { "name": true, "segment": true, "height": true, "wi
                         secInYear = (60 * 60 * 24 * (common.getDOY(params.time.timestamp, params.appTimezone) - 1)) + secInHour;
 
 
-                    var lastMoment = new moment(lastViewTimestamp);
+                    // lastViewTimestamp is a unix timestamp in seconds (like the
+                    // other gates below compare it). new moment(Number) treats the
+                    // value as milliseconds, placing it in 1970, so isoWeek() was a
+                    // tiny number that is almost always < weeklyISO — making the
+                    // weekly-unique gate fire on every repeat view in the same week
+                    // (over-counting weekly unique). Use moment.unix() for seconds.
+                    var lastMoment = moment.unix(lastViewTimestamp);
                     lastMoment.tz(params.appTimezone);
 
                     if (lastViewTimestamp < (params.time.timestamp - secInMin)) {

--- a/plugins/views/tests.js
+++ b/plugins/views/tests.js
@@ -1405,7 +1405,7 @@ describe('Testing views weekly-unique counting', function() {
                     if (err2) {
                         return done(err2);
                     }
-                    docs.should.not.be.empty();
+                    docs.should.not.be.empty;
                     // Only WU_DEVICE_ID viewed WU_VIEW_NAME, so every weekly-unique bucket must be 1.
                     var offending = [];
                     var weeklyBucketsChecked = 0;
@@ -1430,5 +1430,20 @@ describe('Testing views weekly-unique counting', function() {
                 });
             });
         });
+    });
+
+    // Reset the app so the view data written above does not leak into
+    // subsequent test files that reuse the same APP_ID.
+    after(function(done) {
+        var params = {app_id: APP_ID, "period": "reset"};
+        request
+            .get('/i/apps/reset?api_key=' + API_KEY_ADMIN + "&args=" + JSON.stringify(params))
+            .expect(200)
+            .end(function(err) {
+                if (err) {
+                    return done(err);
+                }
+                setTimeout(done, testUtils.testWaitTimeForResetApp * testUtils.testScalingFactor);
+            });
     });
 });

--- a/plugins/views/tests.js
+++ b/plugins/views/tests.js
@@ -6,6 +6,7 @@ var APP_KEY = "";
 var API_KEY_ADMIN = "";
 var APP_ID = "";
 var crypto = require('crypto');
+var moment = require('moment-timezone');
 //var DEVICE_ID = "1234567890";
 
 //add data
@@ -1317,6 +1318,117 @@ describe('Testing views plugin', function() {
                     res.text.should.eql('{"iTotalRecords":0,"iTotalDisplayRecords":0,"aaData":[]}');
                     done();
                 });
+        });
+    });
+});
+
+describe('Testing views weekly-unique counting', function() {
+    var WU_DEVICE_ID = "views_weekly_unique_user";
+    var WU_VIEW_NAME = "viewsWeeklyUniqueTest";
+    var wuDb;
+    // Anchor both views to Wednesday 12:00 UTC of the PREVIOUS ISO week: safely in the
+    // past, and far enough from the Monday week boundary that both events land in the
+    // same ISO week for any reasonable app timezone (avoids boundary/timezone flakiness).
+    var wuAnchor = moment.utc().subtract(1, 'week').startOf('isoWeek').add(2, 'days').add(12, 'hours').valueOf();
+    var wuT1 = Math.floor(wuAnchor / 1000);
+    var wuT2 = Math.floor((wuAnchor + 3 * 60 * 60 * 1000) / 1000); // +3h, same Wednesday / same ISO week
+    var wuViewEvent = JSON.stringify([{"key": "[CLY]_view", "count": 1, "segmentation": {"name": WU_VIEW_NAME, "visit": 1, "start": 1, "platform": "Android"}}]);
+
+    describe('Same user viewing the same view in two sessions within one ISO week', function() {
+        it('init', function(done) {
+            API_KEY_ADMIN = testUtils.get("API_KEY_ADMIN");
+            APP_ID = testUtils.get("APP_ID");
+            APP_KEY = testUtils.get("APP_KEY");
+            wuDb = testUtils.client.db("countly");
+            done();
+        });
+
+        it('records the first session view', function(done) {
+            request
+                .get('/i?begin_session=1&app_key=' + APP_KEY + '&device_id=' + WU_DEVICE_ID + '&timestamp=' + wuT1 + '&events=' + encodeURIComponent(wuViewEvent))
+                .expect(200)
+                .end(function(err) {
+                    if (err) {
+                        return done(err);
+                    }
+                    setTimeout(done, testUtils.testWaitTimeForDrillEvents * testUtils.testScalingFactor);
+                });
+        });
+
+        it('ends the first session', function(done) {
+            request
+                .get('/i?end_session=1&app_key=' + APP_KEY + '&device_id=' + WU_DEVICE_ID + '&timestamp=' + (wuT1 + 3))
+                .expect(200)
+                .end(function(err) {
+                    if (err) {
+                        return done(err);
+                    }
+                    setTimeout(done, 100 * testUtils.testScalingFactor);
+                });
+        });
+
+        it('records the second session view in the same week', function(done) {
+            request
+                .get('/i?begin_session=1&app_key=' + APP_KEY + '&device_id=' + WU_DEVICE_ID + '&timestamp=' + wuT2 + '&events=' + encodeURIComponent(wuViewEvent))
+                .expect(200)
+                .end(function(err) {
+                    if (err) {
+                        return done(err);
+                    }
+                    setTimeout(done, testUtils.testWaitTimeForDrillEvents * testUtils.testScalingFactor);
+                });
+        });
+
+        it('ends the second session', function(done) {
+            request
+                .get('/i?end_session=1&app_key=' + APP_KEY + '&device_id=' + WU_DEVICE_ID + '&timestamp=' + (wuT2 + 3))
+                .expect(200)
+                .end(function(err) {
+                    if (err) {
+                        return done(err);
+                    }
+                    setTimeout(done, testUtils.testWaitTimeForDrillEvents * testUtils.testScalingFactor);
+                });
+        });
+
+        it('counts the view exactly once per week (one device viewed it)', function(done) {
+            wuDb.collection("app_viewsmeta" + APP_ID).findOne({"view": WU_VIEW_NAME}, function(err, viewMeta) {
+                if (err) {
+                    return done(err);
+                }
+                should.exist(viewMeta);
+                var viewIdStr = "" + viewMeta._id;
+                // no-segment view-data collection holds the per-year ("<viewId>_<year>:0")
+                // rollup docs where weekly unique lives under d.w<isoWeek>.u
+                var colName = "app_viewdata" + crypto.createHash('sha1').update("" + APP_ID).digest('hex');
+                wuDb.collection(colName).find({"_id": {"$regex": "^" + viewIdStr + "_"}}).toArray(function(err2, docs) {
+                    if (err2) {
+                        return done(err2);
+                    }
+                    docs.should.not.be.empty();
+                    // Only WU_DEVICE_ID viewed WU_VIEW_NAME, so every weekly-unique bucket must be 1.
+                    var offending = [];
+                    var weeklyBucketsChecked = 0;
+                    docs.forEach(function(doc) {
+                        if (doc.d) {
+                            for (var key in doc.d) {
+                                if (/^w[0-9]+$/.test(key) && doc.d[key] && typeof doc.d[key].u !== "undefined") {
+                                    weeklyBucketsChecked++;
+                                    if (doc.d[key].u !== 1) {
+                                        offending.push(doc._id + "." + key + ".u=" + doc.d[key].u);
+                                    }
+                                }
+                            }
+                        }
+                    });
+                    // Guard against a vacuous pass: a weekly-unique bucket must actually
+                    // have been written and inspected, otherwise an empty offending list
+                    // would "pass" even if weekly data stopped being recorded entirely.
+                    weeklyBucketsChecked.should.be.above(0);
+                    offending.should.eql([]);
+                    done();
+                });
+            });
         });
     });
 });


### PR DESCRIPTION
## Summary

Backports the weekly-unique view-counting fix to `release.24.05` (master fix: Countly/countly-server#7761).

When one device views the same view in two sessions within a single ISO week, the view-data weekly-unique bucket (`d.w<week>.u`) was recorded as **2** instead of **1**.

## Root cause

In `recordMetrics` (`plugins/views/api/api.js`), the weekly-unique gate built its comparison moment with `new moment(lastViewTimestamp)`. `lastViewTimestamp` is a unix timestamp **in seconds** (the adjacent day/month/year gates compare it against `timestamp - secInX`), but `moment(Number)` treats it as **milliseconds** — placing it in **1970**, so `isoWeek()` was a tiny number almost always `< weeklyISO`, firing the weekly-unique increment on every repeat same-week view. Daily/monthly/yearly gates use elapsed-seconds math and were unaffected, which is why only weekly over-counted. Fix: `moment.unix()`.

## Validation

Appends a regression test to `plugins/views/tests.js` (same device, two same-week sessions; asserts every weekly-unique bucket is `1`, timezone-robust, guards against a vacuous pass).

Note: corrects go-forward live counting only; already-stored weekly `u` values would need view-data regeneration to be corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
