### PR TITLE
[start-rating] Logo upload fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## Version 25.03.xx
+Fixes:
+- [star-rating] Fix custom widget logo resolving to the wrong path (mis-detected as the global app logo) after editing a widget
+
 Enterprise Fixes: 
 - [data-manager] Fixed bug where event and view transformations occasionally failed to apply to incoming data
-
 
 ## Version 25.03.49
 Fixes:

--- a/plugins/star-rating/frontend/public/javascripts/countly.views.js
+++ b/plugins/star-rating/frontend/public/javascripts/countly.views.js
@@ -1286,7 +1286,7 @@
                 if (!this.widget.logoType) {
                     this.widget.logoType = 'default';
                 }
-                if (this.widget.logo && this.widget.logo.indexOf("feedback_logo")) {
+                if (this.widget.logo && this.widget.logo.indexOf("feedback_logo") > -1) {
                     this.widget.globalLogo = true;
                 }
                 if (!this.widget.targeting) {


### PR DESCRIPTION
a widget-specific uploaded logo was wrongly treated as the global app logo, breaking the logo image in the feedback popup after editing/saving the widget
