### PR TITLE
Pin npm 11.18.0 in Docker builds

### DIFF
--- a/Dockerfile-api
+++ b/Dockerfile-api
@@ -55,7 +55,7 @@ RUN curl -s -L -o /tmp/tini.deb "https://github.com/krallin/tini/releases/downlo
 	# preinstall
 	cp -n ./api/config.sample.js ./api/config.js && \
 	cp -n ./frontend/express/config.sample.js ./frontend/express/config.js && \
-	HOME=/tmp npm install -g npm@10 && \
+	HOME=/tmp npm install -g npm@11.18.0 && \
 	HOME=/tmp npm install --unsafe-perm=true --allow-root && \
 	HOME=/tmp npm install argon2 --build-from-source --unsafe-perm=true --allow-root && \
 	./bin/docker/preinstall.sh && \

--- a/Dockerfile-centos-api
+++ b/Dockerfile-centos-api
@@ -59,7 +59,7 @@ RUN curl -s -L -o /tmp/tini.rpm "https://github.com/krallin/tini/releases/downlo
 	# preinstall
 	cp -n ./api/config.sample.js ./api/config.js && \
 	cp -n ./frontend/express/config.sample.js ./frontend/express/config.js && \
-	HOME=/tmp npm install -g npm@10 && \
+	HOME=/tmp npm install -g npm@11.18.0 && \
 	HOME=/tmp npm install --unsafe-perm=true --allow-root && \
 	HOME=/tmp npm install argon2 --build-from-source --unsafe-perm=true --allow-root && \
 	./bin/docker/preinstall.sh && \

--- a/Dockerfile-centos-frontend
+++ b/Dockerfile-centos-frontend
@@ -59,7 +59,7 @@ RUN curl -s -L -o /tmp/tini.rpm "https://github.com/krallin/tini/releases/downlo
 	cp -n ./frontend/express/public/javascripts/countly/countly.config.sample.js ./frontend/express/public/javascripts/countly/countly.config.js && \
 	cp -n ./frontend/express/config.sample.js ./frontend/express/config.js && \
 	cp -n ./api/config.sample.js ./api/config.js && \
-	HOME=/tmp npm install -g npm@10 && \
+	HOME=/tmp npm install -g npm@11.18.0 && \
 	HOME=/tmp npm install --unsafe-perm=true --allow-root && \
 	HOME=/tmp npm install argon2 --build-from-source --unsafe-perm=true --allow-root && \
 	./bin/docker/preinstall.sh && \

--- a/Dockerfile-frontend
+++ b/Dockerfile-frontend
@@ -53,7 +53,7 @@ RUN curl -s -L -o /tmp/tini.deb "https://github.com/krallin/tini/releases/downlo
 	cp -n ./api/config.sample.js ./api/config.js && \
 	cp -n ./frontend/express/config.sample.js ./frontend/express/config.js && \
 	cp -n ./frontend/express/public/javascripts/countly/countly.config.sample.js ./frontend/express/public/javascripts/countly/countly.config.js && \
-	HOME=/tmp npm install -g npm@10 && \
+	HOME=/tmp npm install -g npm@11.18.0 && \
 	HOME=/tmp npm install --unsafe-perm=true --allow-root && \
 	HOME=/tmp npm install argon2 --build-from-source --unsafe-perm=true --allow-root && \
 	./bin/docker/preinstall.sh && \


### PR DESCRIPTION
## What changed

- Replace the floating `npm@10` install with exact `npm@11.18.0`.
- Apply the pin consistently to the Debian and CentOS API/frontend Dockerfiles.

## Why

Master's Docker images use Node 20, which supports npm `11.18.0`. The current `npm@10` range resolves to npm `10.9.8`, whose bundled dependency tree still reports known vulnerabilities, including the critical `node-tar` advisory.

npm `11.18.0`:

- supports Node `^20.17.0 || >=22.9.0`;
- includes patched `tar@7.5.19` and `sigstore@4.1.1`;
- returned zero known vulnerabilities in a clean audit comparison performed on 2026-07-23.

Using an exact version also makes the Docker build reproducible and prevents a future npm major release from being selected unexpectedly.

## Impact

The Docker images retain Node 20 while moving their package manager to the latest compatible, audited npm version.

## Validation

- `git diff --check`
- `docker buildx build --check` for all four changed Dockerfiles
- Installed and ran npm `11.18.0` on `node:iron-bookworm-slim`:
  - Node `v20.20.2`
  - npm `11.18.0`

Companion release branch PR: #7840
