### PR TITLE
fix(events): Sum chart tooltip showing raw floating-point value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 25.03.xx
+Fixes:
+- [events] Fix sum chart tooltip displaying the raw floating-point value instead of a rounded number
+
 ## Version 25.03.50
 Fixes:
 - [star-rating] Fix custom widget logo resolving to the wrong path (mis-detected as the global app logo) after editing a widget

--- a/frontend/express/public/core/events/javascripts/countly.details.models.js
+++ b/frontend/express/public/core/events/javascripts/countly.details.models.js
@@ -10,7 +10,7 @@
             var dur = 0;
             for (var i = 0; i < chartData.length; i++) {
                 graphData[0].push(chartData[i].c ? chartData[i].c : 0);
-                graphData[1].push(chartData[i].s ? chartData[i].s : 0);
+                graphData[1].push(chartData[i].s ? parseFloat(chartData[i].s.toFixed(2)) : 0);
                 let avgDur = (chartData[i].dur || 0) / (chartData[i].c || 1);
                 graphData[2].push(avgDur < 0.1 ? 0 : avgDur);
                 if (chartData[i].c) {
@@ -139,7 +139,7 @@
             var maxLength = eventData.chartData.length > 15 ? 15 : eventData.chartData.length;
             for (var i = 0; i < maxLength; i++) {
                 arrCount.push(eventData.chartData[i].c);
-                arrSum.push(eventData.chartData[i].s);
+                arrSum.push(eventData.chartData[i].s ? parseFloat(eventData.chartData[i].s.toFixed(2)) : eventData.chartData[i].s);
                 arrDuration.push(eventData.chartData[i].dur / (eventData.chartData[i].c || 1));
 
                 xAxisData.push(typeof eventData.chartData[i].curr_segment === 'string' ? countlyAllEvents.helpers.decode(eventData.chartData[i].curr_segment) : eventData.chartData[i].curr_segment);

--- a/frontend/express/public/core/events/javascripts/countly.details.models.js
+++ b/frontend/express/public/core/events/javascripts/countly.details.models.js
@@ -20,8 +20,8 @@
                     dur += chartData[i].dur;
                 }
             }
-            var showSumGraph = graphData[1].some(function(item) {
-                return item !== 0;
+            var showSumGraph = chartData.some(function(item) {
+                return !!item.s; //check raw sums, since tiny non-zero sums round to 0
             });
             var series = [];
             var yAxis = [];
@@ -150,13 +150,8 @@
                     dur += eventData.chartData[i].dur;
                 }
             }
-            var showSumGraph = arrSum.some(function(item) {
-                if (item) { //null, undefined, 0
-                    return true;
-                }
-                else {
-                    return false;
-                }
+            var showSumGraph = eventData.chartData.slice(0, maxLength).some(function(item) {
+                return !!item.s; //check raw sums, since tiny non-zero sums round to 0
             });
             xAxis.data = xAxisData;
             var graphPointsLen = 0;

--- a/frontend/express/public/core/events/javascripts/countly.details.models.js
+++ b/frontend/express/public/core/events/javascripts/countly.details.models.js
@@ -10,7 +10,7 @@
             var dur = 0;
             for (var i = 0; i < chartData.length; i++) {
                 graphData[0].push(chartData[i].c ? chartData[i].c : 0);
-                graphData[1].push(chartData[i].s ? parseFloat(chartData[i].s.toFixed(2)) : 0);
+                graphData[1].push(chartData[i].s ? parseFloat(Number(chartData[i].s).toFixed(2)) : 0);
                 let avgDur = (chartData[i].dur || 0) / (chartData[i].c || 1);
                 graphData[2].push(avgDur < 0.1 ? 0 : avgDur);
                 if (chartData[i].c) {
@@ -139,7 +139,7 @@
             var maxLength = eventData.chartData.length > 15 ? 15 : eventData.chartData.length;
             for (var i = 0; i < maxLength; i++) {
                 arrCount.push(eventData.chartData[i].c);
-                arrSum.push(eventData.chartData[i].s ? parseFloat(eventData.chartData[i].s.toFixed(2)) : eventData.chartData[i].s);
+                arrSum.push(eventData.chartData[i].s ? parseFloat(Number(eventData.chartData[i].s).toFixed(2)) : eventData.chartData[i].s);
                 arrDuration.push(eventData.chartData[i].dur / (eventData.chartData[i].c || 1));
 
                 xAxisData.push(typeof eventData.chartData[i].curr_segment === 'string' ? countlyAllEvents.helpers.decode(eventData.chartData[i].curr_segment) : eventData.chartData[i].curr_segment);

--- a/frontend/express/public/javascripts/countly/countly.common.js
+++ b/frontend/express/public/javascripts/countly/countly.common.js
@@ -2431,7 +2431,7 @@
             }
             else if (number >= 0.1 || number <= -0.1) {
                 number += "";
-                tmpNumber = number.replace(".0", "");
+                tmpNumber = number.replace(/\.0$/, "");
             }
             else {
                 tmpNumber = number + "";


### PR DESCRIPTION
The Events segmentation chart tooltip could show a sum like `303.35999999999996` instead of `303.36`, while the summary tiles/table on the same page correctly rounded it. Root cause: the chart series pushed the raw accumulated float, and the tooltip's default formatter (`getShortNumber`) doesn't round for values in `[0.1, 10000)`.

This rounds the sum series to 2 decimals at construction (matching the existing tile/table convention), and separately fixes a pre-existing bug in `getShortNumber` where `.replace(".0", "")` could corrupt values like `303.06` into `3036` by stripping the first mid-string `.0` instead of only a trailing one.

### Changes

- `countly.details.models.js` — `getLineChartData` and `getBarChartData`: round the `s` (sum) series to 2 decimals when building chart data.
- `countly.details.models.js` — `showSumGraph` in both functions now derives from the **raw** `s` values rather than the rounded series. Without this, buckets whose raw sums all round to `0.00` (e.g. `0.004`) would hide the sum series entirely while the summary tile still showed a non-zero total.
- `countly.common.js` — `getShortNumber`: in the `[0.1, 10000)` branch only, `.replace(".0", "")` → `.replace(/\.0$/, "")`. That branch stringifies the raw float, so the digits after the decimal point are unbounded and a literal `.0` could match mid-string. The `K`/`M`/`B` branches are deliberately left unchanged: they operate on `.toFixed(1)` output, which always has exactly one fractional digit, so `.0` can only ever occur at the end there.

### Verification

Verified against 7 cases (positive/negative sums, whole-number rounding, and the K-abbreviation boundary at 10000) — tooltip, tiles, and count/duration formatting all behave as expected with no regressions. The `showSumGraph` change was separately checked against the original, regressed, and fixed logic across tiny/negative/zero/null sums.
