### PR TITLE
chore(deps): override js-yaml to patched 3.15.0 / 4.2.0 (Dependabot)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1282,9 +1282,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7001,9 +7001,9 @@
       }
     },
     "node_modules/grunt/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -7988,9 +7988,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -114,7 +114,9 @@
     },
     "serialize-javascript": "^7.0.5",
     "uuid": "^11.1.1",
-    "@tootallnate/once": "^2.0.1"
+    "@tootallnate/once": "^2.0.1",
+    "js-yaml@^3.0.0": "^3.15.0",
+    "js-yaml@^4.0.0": "^4.2.0"
   },
   "jshintConfig": {
     "esversion": 6,


### PR DESCRIPTION
## What

Adds two version-scoped npm `overrides` for the transitive **js-yaml** dependency in the root manifest, and regenerates `package-lock.json`:

- `js-yaml@^3.0.0` -> `^3.15.0`
- `js-yaml@^4.0.0` -> `^4.2.0`

## Why

Resolves the two remaining open js-yaml Dependabot alerts (quadratic-complexity DoS in merge-key handling via repeated aliases):

- **medium** — js-yaml `4.0.0`–`4.1.1`, patched in `4.2.0`
- **medium** — js-yaml `< 3.15.0`, patched in `3.15.0`

js-yaml is pulled in transitively by dev/build tooling:
- **3.x** via `grunt` and `nyc -> @istanbuljs/load-nyc-config`
- **4.x** via `mocha`, `eslint`, and `puppeteer -> cosmiconfig`

Both patches are **within-major** (3.14.2 -> 3.15.0, 4.1.1 -> 4.3.0), so every consumer keeps an API-compatible js-yaml. The lockfile diff touches only js-yaml nodes — no unrelated churn — and `npm audit` reports no remaining js-yaml advisories.

## Testing

CI exercises all three consumer paths: `lint` (eslint), `dist-all` (grunt), and `mochaTest` (mocha) — verifying the bumped js-yaml versions don't break linting, the asset build, or the test runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)