### PR TITLE
Pin npm 11.18.0 in Node 20 Docker builds

### DIFF
--- a/Dockerfile-api
+++ b/Dockerfile-api
@@ -50,6 +50,7 @@ RUN curl -s -L -o /tmp/tini.deb "https://github.com/krallin/tini/releases/downlo
 	# preinstall
 	cp -n ./api/config.sample.js ./api/config.js && \
 	cp -n ./frontend/express/config.sample.js ./frontend/express/config.js && \
+	HOME=/tmp npm install -g npm@11.18.0 && \
 	HOME=/tmp npm install --unsafe-perm=true --allow-root && \
 	HOME=/tmp npm install argon2 --build-from-source --unsafe-perm=true --allow-root && \
 	./bin/docker/preinstall.sh && \

--- a/Dockerfile-centos-api
+++ b/Dockerfile-centos-api
@@ -53,6 +53,7 @@ RUN curl -s -L -o /tmp/tini.rpm "https://github.com/krallin/tini/releases/downlo
 	# preinstall
 	cp -n ./api/config.sample.js ./api/config.js && \
 	cp -n ./frontend/express/config.sample.js ./frontend/express/config.js && \
+	HOME=/tmp npm install -g npm@11.18.0 && \
 	HOME=/tmp npm install --unsafe-perm=true --allow-root && \
 	HOME=/tmp npm install argon2 --build-from-source --unsafe-perm=true --allow-root && \
 	./bin/docker/preinstall.sh && \

--- a/Dockerfile-centos-frontend
+++ b/Dockerfile-centos-frontend
@@ -52,6 +52,7 @@ RUN curl -s -L -o /tmp/tini.rpm "https://github.com/krallin/tini/releases/downlo
 	cp -n ./frontend/express/public/javascripts/countly/countly.config.sample.js ./frontend/express/public/javascripts/countly/countly.config.js && \
 	cp -n ./frontend/express/config.sample.js ./frontend/express/config.js && \
 	cp -n ./api/config.sample.js ./api/config.js && \
+	HOME=/tmp npm install -g npm@11.18.0 && \
 	HOME=/tmp npm install --unsafe-perm=true --allow-root && \
 	HOME=/tmp npm install argon2 --build-from-source --unsafe-perm=true --allow-root && \
 	./bin/docker/preinstall.sh && \

--- a/Dockerfile-frontend
+++ b/Dockerfile-frontend
@@ -47,6 +47,7 @@ RUN curl -s -L -o /tmp/tini.deb "https://github.com/krallin/tini/releases/downlo
 	cp -n ./api/config.sample.js ./api/config.js && \
 	cp -n ./frontend/express/config.sample.js ./frontend/express/config.js && \
 	cp -n ./frontend/express/public/javascripts/countly/countly.config.sample.js ./frontend/express/public/javascripts/countly/countly.config.js && \
+	HOME=/tmp npm install -g npm@11.18.0 && \
 	HOME=/tmp npm install --unsafe-perm=true --allow-root && \
 	HOME=/tmp npm install argon2 --build-from-source --unsafe-perm=true --allow-root && \
 	./bin/docker/preinstall.sh && \


### PR DESCRIPTION
## What changed

- Pin npm to exactly `11.18.0` in the Debian API/frontend Dockerfiles.
- Apply the same exact pin to the CentOS API/frontend Dockerfiles.

## Why

PR #7839 removed `npm@latest` so npm 12 no longer breaks these Node 20 builds. This follow-up explicitly installs npm `11.18.0`, the latest npm release compatible with the branch's Node `v20.20.2`.

The current npm 10 release (`10.9.8`) still reports known vulnerabilities in its bundled dependency tree, including the critical `node-tar` advisory. npm `11.18.0`:

- supports Node `^20.17.0 || >=22.9.0`;
- includes the patched `tar@7.5.19`;
- returned zero known vulnerabilities in a clean audit comparison performed on 2026-07-23.

The exact pin also prevents future npm major releases from unexpectedly changing the build.

## Validation

- `git diff --check`
- `docker buildx build --check` for all four changed Dockerfiles
- Installed and ran `npm@11.18.0` on the same `node:iron-bookworm-slim` base:
  - Node `v20.20.2`
  - npm `11.18.0`
- A full local `Dockerfile-api` build completed the base-image Python build and tests, then stopped before npm because this arm64 host cannot install the Dockerfile's hardcoded amd64 `tini` package. That architecture mismatch is pre-existing and unrelated to this change.

Original failure:

- https://github.com/Countly/countly-enterprise-plugins/actions/runs/29941618062/job/88998243192
