### PR TITLE
fix(events): show event descriptions for keys with special characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Version 24.05.52
 Fixes:
-- [events] Fixed event descriptions (and custom names / count-sum-dur labels) not showing on the Events page for events whose key contains special characters (`.`, `$`, `\`, `&`, `<`, `>`)
+- [events] Fixed event descriptions (and custom names / count-sum-dur labels) not showing on the Events page for events whose key contains special characters (`.`, `$`, `\`, `&`, `<`, `>`, `"`, `'`)
+
+Enterprise Fixes:
+- [data-manager] Fixed editing an event whose key contains `&` creating undeletable duplicate rows in the events table
 
 ## Version 24.05.51
 Enterprise Fixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 24.05.52
+Fixes:
+- [events] Fixed event descriptions (and custom names / count-sum-dur labels) not showing on the Events page for events whose key contains special characters (`.`, `$`, `\`, `&`, `<`, `>`)
+
 ## Version 24.05.51
 Enterprise Fixes:
 - [data-manager] Fixed bug where event and view transformations occasionally failed to apply to incoming data

--- a/frontend/express/public/core/events/javascripts/countly.details.models.js
+++ b/frontend/express/public/core/events/javascripts/countly.details.models.js
@@ -236,7 +236,8 @@
             return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/<=/g, "&le;").replace(/>=/g, "&ge;");
         },
         getEventLongName: function(eventKey, eventMap) {
-            var mapKey = eventKey.replace(/\\/g, "\\\\").replace(/\$/g, "\\u0024").replace(/\./g, "\\u002e");
+            //events.map is keyed by the raw event key, exactly as it appears in events.list, so do not escape it here
+            var mapKey = eventKey;
             if (eventMap && eventMap[mapKey] && eventMap[mapKey].name) {
                 return eventMap[mapKey].name;
             }
@@ -249,7 +250,8 @@
             var allEvents = context.state.allEventsData;
             var groupData = context.state.groupData.displayMap;
             var eventMap = allEvents.map;
-            var mapKey = context.state.selectedEventName.replace(/\\/g, "\\\\").replace(/\$/g, "\\u0024").replace(/\./g, '\\u002e');
+            //events.map is keyed by the raw event key, exactly as it appears in events.list, so do not escape it here
+            var mapKey = context.state.selectedEventName;
             var countString = (mapKey.startsWith('[CLY]_group') && groupData.c) ? groupData.c : (eventMap && eventMap[mapKey] && eventMap[mapKey].count) ? eventMap[mapKey].count : jQuery.i18n.map["events.table.count"];
             var sumString = (mapKey.startsWith('[CLY]_group') && groupData.s) ? groupData.s : (eventMap && eventMap[mapKey] && eventMap[mapKey].sum) ? eventMap[mapKey].sum : jQuery.i18n.map["events.table.sum"];
             var durString = (mapKey.startsWith('[CLY]_group') && groupData.d) ? groupData.d : (eventMap && eventMap[mapKey] && eventMap[mapKey].dur) ? eventMap[mapKey].dur : jQuery.i18n.map["events.table.dur"];

--- a/frontend/express/public/core/events/javascripts/countly.details.models.js
+++ b/frontend/express/public/core/events/javascripts/countly.details.models.js
@@ -1103,7 +1103,11 @@
                     });
                 }
                 if (value && value.map && typeof value.map === "object") {
-                    var decodedMap = {};
+                    //null prototype: event keys are arbitrary strings, and assigning a
+                    //"__proto__" key on a plain object reparents the map instead of adding
+                    //an own property, which would let unrelated key lookups resolve through
+                    //the assigned value
+                    var decodedMap = Object.create(null);
                     Object.keys(value.map).forEach(function(eventKey) {
                         decodedMap[countlyCommon.unescapeHtml(eventKey)] = value.map[eventKey];
                     });

--- a/frontend/express/public/core/events/javascripts/countly.details.models.js
+++ b/frontend/express/public/core/events/javascripts/countly.details.models.js
@@ -888,9 +888,7 @@
                 return countlyAllEvents.service.fetchAllEventsData(context, period)
                     .then(function(res) {
                         if (res) {
-                            if (Array.isArray(res.list)) {
-                                res.list = res.list.map(eventName => countlyCommon.unescapeHtml(eventName));
-                            }
+                            // setAllEventsData decodes res.list and res.map keys in place
                             context.commit("setAllEventsData", res);
                             if ((!context.state.selectedEventName) || (res.map && res.map[context.state.selectedEventName] && !res.map[context.state.selectedEventName].is_visible) || (res.list && res.list.indexOf(context.state.selectedEventName) === -1)) {
                                 var appId = countlyCommon.ACTIVE_APP_ID;
@@ -1092,6 +1090,25 @@
 
         var allEventsMutations = {
             setAllEventsData: function(state, value) {
+                // The API HTML-escapes every key and value on the way out (common.returnOutput),
+                // but the rest of this store works with raw event keys - selectedEventName is
+                // taken from `list`. Normalise `list` and the `map` keys together here, the one
+                // point both fetch paths commit through, so lookups like map[selectedEventName]
+                // don't silently miss for keys containing & < > " '. Keys without those chars
+                // (dots, dashes) were unaffected, which is why only some events lost their
+                // description on the Events page.
+                if (value && Array.isArray(value.list)) {
+                    value.list = value.list.map(function(eventName) {
+                        return countlyCommon.unescapeHtml(eventName);
+                    });
+                }
+                if (value && value.map && typeof value.map === "object") {
+                    var decodedMap = {};
+                    Object.keys(value.map).forEach(function(eventKey) {
+                        decodedMap[countlyCommon.unescapeHtml(eventKey)] = value.map[eventKey];
+                    });
+                    value.map = decodedMap;
+                }
                 state.allEventsData = value;
             },
             setAllEventsList: function(state, value) {

--- a/plugins/data-manager/frontend/public/javascripts/countly.views.js
+++ b/plugins/data-manager/frontend/public/javascripts/countly.views.js
@@ -696,7 +696,9 @@
                 var isVisible = command === 'visible';
                 var events = [];
                 rows.forEach(function(row) {
-                    events.push(row.key);
+                    // row.key is still API-escaped; change_visibility writes events.map[key]
+                    // directly, so submitting it raw would create a ghost map entry
+                    events.push(countlyCommon.unescapeHtml(row.key));
                 });
                 this.$store.dispatch('countlyDataManager/changeVisibility', { events: events, isVisible: isVisible }).then(function() {
                     countlyEvent.refreshEvents();
@@ -1324,8 +1326,22 @@
             },
             handleEdit: function() {
                 var event = JSON.parse(JSON.stringify(this.event));
-                event.segments = this.segments;
+                event.segments = JSON.parse(JSON.stringify(this.segments));
                 event.isEditMode = true;
+                // The store holds values exactly as the API returned them, and common.returnOutput
+                // HTML-escapes every string on the way out. The events table decodes these before
+                // opening the same drawer (see the 'dm-open-edit-event-drawer' handler) - do the
+                // same here, otherwise a key like "a & b" is submitted back as "a &amp; b" and
+                // forks a second drill_meta doc / events.map entry that shows up as a ghost row.
+                event.key = countlyCommon.unescapeHtml(event.key);
+                event.e = countlyCommon.unescapeHtml(event.e);
+                event.name = countlyCommon.unescapeHtml(event.name);
+                event.description = countlyCommon.unescapeHtml(event.description);
+                event.categoryName = countlyCommon.unescapeHtml(event.categoryName);
+                event.segments = event.segments.map(function(seg) {
+                    seg.name = countlyCommon.unescapeHtml(seg.name);
+                    return seg;
+                });
                 this.openDrawer("events", event);
             },
             handleEditSegment: function(seg) {


### PR DESCRIPTION
## Problem

Event descriptions set in Data Manager render **blank on the Events page** for events whose key contains `.` `$` `\` `&` `<` `>` `"` `'`. Plain keys work, which made the issue look intermittent.

Editing such an event also had a second symptom: an event whose key contains `&` would be saved back as `a &amp; b`, forking a second `drill_meta` / `events.map` entry that shows up as an **undeletable duplicate ("ghost") row** in the Data Manager events table.

## Root cause

Two *independent* escaping bugs that happen to produce the same blank-description symptom:

1. **`.` `$` `\`** — the Events page unicode-escaped the event key (`.` → `.`, `$` → `$`) before looking it up, but `events.map` is keyed **raw**, exactly as the key appears in `events.list`. The lookup missed.

2. **`&` `<` `>` `"` `'`** — `common.returnOutput` → `escape_html(str, true)` HTML-escapes every string **key and value** in every API response. The events store decoded `res.list` but **not** the keys of `res.map`, so `map[selectedEventName]` compared a raw key against an escaped map. `escape_html` only touches charCodes 34/38/39/60/62, so dots and dashes passed through untouched — hence the "only some events" appearance.

The ghost rows come from the same escaping: the event detail page's **Edit event** button and the bulk visibility action read values straight out of the store (i.e. still API-escaped) and submitted them back as-is.

## Changes

**`frontend/express/public/core/events/javascripts/countly.details.models.js`**
- `getEventLongName` / `getLabels`: look the key up **raw** instead of unicode-escaping it.
- `setAllEventsData`: normalize `list` and the `map` **keys** together. This is the one point both fetch paths commit through, so it also fixes `fetchRefreshAllEventsData` never decoding `list` at all. The now-redundant decode in `fetchAllEventsData` is removed.

**`plugins/data-manager/frontend/public/javascripts/countly.views.js`**
- `handleEdit`: decode `key` / `e` / `name` / `description` / `categoryName` and segment names before opening the drawer, and **deep-copy** `segments` (previously assigned by reference, so drawer edits mutated the store).
- `handleChangeVisibility`: decode `row.key` before submitting.

The decode set in `handleEdit` deliberately mirrors the file's existing, already-correct `dm-open-edit-event-drawer` handler, which is the path the events **table** uses to open the very same drawer. The bug was that the detail page's button did not do the same thing.

## Verification

Two harnesses that lift the **real** shipped functions out of the files and run them against a payload built by modelling `escape_html`, so before/after is measured on actual code rather than a re-implementation.

Read path (description resolution, 18 keys incl. dots, `$`, backslash, `&`, `&&`, quotes, apostrophe, angle brackets, `%`, `#`, emoji, accents):

| | before | after |
|---|---|---|
| synthetic set | 12 passed, **6 failed** | **18 passed, 0 failed** |
| dump from a real dev app | — | 6 passed, 0 failed |

The 6 baseline failures were exactly the `&` `<` `>` `"` `'` family.

Write path (ghost rows), 10 keys:

| | before | after |
|---|---|---|
| key submitted intact by `handleEdit` | 4/10 | **10/10** |
| name/description/category intact | 0/10 | **10/10** |
| key submitted intact by `handleChangeVisibility` | 4/10 | **10/10** |

`node --check` and `eslint` clean on both changed files.

## Notes

- `EventsGroupsTabView` has the same raw-`row.key` pattern but is **not** affected: event group ids are `[CLY]_group_` + an md5 hex digest, which cannot contain the escaped characters.
- An additional `events.map` write in the enterprise `/i/data-manager/event/edit` handler was investigated and **dropped** — the drawer fires core `/i/events/edit_map` first and that already persists name/description, so the extra branches were unreachable and added a second whole-map read-modify-write with clobber risk. No enterprise-plugins change is needed for this case.
