### PR TITLE
security(reports): authorize the apps a report targets, on every path that uses them (24.05)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Version 24.05.51
+Fixes:
+- [reports] Non-core reports, such as dashboard reports, now authorize the object they target on create and update
+
 Enterprise Fixes:
 - [data-manager] Fixed bug where event and view transformations occasionally failed to apply to incoming data
 

--- a/plugins/reports/api/api.js
+++ b/plugins/reports/api/api.js
@@ -259,6 +259,24 @@ const FEATURE_NAME = 'reports';
                 //report for arbitrary apps.
                 props.report_type = props.report_type || "core";
 
+                /**
+                 * Insert the authorized report document
+                 * @returns {void}
+                 */
+                function insertReport() {
+                    common.db.collection('reports').insert(props, function(err0, result) {
+                        result = result.ops;
+                        if (err0) {
+                            err0 = err0.err;
+                            common.returnMessage(params, 200, err0);
+                        }
+                        else {
+                            plugins.dispatch("/systemlogs", {params: params, action: "reports_create", data: result[0]});
+                            common.returnMessage(params, 200, "Success");
+                        }
+                    });
+                }
+
                 if (props.report_type === "core") {
                     if (!props.apps || !Array.isArray(props.apps) || props.apps.length === 0) {
                         common.returnMessage(params, 400, 'Invalid or missing apps');
@@ -278,19 +296,22 @@ const FEATURE_NAME = 'reports';
                             return common.returnMessage(params, 401, 'User does not have right to access this information');
                         }
                     }
+                    insertReport();
                 }
-
-                common.db.collection('reports').insert(props, function(err0, result) {
-                    result = result.ops;
-                    if (err0) {
-                        err0 = err0.err;
-                        common.returnMessage(params, 200, err0);
-                    }
-                    else {
-                        plugins.dispatch("/systemlogs", {params: params, action: "reports_create", data: result[0]});
-                        common.returnMessage(params, 200, "Success");
-                    }
-                });
+                else {
+                    //a non-core report targets another plugin's object - a
+                    //"dashboards" report renders the dashboard named in
+                    //props.dashboards - and only that plugin knows whether the
+                    //member may use it. Previously nothing checked this, so any
+                    //member with reports-create rights could schedule a report
+                    //against an arbitrary dashboard id.
+                    validateNonCoreUser(params, props, function(authErr, authorized) {
+                        if (!authorized) {
+                            return common.returnMessage(params, 401, 'User does not have right to access this information');
+                        }
+                        insertReport();
+                    });
+                }
             });
             break;
         case 'update':
@@ -339,35 +360,59 @@ const FEATURE_NAME = 'reports';
                     //treated as a non-core type to skip the per-app check.
                     var effectiveType = props.report_type || report.report_type || "core";
 
-                    if (effectiveType === "core" && typeof props.apps !== "undefined") {
-                        if (!Array.isArray(props.apps) || props.apps.length === 0) {
-                            return common.returnMessage(params, 400, 'Invalid or missing apps');
-                        }
-                        if (!params.member.global_admin) {
-                            let allowedApps = (getAdminApps(params.member) || [])
-                                .concat(getUserAppsForFeaturePermission(params.member, FEATURE_NAME, 'r') || []);
-                            if (typeof params.member.permission === "undefined" && Array.isArray(params.member.user_of)) {
-                                allowedApps = allowedApps.concat(params.member.user_of);
+                    /**
+                     * Apply the authorized update
+                     * @returns {void}
+                     */
+                    function applyUpdate() {
+                        common.db.collection('reports').update(recordUpdateOrDeleteQuery(params, id), {$set: props}, function(err_update2) {
+                            if (err_update2) {
+                                err_update2 = err_update2.err;
+                                common.returnMessage(params, 200, err_update2);
                             }
-                            let notPermitted = props.apps.some(function(appId) {
-                                return allowedApps.indexOf(appId) === -1;
-                            });
-                            if (notPermitted) {
-                                return common.returnMessage(params, 401, 'User does not have right to access this information');
+                            else {
+                                plugins.dispatch("/systemlogs", {params: params, action: "reports_edited", data: {_id: id, before: report, update: props}});
+                                common.returnMessage(params, 200, "Success");
                             }
-                        }
+                        });
                     }
 
-                    common.db.collection('reports').update(recordUpdateOrDeleteQuery(params, id), {$set: props}, function(err_update2) {
-                        if (err_update2) {
-                            err_update2 = err_update2.err;
-                            common.returnMessage(params, 200, err_update2);
+                    if (effectiveType === "core") {
+                        if (typeof props.apps !== "undefined") {
+                            if (!Array.isArray(props.apps) || props.apps.length === 0) {
+                                return common.returnMessage(params, 400, 'Invalid or missing apps');
+                            }
+                            if (!params.member.global_admin) {
+                                let allowedApps = (getAdminApps(params.member) || [])
+                                    .concat(getUserAppsForFeaturePermission(params.member, FEATURE_NAME, 'r') || []);
+                                if (typeof params.member.permission === "undefined" && Array.isArray(params.member.user_of)) {
+                                    allowedApps = allowedApps.concat(params.member.user_of);
+                                }
+                                let notPermitted = props.apps.some(function(appId) {
+                                    return allowedApps.indexOf(appId) === -1;
+                                });
+                                if (notPermitted) {
+                                    return common.returnMessage(params, 401, 'User does not have right to access this information');
+                                }
+                            }
                         }
-                        else {
-                            plugins.dispatch("/systemlogs", {params: params, action: "reports_edited", data: {_id: id, before: report, update: props}});
-                            common.returnMessage(params, 200, "Success");
-                        }
-                    });
+                        applyUpdate();
+                    }
+                    else {
+                        //authorize the merged report, not just the payload: a
+                        //partial update may leave the target (props.dashboards)
+                        //in the stored document, and repointing an existing
+                        //report at another dashboard must be checked too. A copy
+                        //is passed so the authorize flag never reaches $set.
+                        var mergedReport = Object.assign({}, report, props);
+                        mergedReport.report_type = effectiveType;
+                        validateNonCoreUser(params, mergedReport, function(authErr, authorized) {
+                            if (!authorized) {
+                                return common.returnMessage(params, 401, 'User does not have right to access this information');
+                            }
+                            applyUpdate();
+                        });
+                    }
                 });
             });
             break;
@@ -551,40 +596,29 @@ const FEATURE_NAME = 'reports';
     }
 
     /**
-     * validation function for verifing user have permission to access infomation or not for core type of report
+     * Verify the member may use a non-core report's target.
+     *
+     * A non-core report_type names the plugin that owns the report, and that
+     * plugin authorizes the target through the /report/authorize event: the
+     * dashboards plugin checks view access to report.dashboards there. This
+     * fails closed, so a report type whose plugin does not answer the event is
+     * not authorized. A plugin adding a new report type must implement
+     * /report/authorize for it.
+     *
+     * Core reports are authorized inline against the member's per-app reports
+     * permission instead, so they never reach this.
+     *
      * @param {object} params - request params object
-     * @param {object} props  - report related props
-     * @param {func} cb - callback function
-     * @return {func} cb - callback function
-    
-    function validateCoreUser(params, props, cb) {
-        var userApps = getUserApps(params.member);
-        var apps = props.apps;
-        var isAppUser = apps.every(function(app) {
-            return userApps && userApps.indexOf(app) > -1;
-        });
-
-        if (!params.member.global_admin && !isAppUser) {
-            return cb(null, false);
-        }
-        else {
-            return cb(null, true);
-        }
-
-    }
-    */
-
-    /**
-     * validation function for verifing user have permission to access infomation or not for not core type of report
-     * @param {object} params - request params object
-     * @param {object} props  - report related props
-     * @param {func} cb - callback function
-     
+     * @param {object} props - report related props
+     * @param {function} cb - callback receiving (err, authorized)
+     */
     function validateNonCoreUser(params, props, cb) {
         plugins.dispatch("/report/authorize", { params: params, report: props }, function() {
             var authorized = props.authorized || false;
+            //the flag is only how the dispatch reports its result back; it must
+            //not be persisted onto the report document
+            delete props.authorized;
             cb(null, authorized);
         });
     }
-    */
 }());

--- a/plugins/reports/api/api.js
+++ b/plugins/reports/api/api.js
@@ -226,6 +226,39 @@ const FEATURE_NAME = 'reports';
             return query;
         };
 
+        /**
+         * Whether the member may use a report covering every app in a list.
+         *
+         * The same allow-list the create and update paths build inline, extracted so the
+         * paths below can share it rather than repeat it. An empty or absent list is
+         * permitted: a non-core report legitimately has no apps, and its target is
+         * authorized by its own plugin through /report/authorize instead.
+         *
+         * Legacy members have no permission object and reach apps through user_of, so
+         * they are allowed for those, matching /o/reports/all.
+         *
+         * @param {object} params - request params object, for member and global_admin
+         * @param {Array} apps - app ids the report covers
+         * @returns {boolean} true when every app is permitted
+         */
+        const appsArePermitted = function(params, apps) {
+            if (params.member.global_admin) {
+                return true;
+            }
+            if (!Array.isArray(apps) || apps.length === 0) {
+                return true;
+            }
+            let allowedApps = (getAdminApps(params.member) || [])
+                .concat(getUserAppsForFeaturePermission(params.member, FEATURE_NAME, 'r') || []);
+            if (typeof params.member.permission === "undefined" && Array.isArray(params.member.user_of)) {
+                allowedApps = allowedApps.concat(params.member.user_of);
+            }
+            allowedApps = allowedApps.map(String);
+            return apps.every(function(appId) {
+                return allowedApps.indexOf(appId + "") > -1;
+            });
+        };
+
         switch (paths[3]) {
         case 'create':
             validateCreate(paramsInstance, FEATURE_NAME, function() {
@@ -462,6 +495,16 @@ const FEATURE_NAME = 'reports';
                         return false;
                     }
 
+                    //Owning a report does not mean still being allowed to read the apps
+                    //it covers. Without this check somebody who lost access to an app
+                    //could send themselves that app's figures on demand, which is the
+                    //most direct form of the problem the scheduled path also has.
+                    if (!appsArePermitted(params, result.apps)) {
+                        log.d("Rejected report send: report " + id + " targets apps the caller may not read");
+                        common.returnMessage(params, 401, 'User does not have right to access this information');
+                        return false;
+                    }
+
                     reports.sendReport(common.db, id, function(err2) {
                         if (err2) {
                             log.d("Error occurred while sending out report.", err);
@@ -494,6 +537,15 @@ const FEATURE_NAME = 'reports';
 
                     // TODO: Handle report type check
 
+                    //renders the report's contents straight into the response, so the
+                    //apps it covers have to be readable by the caller now, not merely
+                    //at the time they created it
+                    if (!appsArePermitted(params, result.apps)) {
+                        log.d("Rejected report preview: report " + id + " targets apps the caller may not read");
+                        common.returnMessage(params, 401, 'User does not have right to access this information');
+                        return false;
+                    }
+
                     reports.getReport(common.db, result, function(err2, res) {
                         if (err2) {
                             common.returnMessage(params, 200, err2);
@@ -513,11 +565,53 @@ const FEATURE_NAME = 'reports';
             });
             break;
         case 'status':
-            validateUpdate(paramsInstance, FEATURE_NAME, function() {
+            validateUpdate(paramsInstance, FEATURE_NAME, async function() {
                 var params = paramsInstance;
                 const statusList = params.qstring.args;
 
-                console.log(statusList, 'status-list');
+                //Owning a report is not the same as being allowed to act on the apps it
+                //targets, so enabling one is authorized against its *stored* apps.
+                //Without this, somebody who lost access to an app could switch their old
+                //report back on and keep that app's figures arriving by email.
+                //
+                //Switching one off stays allowed. It only reduces what the report does,
+                //and refusing would leave them unable to stop mail they no longer want.
+                const enablingIds = Object.keys(statusList || {}).filter(function(id) {
+                    return statusList[id] === true || statusList[id] === "true";
+                });
+                if (enablingIds.length > 0 && !params.member.global_admin) {
+                    let toEnable = [];
+                    try {
+                        //scoped to records the caller may modify, the same as the write
+                        //below. An id belonging to somebody else must stay the silent
+                        //no-op it already was, rather than returning a 403 that would
+                        //confirm a report with those apps exists.
+                        toEnable = await common.db.collection("reports").find({
+                            _id: {
+                                $in: enablingIds.map(function(id) {
+                                    return common.db.ObjectID(id);
+                                })
+                            },
+                            user: common.db.ObjectID(params.member._id)
+                        }, { projection: { apps: 1 } }).toArray();
+                    }
+                    catch (e) {
+                        log.e("Failed to load reports for a status change", e);
+                        common.returnMessage(params, 500, "Failed to change report status");
+                        return;
+                    }
+                    const unauthorized = toEnable.filter(function(report) {
+                        return !appsArePermitted(params, report.apps);
+                    });
+                    if (unauthorized.length > 0) {
+                        log.d("Rejected report status change: report(s) "
+                            + unauthorized.map(function(r) {
+                                return r._id;
+                            }).join(", ") + " target apps the caller may not read");
+                        common.returnMessage(params, 401, 'User does not have right to access this information');
+                        return;
+                    }
+                }
 
                 var bulk = common.db.collection("reports").initializeUnorderedBulkOp();
                 for (const id in statusList) {

--- a/plugins/reports/api/api.js
+++ b/plugins/reports/api/api.js
@@ -245,7 +245,16 @@ const FEATURE_NAME = 'reports';
             if (params.member.global_admin) {
                 return true;
             }
-            if (!Array.isArray(apps) || apps.length === 0) {
+            if (typeof apps === "undefined" || apps === null) {
+                return true;
+            }
+            //a value that is not a list cannot be authorized app by app. Passing it
+            //through as if it were "no apps" let a non-core report store an unchecked
+            //list, which an update flipping report_type to "core" then started using.
+            if (!Array.isArray(apps)) {
+                return false;
+            }
+            if (apps.length === 0) {
                 return true;
             }
             let allowedApps = (getAdminApps(params.member) || [])
@@ -270,6 +279,10 @@ const FEATURE_NAME = 'reports';
                 props.day = (props.day) ? parseInt(props.day) : 0;
                 props.timezone = props.timezone || "Etc/GMT";
                 props.user = params.member._id;
+                //authorized is how /report/authorize reports its result back, so the
+                //request must not be able to supply one: it would both answer the
+                //non-core check for the caller and be written onto the report below
+                delete props.authorized;
 
                 if (props.frequency !== "weekly") {
                     if (props.frequency !== "monthly") {
@@ -310,24 +323,23 @@ const FEATURE_NAME = 'reports';
                     });
                 }
 
+                //apps is authorized whatever the report type. It used to be checked
+                //only for core reports, so a non-core report could be stored with an
+                //arbitrary apps list, and a later update flipping report_type to "core"
+                //would start using that list without it ever having been checked. The
+                //dashboards drawer hides the app picker, so a legitimate non-core report
+                //carries an empty apps and is unaffected by this.
+                if (typeof props.apps !== "undefined" && props.apps !== null && !Array.isArray(props.apps)) {
+                    return common.returnMessage(params, 400, 'Invalid apps');
+                }
+                if (!appsArePermitted(params, props.apps)) {
+                    return common.returnMessage(params, 401, 'User does not have right to access this information');
+                }
+
                 if (props.report_type === "core") {
                     if (!props.apps || !Array.isArray(props.apps) || props.apps.length === 0) {
                         common.returnMessage(params, 400, 'Invalid or missing apps');
                         return;
-                    }
-
-                    if (!params.member.global_admin) {
-                        let allowedApps = (getAdminApps(params.member) || [])
-                            .concat(getUserAppsForFeaturePermission(params.member, FEATURE_NAME, 'r') || []);
-                        if (typeof params.member.permission === "undefined" && Array.isArray(params.member.user_of)) {
-                            allowedApps = allowedApps.concat(params.member.user_of);
-                        }
-                        let notPermitted = props.apps.some(function(appId) {
-                            return allowedApps.indexOf(appId) === -1;
-                        });
-                        if (notPermitted) {
-                            return common.returnMessage(params, 401, 'User does not have right to access this information');
-                        }
                     }
                     insertReport();
                 }
@@ -359,6 +371,9 @@ const FEATURE_NAME = 'reports';
                 //scheduled sender fall back to a global admin and render the
                 //report (e.g. a dashboard) with elevated access
                 delete props.user;
+                //see create: the authorize flag comes back through the object passed to
+                //the dispatch, so a submitted one must reach neither that nor $set
+                delete props.authorized;
                 if (props.frequency !== "daily" && props.frequency !== "weekly" && props.frequency !== "monthly") {
                     delete props.frequency;
                 }
@@ -410,24 +425,22 @@ const FEATURE_NAME = 'reports';
                         });
                     }
 
+                    //Authorize the apps the report will actually have, which is the
+                    //submitted list when one is sent and the stored list otherwise.
+                    //Checking only the submitted list let an update omit apps to keep a
+                    //stored list that was never checked, and flip report_type to "core"
+                    //so that list started being used.
+                    if (typeof props.apps !== "undefined" && props.apps !== null && !Array.isArray(props.apps)) {
+                        return common.returnMessage(params, 400, 'Invalid apps');
+                    }
+                    var effectiveApps = (typeof props.apps !== "undefined") ? props.apps : report.apps;
+                    if (!appsArePermitted(params, effectiveApps)) {
+                        return common.returnMessage(params, 401, 'User does not have right to access this information');
+                    }
+
                     if (effectiveType === "core") {
-                        if (typeof props.apps !== "undefined") {
-                            if (!Array.isArray(props.apps) || props.apps.length === 0) {
-                                return common.returnMessage(params, 400, 'Invalid or missing apps');
-                            }
-                            if (!params.member.global_admin) {
-                                let allowedApps = (getAdminApps(params.member) || [])
-                                    .concat(getUserAppsForFeaturePermission(params.member, FEATURE_NAME, 'r') || []);
-                                if (typeof params.member.permission === "undefined" && Array.isArray(params.member.user_of)) {
-                                    allowedApps = allowedApps.concat(params.member.user_of);
-                                }
-                                let notPermitted = props.apps.some(function(appId) {
-                                    return allowedApps.indexOf(appId) === -1;
-                                });
-                                if (notPermitted) {
-                                    return common.returnMessage(params, 401, 'User does not have right to access this information');
-                                }
-                            }
+                        if (typeof props.apps !== "undefined" && (!Array.isArray(props.apps) || props.apps.length === 0)) {
+                            return common.returnMessage(params, 400, 'Invalid or missing apps');
                         }
                         applyUpdate();
                     }
@@ -505,10 +518,17 @@ const FEATURE_NAME = 'reports';
                         return false;
                     }
 
-                    reports.sendReport(common.db, id, function(err2) {
+                    reports.sendReport(common.db, id, function(err2, res2, skipped) {
                         if (err2) {
-                            log.d("Error occurred while sending out report.", err);
+                            log.d("Error occurred while sending out report.", err2);
                             common.returnMessage(params, 200, err2);
+                        }
+                        else if (skipped) {
+                            //deliberately not sent: the member the report is scheduled as
+                            //may no longer read the apps it covers. Saying "Success" here
+                            //would report an email that never went out.
+                            log.d("Report " + id + " was not sent: its owner may no longer read the apps it covers");
+                            common.returnMessage(params, 200, "Report not sent: its owner no longer has access to the apps it covers");
                         }
                         else {
                             common.returnMessage(params, 200, "Success");
@@ -567,7 +587,24 @@ const FEATURE_NAME = 'reports';
         case 'status':
             validateUpdate(paramsInstance, FEATURE_NAME, async function() {
                 var params = paramsInstance;
-                const statusList = params.qstring.args;
+                const statusList = (params.qstring.args && typeof params.qstring.args === "object") ? params.qstring.args : {};
+
+                /**
+                 * The enabled state a status change asks for, as a strict boolean.
+                 *
+                 * The authorization below and the write further down have to read the
+                 * request the same way. The sender only tests `enabled + "" !== "false"`,
+                 * so a truthy value that is not exactly true - a 1, say - would leave the
+                 * report enabled while skipping the authorization, which is the whole
+                 * point of it. Anything else is stored as false, and switching a report
+                 * off needs no authorization.
+                 *
+                 * @param {*} value - the value submitted for one report id
+                 * @returns {boolean} true when the change asks for the report to be enabled
+                 */
+                function asksToEnable(value) {
+                    return value === true || value === "true" || value === 1 || value === "1";
+                }
 
                 //Owning a report is not the same as being allowed to act on the apps it
                 //targets, so enabling one is authorized against its *stored* apps.
@@ -576,8 +613,9 @@ const FEATURE_NAME = 'reports';
                 //
                 //Switching one off stays allowed. It only reduces what the report does,
                 //and refusing would leave them unable to stop mail they no longer want.
-                const enablingIds = Object.keys(statusList || {}).filter(function(id) {
-                    return statusList[id] === true || statusList[id] === "true";
+                const requestedIds = Object.keys(statusList);
+                const enablingIds = requestedIds.filter(function(id) {
+                    return asksToEnable(statusList[id]);
                 });
                 if (enablingIds.length > 0 && !params.member.global_admin) {
                     let toEnable = [];
@@ -613,21 +651,28 @@ const FEATURE_NAME = 'reports';
                     }
                 }
 
+                //nothing to act on: answer, rather than leaving the request open,
+                //which is what happened while the write below was the only responder
+                if (requestedIds.length === 0) {
+                    common.returnMessage(params, 400, 'Invalid or missing args');
+                    return;
+                }
+
                 var bulk = common.db.collection("reports").initializeUnorderedBulkOp();
-                for (const id in statusList) {
+                requestedIds.forEach(function(id) {
                     //scope to records the caller may modify (owner / global
                     //admin); otherwise any report's enabled state could be
                     //toggled by _id alone.
-                    bulk.find(recordUpdateOrDeleteQuery(params, id)).updateOne({ $set: { enabled: statusList[id] } });
-                }
-                if (bulk.length > 0) {
-                    bulk.execute(function(err) {
-                        if (err) {
-                            common.returnMessage(params, 200, err);
-                        }
-                        common.returnMessage(params, 200, "Success");
-                    });
-                }
+                    bulk.find(recordUpdateOrDeleteQuery(params, id)).updateOne({ $set: { enabled: asksToEnable(statusList[id]) } });
+                });
+                bulk.execute(function(err) {
+                    if (err) {
+                        log.e("Failed to change report status", err);
+                        common.returnMessage(params, 200, err);
+                        return;
+                    }
+                    common.returnMessage(params, 200, "Success");
+                });
             });
             break;
         default:
@@ -707,10 +752,17 @@ const FEATURE_NAME = 'reports';
      * @param {function} cb - callback receiving (err, authorized)
      */
     function validateNonCoreUser(params, props, cb) {
+        //the flag is only how the dispatch reports its result back, and props is built
+        //from the request, so a submitted authorized:true has to be cleared before the
+        //dispatch runs. Any path where no plugin overwrites it - an unrecognised report
+        //type, a disabled plugin, the dashboards handler's missing-dashboard and error
+        //paths - would otherwise read the caller's own value and fail open, which is
+        //what this check exists to prevent.
+        delete props.authorized;
         plugins.dispatch("/report/authorize", { params: params, report: props }, function() {
-            var authorized = props.authorized || false;
-            //the flag is only how the dispatch reports its result back; it must
-            //not be persisted onto the report document
+            //only an explicit true from a plugin that recognised the type authorizes
+            var authorized = props.authorized === true;
+            //and it must not be persisted onto the report document either
             delete props.authorized;
             cb(null, authorized);
         });

--- a/plugins/reports/api/jobs/send.js
+++ b/plugins/reports/api/jobs/send.js
@@ -80,7 +80,9 @@ class ReportsJob extends job.Job {
                                     });
                                 }
                                 else {
-                                    log.d(err2, ob.report);
+                                    //getReport reports some failures with the error
+                                    //alone, so ob is not always there to log from
+                                    log.d(err2, ob && ob.report);
                                     done(null, null);
                                 }
                             }, cache);

--- a/plugins/reports/api/jobs/send.js
+++ b/plugins/reports/api/jobs/send.js
@@ -60,20 +60,31 @@ class ReportsJob extends job.Job {
                         if (report.last_sent && report.last_sent.hour === hour && report.last_sent.dow === dow && report.last_sent.dom === dom) {
                             return done();
                         }
-                        reports.getReport(countlyDb, report, function(err2, ob) {
-                            if (!err2) {
-                                reports.send(ob.report, ob.message, function() {
-                                    log.d("sent to", ob.report.emails);
-                                    countlyDb.collection("reports").updateOne({_id: countlyDb.ObjectID(report._id)}, {$set: {last_sent: {hour: hour, dow: dow, dom: dom}}}, function() {
-                                        done(null, null);
+                        //An app's figures must not keep arriving by email once the member
+                        //the report is scheduled as can no longer read that app. Nothing
+                        //re-checked this after a report was enabled, so one created
+                        //before access was revoked went on sending indefinitely.
+                        //last_sent is deliberately not stamped when a report is skipped,
+                        //so it resumes on its own if the owner's access is restored.
+                        reports.ownerMayStillSend(countlyDb, report, function(maySend) {
+                            if (!maySend) {
+                                return done(null, null);
+                            }
+                            reports.getReport(countlyDb, report, function(err2, ob) {
+                                if (!err2) {
+                                    reports.send(ob.report, ob.message, function() {
+                                        log.d("sent to", ob.report.emails);
+                                        countlyDb.collection("reports").updateOne({_id: countlyDb.ObjectID(report._id)}, {$set: {last_sent: {hour: hour, dow: dow, dom: dom}}}, function() {
+                                            done(null, null);
+                                        });
                                     });
-                                });
-                            }
-                            else {
-                                log.d(err2, ob.report);
-                                done(null, null);
-                            }
-                        }, cache);
+                                }
+                                else {
+                                    log.d(err2, ob.report);
+                                    done(null, null);
+                                }
+                            }, cache);
+                        });
                     }
                     else {
                         done(null, null);

--- a/plugins/reports/api/reports.js
+++ b/plugins/reports/api/reports.js
@@ -16,7 +16,10 @@ var reportsInstance = {},
     versionInfo = require('../../../frontend/express/version.info'),
     countlyConfig = require('../../../frontend/express/config.js'),
     countlyApiConfig = require('./../../../api/config', 'dont-enclose'),
+    rights = require('../../../api/utils/rights.js'),
     pdf = require('../../../api/utils/pdf');
+
+const FEATURE_NAME = 'reports';
 
 countlyConfig.passwordSecret || "";
 
@@ -61,23 +64,117 @@ var metricProps = {
 };
 (function(reports) {
     let _periodObj = null;
+    /**
+     * Whether the member a report is scheduled as may still read every app it covers.
+     *
+     * The endpoints authorize a request, but nothing re-checked anything once a report
+     * was scheduled, so one created before access was revoked kept mailing that app's
+     * figures indefinitely with no further action by anybody.
+     *
+     * A report with no apps is a non-core report (a dashboard, say), whose target is
+     * authorized by its own plugin through /report/authorize rather than per app, so
+     * there is nothing to judge here and it passes.
+     *
+     * @param {object} member - the member the report is scheduled as
+     * @param {Array} apps - app ids the report covers
+     * @returns {boolean} true when the report may still be sent
+     */
+    function ownerMayStillReadApps(member, apps) {
+        if (!member) {
+            return false;
+        }
+        if (member.global_admin) {
+            return true;
+        }
+        if (!Array.isArray(apps) || apps.length === 0) {
+            return true;
+        }
+        //members created before the permission object reach apps through user_of, and
+        //the right helpers fall through to admin_of alone, so without this their
+        //reports would stop arriving
+        const legacy = (typeof member.permission === "undefined" && Array.isArray(member.user_of))
+            ? member.user_of.map(String)
+            : [];
+        return apps.every(function(appId) {
+            return rights.hasReadRight(FEATURE_NAME, appId + "", member) || legacy.indexOf(appId + "") > -1;
+        });
+    }
+
+    /**
+     * Whether a stored report may still be sent, judged by its owner's current access.
+     *
+     * Used by both the scheduled job and the send-now path, which reach the renderer by
+     * different routes and would otherwise disagree.
+     *
+     * @param {object} db - database connection
+     * @param {object} report - the stored report
+     * @param {function} cb - cb(maySend), called with false when it must not be sent
+     * @returns {void}
+     */
+    reports.ownerMayStillSend = function(db, report, cb) {
+        if (!report) {
+            return cb(false);
+        }
+        db.collection('members').findOne({_id: db.ObjectID(report.user + "")}, function(memberErr, owner) {
+            if (memberErr) {
+                log.e("Could not resolve the owner of report " + report._id + ", not sending", memberErr);
+                return cb(false);
+            }
+            //an owner that no longer exists is left to getReport, which falls back to a
+            //global admin. That fallback predates this check and silently raises the
+            //access a report renders with, but changing it here would stop reports that
+            //have worked for years, so it is left alone and only noted.
+            if (!owner) {
+                log.w("Report " + report._id + " has no resolvable owner, so its access cannot be checked. Sending anyway.");
+                return cb(true);
+            }
+            if (!ownerMayStillReadApps(owner, report.apps)) {
+                log.d("Not sending report " + report._id + ": its owner no longer has access to the apps it covers");
+                return cb(false);
+            }
+            cb(true);
+        });
+    };
+
     reports.sendReport = function(db, id, callback) {
         reports.loadReport(db, id, function(err, report) {
             if (err) {
                 return callback(err, null);
             }
-            reports.getReport(db, report, function(err2, ob) {
-                if (!err2) {
-                    reports.send(ob.report, ob.message, function() {
-                        if (callback) {
-                            callback(err2, ob.message);
-                        }
-                    });
+            if (!report) {
+                return callback("Report not found", null);
+            }
+            //Do not keep mailing an app's figures to somebody who may no longer read it.
+            //Checked here rather than in getReport, so that preview keeps being judged
+            //against the caller making the request instead.
+            reports.ownerMayStillSend(db, report, function(maySend) {
+                if (!maySend) {
+                    return callback(null, null);
                 }
-                else if (callback) {
-                    callback(err2, ob.message);
-                }
+                reports.sendLoadedReport(db, report, callback);
             });
+        });
+    };
+
+    /**
+     * Render and send a report that has already been loaded and authorized.
+     * @param {object} db - database connection
+     * @param {object} report - the stored report
+     * @param {function} callback - callback
+     * @returns {void}
+     */
+    reports.sendLoadedReport = function(db, report, callback) {
+        reports.getReport(db, report, function(err2, ob) {
+            if (!err2) {
+                reports.send(ob.report, ob.message, function() {
+                    if (callback) {
+                        callback(err2, ob.message);
+                    }
+                });
+            }
+            else if (callback) {
+                callback(err2, ob.message);
+            }
         });
     };
 

--- a/plugins/reports/api/reports.js
+++ b/plugins/reports/api/reports.js
@@ -86,7 +86,16 @@ var metricProps = {
         if (member.global_admin) {
             return true;
         }
-        if (!Array.isArray(apps) || apps.length === 0) {
+        if (typeof apps === "undefined" || apps === null) {
+            return true;
+        }
+        //a value that is not a list is not a list of no apps either: it cannot be
+        //authorized app by app, so it must not be sent rather than pass as empty
+        if (!Array.isArray(apps)) {
+            log.d("Not sending a report whose apps is not a list");
+            return false;
+        }
+        if (apps.length === 0) {
             return true;
         }
         //members created before the permission object reach apps through user_of, and
@@ -149,7 +158,11 @@ var metricProps = {
             //against the caller making the request instead.
             reports.ownerMayStillSend(db, report, function(maySend) {
                 if (!maySend) {
-                    return callback(null, null);
+                    //not an error, but not a send either. Reported as a third argument
+                    //so /i/reports/send does not answer "Success" for a report it
+                    //deliberately did not send, while existing callers that only read
+                    //(err, res) keep working unchanged.
+                    return callback(null, null, true);
                 }
                 reports.sendLoadedReport(db, report, callback);
             });
@@ -173,7 +186,9 @@ var metricProps = {
                 });
             }
             else if (callback) {
-                callback(err2, ob.message);
+                //getReport reports some failures with the error alone, so there is not
+                //always a second argument to read a message off
+                callback(err2, ob && ob.message);
             }
         });
     };

--- a/plugins/reports/api/reports.js
+++ b/plugins/reports/api/reports.js
@@ -120,13 +120,13 @@ var metricProps = {
                 log.e("Could not resolve the owner of report " + report._id + ", not sending", memberErr);
                 return cb(false);
             }
-            //an owner that no longer exists is left to getReport, which falls back to a
-            //global admin. That fallback predates this check and silently raises the
-            //access a report renders with, but changing it here would stop reports that
-            //have worked for years, so it is left alone and only noted.
+            //A deleted account holds access to nothing, so the same rule applies: stop
+            //sending. getReport still falls back to a global admin when it cannot resolve
+            //the owner, which is what preview and pdf rely on, but that fallback must not
+            //be the thing that keeps an app's figures being mailed out.
             if (!owner) {
-                log.w("Report " + report._id + " has no resolvable owner, so its access cannot be checked. Sending anyway.");
-                return cb(true);
+                log.d("Owner of report " + report._id + " no longer exists, not sending");
+                return cb(false);
             }
             if (!ownerMayStillReadApps(owner, report.apps)) {
                 log.d("Not sending report " + report._id + ": its owner no longer has access to the apps it covers");

--- a/plugins/reports/tests.js
+++ b/plugins/reports/tests.js
@@ -337,6 +337,7 @@ describe('Testing Reports non-core authorization', function() {
     var sharedDashIdForCleanup = "";
     var memberApiKey = "";
     var memberUserId = "";
+    var VICTIM_APP_ID = "";
     var uniq = Date.now();
 
     /**
@@ -404,6 +405,20 @@ describe('Testing Reports non-core authorization', function() {
             });
     });
 
+    it('should create a second app the member has no rights on', function(done) {
+        request.get('/i/apps/create?api_key=' + API_KEY_ADMIN
+            + '&args=' + encodeURIComponent(JSON.stringify({name: "reportsVictim" + uniq, country: "TR", type: "mobile", category: "6", timezone: "Europe/Istanbul"})))
+            .expect(200)
+            .end(function(err, res) {
+                if (err) {
+                    return done(err);
+                }
+                VICTIM_APP_ID = res.body._id;
+                should.exist(VICTIM_APP_ID);
+                done();
+            });
+    });
+
     it('should reject a dashboards report for a dashboard the member cannot view', function(done) {
         request.get('/i/reports/create?api_key=' + memberApiKey + '&app_id=' + APP_ID
             + '&args=' + encodeURIComponent(JSON.stringify(dashboardReport(adminDashboardId))))
@@ -433,6 +448,65 @@ describe('Testing Reports non-core authorization', function() {
                         }
                         r.body.should.have.property('result', 'Success');
                         done();
+                    });
+            });
+    });
+
+    it('should refuse a non-core report naming an app the member cannot read', function(done) {
+        // apps used to be authorized only for core reports, so a non-core report could
+        // carry any apps list at all
+        var sneaky = Object.assign({}, dashboardReport(memberDashboardId), {apps: [VICTIM_APP_ID]});
+        request.get('/i/reports/create?api_key=' + memberApiKey + '&app_id=' + APP_ID
+            + '&args=' + encodeURIComponent(JSON.stringify(sneaky)))
+            .expect(401)
+            .end(function(err) {
+                if (err) {
+                    return done(err);
+                }
+                done();
+            });
+    });
+
+    it('should refuse to convert a stored report onto an app the member cannot read', function(done) {
+        // the second half of the chain: store apps while the type is non-core, then flip
+        // report_type to core with apps omitted so the stored list survives unchecked
+        var report = Object.assign({}, dashboardReport(memberDashboardId), {title: "convert-" + uniq});
+        request.get('/i/reports/create?api_key=' + memberApiKey + '&app_id=' + APP_ID
+            + '&args=' + encodeURIComponent(JSON.stringify(report)))
+            .expect(200)
+            .end(function(err) {
+                if (err) {
+                    return done(err);
+                }
+                request.get('/o/reports/all?api_key=' + memberApiKey + '&app_id=' + APP_ID)
+                    .expect(200)
+                    .end(function(e, r) {
+                        if (e) {
+                            return done(e);
+                        }
+                        var created = (r.body || []).filter(function(x) {
+                            return x.title === "convert-" + uniq;
+                        })[0];
+                        should.exist(created);
+                        // an admin plants the unauthorized apps list directly, standing in
+                        // for the first half of the chain now that create refuses it
+                        request.get('/i/reports/update?api_key=' + API_KEY_ADMIN + '&app_id=' + APP_ID
+                            + '&args=' + encodeURIComponent(JSON.stringify({_id: created._id, apps: [VICTIM_APP_ID]})))
+                            .expect(200)
+                            .end(function(e1) {
+                                if (e1) {
+                                    return done(e1);
+                                }
+                                request.get('/i/reports/update?api_key=' + memberApiKey + '&app_id=' + APP_ID
+                                    + '&args=' + encodeURIComponent(JSON.stringify({_id: created._id, report_type: "core"})))
+                                    .expect(401)
+                                    .end(function(e2) {
+                                        if (e2) {
+                                            return done(e2);
+                                        }
+                                        done();
+                                    });
+                            });
                     });
             });
     });
@@ -484,6 +558,48 @@ describe('Testing Reports non-core authorization', function() {
             });
     });
 
+    it('should refuse a non-core report that supplies its own authorize flag', function(done) {
+        // authorized is only how /report/authorize reports its result back, and it was
+        // read after the dispatch without being cleared first. The dashboards handler
+        // leaves it untouched when the dashboard cannot be found, and no handler runs at
+        // all for a type no plugin owns, so on both paths a caller could answer the
+        // check for themselves by sending the flag.
+        var missingDashboard = Object.assign({}, dashboardReport("60f0f0f0f0f0f0f0f0f0f0f0"), {authorized: true, title: "forged-a-" + uniq});
+        request.get('/i/reports/create?api_key=' + memberApiKey + '&app_id=' + APP_ID
+            + '&args=' + encodeURIComponent(JSON.stringify(missingDashboard)))
+            .expect(401)
+            .end(function(err) {
+                if (err) {
+                    return done(err);
+                }
+                var unknownType = Object.assign({}, dashboardReport(memberDashboardId), {report_type: "nosuchplugin", authorized: true, title: "forged-b-" + uniq});
+                request.get('/i/reports/create?api_key=' + memberApiKey + '&app_id=' + APP_ID
+                    + '&args=' + encodeURIComponent(JSON.stringify(unknownType)))
+                    .expect(401)
+                    .end(function(e) {
+                        if (e) {
+                            return done(e);
+                        }
+                        done();
+                    });
+            });
+    });
+
+    it('should refuse an apps value that is not a list', function(done) {
+        // a non-array apps was read as "no apps" and stored unchecked, and an update
+        // flipping report_type to core then started using it
+        var odd = Object.assign({}, dashboardReport(memberDashboardId), {apps: {0: VICTIM_APP_ID}, title: "oddapps-" + uniq});
+        request.get('/i/reports/create?api_key=' + memberApiKey + '&app_id=' + APP_ID
+            + '&args=' + encodeURIComponent(JSON.stringify(odd)))
+            .expect(400)
+            .end(function(err) {
+                if (err) {
+                    return done(err);
+                }
+                done();
+            });
+    });
+
     it('should still allow a core report for an app the member has rights on', function(done) {
         var coreReport = Object.assign({}, newReport, {apps: [APP_ID], title: "noncore-core-control-" + uniq});
         request.get('/i/reports/create?api_key=' + memberApiKey + '&app_id=' + APP_ID
@@ -514,6 +630,19 @@ describe('Testing Reports non-core authorization', function() {
                 function cleanupRest() {
                     var dashboards = [adminDashboardId, memberDashboardId, sharedDashIdForCleanup].filter(Boolean);
                     /**
+                     * Delete the second app, if one was created, and finish
+                     * @returns {void}
+                     */
+                    function deleteVictimApp() {
+                        if (!VICTIM_APP_ID) {
+                            return done();
+                        }
+                        request.get('/i/apps/delete?api_key=' + API_KEY_ADMIN + '&args=' + encodeURIComponent(JSON.stringify({app_id: VICTIM_APP_ID})))
+                            .end(function() {
+                                done();
+                            });
+                    }
+                    /**
                      * Delete the dashboards one at a time, then the member
                      * @param {number} i - index into dashboards
                      * @returns {void}
@@ -522,7 +651,7 @@ describe('Testing Reports non-core authorization', function() {
                         if (i >= dashboards.length) {
                             return request.get('/i/users/delete?api_key=' + API_KEY_ADMIN + '&args=' + encodeURIComponent(JSON.stringify({user_ids: [memberUserId]})))
                                 .end(function() {
-                                    done();
+                                    deleteVictimApp();
                                 });
                         }
                         request.get('/i/dashboards/delete?api_key=' + API_KEY_ADMIN + '&dashboard_id=' + dashboards[i])
@@ -699,6 +828,35 @@ describe('Testing Reports after access is revoked', function() {
         status[reportOnA] = true;
         request.get('/i/reports/status?api_key=' + memberApiKey + '&app_id=' + APP_B + '&args=' + encodeURIComponent(JSON.stringify(status)))
             .expect(401)
+            .end(function(err) {
+                if (err) {
+                    return done(err);
+                }
+                done();
+            });
+    });
+
+    it('should refuse to enable the revoked app report with a truthy non-boolean', function(done) {
+        // the authorization matched only true / "true", while the sender treats anything
+        // that is not the string "false" as enabled, so a 1 switched the report back on
+        // without ever being checked
+        var status = {};
+        status[reportOnA] = 1;
+        request.get('/i/reports/status?api_key=' + memberApiKey + '&app_id=' + APP_B + '&args=' + encodeURIComponent(JSON.stringify(status)))
+            .expect(401)
+            .end(function(err) {
+                if (err) {
+                    return done(err);
+                }
+                done();
+            });
+    });
+
+    it('should answer a status change that has nothing to act on', function(done) {
+        // the write was the only thing that answered, so an empty args left the request
+        // open until it timed out
+        request.get('/i/reports/status?api_key=' + memberApiKey + '&app_id=' + APP_B + '&args=' + encodeURIComponent(JSON.stringify({})))
+            .expect(400)
             .end(function(err) {
                 if (err) {
                     return done(err);

--- a/plugins/reports/tests.js
+++ b/plugins/reports/tests.js
@@ -316,3 +316,191 @@ describe('Testing Reports', function() {
     });
 });
 
+
+// Regression tests for authorization of non-core report targets.
+//
+// A non-core report_type names the plugin that owns the report, and that plugin
+// authorizes the target through /report/authorize: the dashboards plugin checks
+// view access to the dashboard a "dashboards" report renders. That caller was
+// commented out, so a member with reports rights could schedule a report against
+// any dashboard id, including a private dashboard belonging to someone else.
+//
+// These go through the real HTTP endpoints with a real non-admin member, so the
+// whole path is exercised: validateCreate, the report_type branch, the
+// /report/authorize dispatch into the dashboards plugin, and the insert.
+
+describe('Testing Reports non-core authorization', function() {
+    var API_KEY_ADMIN = "";
+    var APP_ID = "";
+    var adminDashboardId = "";
+    var memberDashboardId = "";
+    var memberApiKey = "";
+    var memberUserId = "";
+    var uniq = Date.now();
+
+    /**
+     * Build a dashboards-type report config
+     * @param {string} dashboardId - dashboard the report renders
+     * @returns {object} report config
+     */
+    function dashboardReport(dashboardId) {
+        return {
+            title: "noncore-authz-" + uniq,
+            report_type: "dashboards",
+            dashboards: dashboardId,
+            emails: ["a@abc.com"],
+            frequency: "daily",
+            timezone: "Europe/Tirane",
+            hour: 4,
+            minute: 0,
+            sendPdf: true
+        };
+    }
+
+    it('should create a private dashboard as admin', function(done) {
+        API_KEY_ADMIN = testUtils.get("API_KEY_ADMIN");
+        APP_ID = testUtils.get("APP_ID");
+        request.get('/i/dashboards/create?api_key=' + API_KEY_ADMIN + '&name=ReportsPrivateDash' + uniq + '&share_with=none')
+            .expect(200)
+            .end(function(err, res) {
+                if (err) {
+                    return done(err);
+                }
+                adminDashboardId = JSON.parse(res.text);
+                should.exist(adminDashboardId);
+                done();
+            });
+    });
+
+    it('should create a non-admin member with reports rights on the test app', function(done) {
+        var permission = {
+            _: {a: [], u: [[APP_ID]]},
+            c: {},
+            r: {},
+            u: {},
+            d: {}
+        };
+        permission.c[APP_ID] = {all: false, allowed: {reports: true}};
+        permission.r[APP_ID] = {all: false, allowed: {reports: true}};
+        permission.u[APP_ID] = {all: false, allowed: {reports: true}};
+        var userParams = {
+            full_name: "reportsmember" + uniq,
+            username: "reportsmember" + uniq,
+            password: "p4ssw0rD!",
+            email: "reportsmember" + uniq + "@mail.test",
+            permission: permission
+        };
+        request.get('/i/users/create?api_key=' + API_KEY_ADMIN + '&args=' + encodeURIComponent(JSON.stringify(userParams)))
+            .expect(200)
+            .end(function(err, res) {
+                if (err) {
+                    return done(err);
+                }
+                memberApiKey = res.body.api_key;
+                memberUserId = res.body._id;
+                should.exist(memberApiKey);
+                done();
+            });
+    });
+
+    it('should reject a dashboards report for a dashboard the member cannot view', function(done) {
+        request.get('/i/reports/create?api_key=' + memberApiKey + '&app_id=' + APP_ID
+            + '&args=' + encodeURIComponent(JSON.stringify(dashboardReport(adminDashboardId))))
+            .expect(401)
+            .end(function(err) {
+                if (err) {
+                    return done(err);
+                }
+                done();
+            });
+    });
+
+    it('should allow a dashboards report for the member own dashboard', function(done) {
+        request.get('/i/dashboards/create?api_key=' + memberApiKey + '&name=MemberDash' + uniq + '&share_with=none')
+            .expect(200)
+            .end(function(err, res) {
+                if (err) {
+                    return done(err);
+                }
+                memberDashboardId = JSON.parse(res.text);
+                request.get('/i/reports/create?api_key=' + memberApiKey + '&app_id=' + APP_ID
+                    + '&args=' + encodeURIComponent(JSON.stringify(dashboardReport(memberDashboardId))))
+                    .expect(200)
+                    .end(function(e, r) {
+                        if (e) {
+                            return done(e);
+                        }
+                        r.body.should.have.property('result', 'Success');
+                        done();
+                    });
+            });
+    });
+
+    it('should not persist the authorize flag on the stored report', function(done) {
+        request.get('/o/reports/all?api_key=' + memberApiKey + '&app_id=' + APP_ID)
+            .expect(200)
+            .end(function(err, res) {
+                if (err) {
+                    return done(err);
+                }
+                res.body.forEach(function(r) {
+                    r.should.not.have.property('authorized');
+                });
+                done();
+            });
+    });
+
+    it('should still allow a core report for an app the member has rights on', function(done) {
+        var coreReport = Object.assign({}, newReport, {apps: [APP_ID], title: "noncore-core-control-" + uniq});
+        request.get('/i/reports/create?api_key=' + memberApiKey + '&app_id=' + APP_ID
+            + '&args=' + encodeURIComponent(JSON.stringify(coreReport)))
+            .expect(200)
+            .end(function(err, res) {
+                if (err) {
+                    return done(err);
+                }
+                res.body.should.have.property('result', 'Success');
+                done();
+            });
+    });
+
+    after(function(done) {
+        // remove everything this block created: the reports it scheduled, both
+        // dashboards, and the member
+        request.get('/o/reports/all?api_key=' + API_KEY_ADMIN + '&app_id=' + APP_ID)
+            .end(function(listErr, listRes) {
+                var created = ((listRes && listRes.body) || []).filter(function(r) {
+                    return typeof r.title === "string" && r.title.indexOf("" + uniq) > -1;
+                });
+                var pending = created.length;
+                /**
+                 * Delete the dashboards and the member once reports are gone
+                 * @returns {void}
+                 */
+                function cleanupRest() {
+                    request.get('/i/dashboards/delete?api_key=' + API_KEY_ADMIN + '&dashboard_id=' + adminDashboardId)
+                        .end(function() {
+                            request.get('/i/dashboards/delete?api_key=' + API_KEY_ADMIN + '&dashboard_id=' + memberDashboardId)
+                                .end(function() {
+                                    request.get('/i/users/delete?api_key=' + API_KEY_ADMIN + '&args=' + encodeURIComponent(JSON.stringify({user_ids: [memberUserId]})))
+                                        .end(function() {
+                                            done();
+                                        });
+                                });
+                        });
+                }
+                if (!pending) {
+                    return cleanupRest();
+                }
+                created.forEach(function(r) {
+                    request.get('/i/reports/delete?api_key=' + API_KEY_ADMIN + '&app_id=' + APP_ID + '&args=' + encodeURIComponent(JSON.stringify({_id: r._id})))
+                        .end(function() {
+                            pending--;
+                            if (!pending) {
+                                cleanupRest();
+                            }
+                        });
+                });
+            });
+    });
+});

--- a/plugins/reports/tests.js
+++ b/plugins/reports/tests.js
@@ -334,6 +334,7 @@ describe('Testing Reports non-core authorization', function() {
     var APP_ID = "";
     var adminDashboardId = "";
     var memberDashboardId = "";
+    var sharedDashIdForCleanup = "";
     var memberApiKey = "";
     var memberUserId = "";
     var uniq = Date.now();
@@ -436,6 +437,39 @@ describe('Testing Reports non-core authorization', function() {
             });
     });
 
+    it('should allow a dashboards report for a dashboard shared with the member', function(done) {
+        // Dashboard permissions are deliberately separate from app permissions: a
+        // dashboard can be shared with a member who has no access to the apps its
+        // widgets reference, and they are meant to be able to view it and schedule a
+        // report for it. This is the same admin-owned dashboard the member was
+        // refused above, so the only thing that changes here is the share, which is
+        // what proves authorization follows the share and not app rights.
+        var sharedDashboardId = "";
+        request.get('/i/dashboards/create?api_key=' + API_KEY_ADMIN
+            + '&name=ReportsSharedDash' + uniq
+            + '&share_with=selected-users'
+            + '&shared_email_view=' + encodeURIComponent(JSON.stringify(["reportsmember" + uniq + "@mail.test"])))
+            .expect(200)
+            .end(function(err, res) {
+                if (err) {
+                    return done(err);
+                }
+                sharedDashboardId = JSON.parse(res.text);
+                should.exist(sharedDashboardId);
+                request.get('/i/reports/create?api_key=' + memberApiKey + '&app_id=' + APP_ID
+                    + '&args=' + encodeURIComponent(JSON.stringify(dashboardReport(sharedDashboardId))))
+                    .expect(200)
+                    .end(function(e, r) {
+                        if (e) {
+                            return done(e);
+                        }
+                        r.body.should.have.property('result', 'Success');
+                        sharedDashIdForCleanup = sharedDashboardId;
+                        done();
+                    });
+            });
+    });
+
     it('should not persist the authorize flag on the stored report', function(done) {
         request.get('/o/reports/all?api_key=' + memberApiKey + '&app_id=' + APP_ID)
             .expect(200)
@@ -478,16 +512,25 @@ describe('Testing Reports non-core authorization', function() {
                  * @returns {void}
                  */
                 function cleanupRest() {
-                    request.get('/i/dashboards/delete?api_key=' + API_KEY_ADMIN + '&dashboard_id=' + adminDashboardId)
-                        .end(function() {
-                            request.get('/i/dashboards/delete?api_key=' + API_KEY_ADMIN + '&dashboard_id=' + memberDashboardId)
+                    var dashboards = [adminDashboardId, memberDashboardId, sharedDashIdForCleanup].filter(Boolean);
+                    /**
+                     * Delete the dashboards one at a time, then the member
+                     * @param {number} i - index into dashboards
+                     * @returns {void}
+                     */
+                    function deleteDashboard(i) {
+                        if (i >= dashboards.length) {
+                            return request.get('/i/users/delete?api_key=' + API_KEY_ADMIN + '&args=' + encodeURIComponent(JSON.stringify({user_ids: [memberUserId]})))
                                 .end(function() {
-                                    request.get('/i/users/delete?api_key=' + API_KEY_ADMIN + '&args=' + encodeURIComponent(JSON.stringify({user_ids: [memberUserId]})))
-                                        .end(function() {
-                                            done();
-                                        });
+                                    done();
                                 });
-                        });
+                        }
+                        request.get('/i/dashboards/delete?api_key=' + API_KEY_ADMIN + '&dashboard_id=' + dashboards[i])
+                            .end(function() {
+                                deleteDashboard(i + 1);
+                            });
+                    }
+                    deleteDashboard(0);
                 }
                 if (!pending) {
                     return cleanupRest();

--- a/plugins/reports/tests.js
+++ b/plugins/reports/tests.js
@@ -547,3 +547,319 @@ describe('Testing Reports non-core authorization', function() {
             });
     });
 });
+
+
+// Regression tests for what happens to a report after its owner loses access to the app
+// it covers.
+//
+// Owning a report is not the same as being allowed to read the apps it covers, but every
+// one of these paths was scoped by owner alone. So a member who scheduled a report while
+// they held an app, then lost that access while keeping reports rights elsewhere, could
+// still re-enable it, send it to themselves on demand, and render its contents straight
+// into a response.
+//
+// Both directions are covered: the exploit stops working, and everything a member is
+// still entitled to do keeps working.
+describe('Testing Reports after access is revoked', function() {
+    var API_KEY_ADMIN = "";
+    var APP_A = "";
+    var APP_B = "";
+    var memberApiKey = "";
+    var memberId = "";
+    var reportOnA = "";
+    var reportOnB = "";
+    var uniq = Date.now();
+
+    /**
+     * Build a core report config for the given apps
+     * @param {Array} apps - app ids
+     * @param {string} title - report title
+     * @returns {object} report config
+     */
+    function reportFor(apps, title) {
+        return Object.assign({}, newReport, {
+            title: title,
+            apps: apps,
+            emails: ["revoked-" + uniq + "@mail.test"]
+        });
+    }
+
+    /**
+     * Set the member's reports permissions to exactly the given apps
+     * @param {Array} apps - app ids to grant
+     * @param {function} cb - callback
+     * @returns {void}
+     */
+    function grantReportsOn(apps, cb) {
+        var permission = {_: {a: [], u: [apps]}, c: {}, r: {}, u: {}, d: {}};
+        apps.forEach(function(a) {
+            permission.c[a] = {all: false, allowed: {reports: true}};
+            permission.r[a] = {all: false, allowed: {reports: true}};
+            permission.u[a] = {all: false, allowed: {reports: true}};
+            permission.d[a] = {all: false, allowed: {reports: true}};
+        });
+        request.get('/i/users/update?api_key=' + API_KEY_ADMIN + '&args=' + encodeURIComponent(JSON.stringify({user_id: memberId, permission: permission})))
+            .end(function() {
+                cb();
+            });
+    }
+
+    /**
+     * Find one of the member's reports by title
+     * @param {string} title - report title
+     * @param {function} cb - cb(id)
+     * @returns {void}
+     */
+    function findReportIdByTitle(title, cb) {
+        request.get('/o/reports/all?api_key=' + API_KEY_ADMIN + '&app_id=' + APP_A)
+            .end(function(err, res) {
+                var list = (res && res.body) || [];
+                var found = list.filter(function(r) {
+                    return r.title === title;
+                })[0];
+                cb(found && found._id);
+            });
+    }
+
+    it('should set up two apps and a member with reports rights on both', function(done) {
+        API_KEY_ADMIN = testUtils.get("API_KEY_ADMIN");
+        APP_A = testUtils.get("APP_ID");
+        request.get('/i/apps/create?api_key=' + API_KEY_ADMIN + '&args=' + encodeURIComponent(JSON.stringify({name: "revokedAppB" + uniq, country: "TR", type: "mobile", category: "6", timezone: "Europe/Istanbul"})))
+            .expect(200)
+            .end(function(err, res) {
+                if (err) {
+                    return done(err);
+                }
+                APP_B = res.body._id;
+                should.exist(APP_B);
+                var permission = {_: {a: [], u: [[APP_A, APP_B]]}, c: {}, r: {}, u: {}, d: {}};
+                [APP_A, APP_B].forEach(function(a) {
+                    permission.c[a] = {all: false, allowed: {reports: true}};
+                    permission.r[a] = {all: false, allowed: {reports: true}};
+                    permission.u[a] = {all: false, allowed: {reports: true}};
+                    permission.d[a] = {all: false, allowed: {reports: true}};
+                });
+                var userParams = {
+                    full_name: "reportrevoked" + uniq,
+                    username: "reportrevoked" + uniq,
+                    password: "p4ssw0rD!",
+                    email: "reportrevoked" + uniq + "@mail.test",
+                    permission: permission
+                };
+                request.get('/i/users/create?api_key=' + API_KEY_ADMIN + '&args=' + encodeURIComponent(JSON.stringify(userParams)))
+                    .expect(200)
+                    .end(function(e, r) {
+                        if (e) {
+                            return done(e);
+                        }
+                        memberApiKey = r.body.api_key;
+                        memberId = r.body._id;
+                        should.exist(memberApiKey);
+                        done();
+                    });
+            });
+    });
+
+    it('should let the member create a report on each app while they have both', function(done) {
+        request.get('/i/reports/create?api_key=' + memberApiKey + '&app_id=' + APP_A + '&args=' + encodeURIComponent(JSON.stringify(reportFor([APP_A], "revokedA-" + uniq))))
+            .expect(200)
+            .end(function(err) {
+                if (err) {
+                    return done(err);
+                }
+                request.get('/i/reports/create?api_key=' + memberApiKey + '&app_id=' + APP_B + '&args=' + encodeURIComponent(JSON.stringify(reportFor([APP_B], "revokedB-" + uniq))))
+                    .expect(200)
+                    .end(function(e) {
+                        if (e) {
+                            return done(e);
+                        }
+                        findReportIdByTitle("revokedA-" + uniq, function(idA) {
+                            should.exist(idA);
+                            reportOnA = idA + "";
+                            findReportIdByTitle("revokedB-" + uniq, function(idB) {
+                                should.exist(idB);
+                                reportOnB = idB + "";
+                                done();
+                            });
+                        });
+                    });
+            });
+    });
+
+    it('should revoke access to the first app, keeping reports rights on the second', function(done) {
+        grantReportsOn([APP_B], function() {
+            done();
+        });
+    });
+
+    // the exploit
+
+    it('should refuse to enable the revoked app report', function(done) {
+        var status = {};
+        status[reportOnA] = true;
+        request.get('/i/reports/status?api_key=' + memberApiKey + '&app_id=' + APP_B + '&args=' + encodeURIComponent(JSON.stringify(status)))
+            .expect(401)
+            .end(function(err) {
+                if (err) {
+                    return done(err);
+                }
+                done();
+            });
+    });
+
+    it('should refuse to send the revoked app report on demand', function(done) {
+        request.get('/i/reports/send?api_key=' + memberApiKey + '&app_id=' + APP_B + '&args=' + encodeURIComponent(JSON.stringify({_id: reportOnA})))
+            .expect(401)
+            .end(function(err) {
+                if (err) {
+                    return done(err);
+                }
+                done();
+            });
+    });
+
+    it('should refuse to render the revoked app report as a preview', function(done) {
+        // the most direct case: this returns the app's figures in the response body
+        request.get('/i/reports/preview?api_key=' + memberApiKey + '&app_id=' + APP_B + '&args=' + encodeURIComponent(JSON.stringify({_id: reportOnA})))
+            .expect(401)
+            .end(function(err) {
+                if (err) {
+                    return done(err);
+                }
+                done();
+            });
+    });
+
+    it('should not have enabled the report despite the attempts', function(done) {
+        request.get('/o/reports/all?api_key=' + API_KEY_ADMIN + '&app_id=' + APP_A)
+            .expect(200)
+            .end(function(err, res) {
+                if (err) {
+                    return done(err);
+                }
+                var found = ((res.body) || []).filter(function(r) {
+                    return r._id + "" === reportOnA;
+                })[0];
+                should.exist(found);
+                found.enabled.should.not.equal(true);
+                done();
+            });
+    });
+
+    // the happy paths, which have to keep working
+
+    it('should still let the member enable and disable a report on the app they hold', function(done) {
+        var on = {};
+        on[reportOnB] = true;
+        request.get('/i/reports/status?api_key=' + memberApiKey + '&app_id=' + APP_B + '&args=' + encodeURIComponent(JSON.stringify(on)))
+            .expect(200)
+            .end(function(err) {
+                if (err) {
+                    return done(err);
+                }
+                var off = {};
+                off[reportOnB] = false;
+                request.get('/i/reports/status?api_key=' + memberApiKey + '&app_id=' + APP_B + '&args=' + encodeURIComponent(JSON.stringify(off)))
+                    .expect(200)
+                    .end(function(e) {
+                        if (e) {
+                            return done(e);
+                        }
+                        done();
+                    });
+            });
+    });
+
+    it('should still let the member send and preview a report on the app they hold', function(done) {
+        request.get('/i/reports/send?api_key=' + memberApiKey + '&app_id=' + APP_B + '&args=' + encodeURIComponent(JSON.stringify({_id: reportOnB})))
+            .expect(200)
+            .end(function(err) {
+                if (err) {
+                    return done(err);
+                }
+                // asserted as "not refused" rather than a specific status: the preview
+                // renderer on this branch dereferences res.message without checking res,
+                // so a report for an app with no data can fail inside rendering. That is
+                // unrelated to authorization, which is what this test is about.
+                request.get('/i/reports/preview?api_key=' + memberApiKey + '&app_id=' + APP_B + '&args=' + encodeURIComponent(JSON.stringify({_id: reportOnB})))
+                    .end(function(e, res) {
+                        res.status.should.not.equal(401);
+                        done();
+                    });
+            });
+    });
+
+    it('should let the member switch OFF the revoked app report, so they are not stuck with it', function(done) {
+        // deliberately allowed: disabling only reduces what the report does, and refusing
+        // would leave them unable to stop mail they no longer want
+        var off = {};
+        off[reportOnA] = false;
+        request.get('/i/reports/status?api_key=' + memberApiKey + '&app_id=' + APP_B + '&args=' + encodeURIComponent(JSON.stringify(off)))
+            .expect(200)
+            .end(function(err) {
+                if (err) {
+                    return done(err);
+                }
+                done();
+            });
+    });
+
+    it('should let a global admin send and enable any report', function(done) {
+        var on = {};
+        on[reportOnA] = true;
+        request.get('/i/reports/status?api_key=' + API_KEY_ADMIN + '&app_id=' + APP_A + '&args=' + encodeURIComponent(JSON.stringify(on)))
+            .expect(200)
+            .end(function(err) {
+                if (err) {
+                    return done(err);
+                }
+                request.get('/i/reports/send?api_key=' + API_KEY_ADMIN + '&app_id=' + APP_A + '&args=' + encodeURIComponent(JSON.stringify({_id: reportOnA})))
+                    .expect(200)
+                    .end(function(e) {
+                        if (e) {
+                            return done(e);
+                        }
+                        done();
+                    });
+            });
+    });
+
+    it('should let the member delete the revoked app report they own', function(done) {
+        // also deliberately allowed: deleting cannot reach another app's data, and the
+        // owner needs a way to clean up
+        request.get('/i/reports/delete?api_key=' + memberApiKey + '&app_id=' + APP_B + '&args=' + encodeURIComponent(JSON.stringify({_id: reportOnA})))
+            .expect(200)
+            .end(function(err) {
+                if (err) {
+                    return done(err);
+                }
+                done();
+            });
+    });
+
+    after(function(done) {
+        /**
+         * remove the member and the extra app once the reports are gone
+         * @returns {void}
+         */
+        function cleanupRest() {
+            request.get('/i/users/delete?api_key=' + API_KEY_ADMIN + '&args=' + encodeURIComponent(JSON.stringify({user_ids: [memberId]})))
+                .end(function() {
+                    if (!APP_B) {
+                        return done();
+                    }
+                    request.get('/i/apps/delete?api_key=' + API_KEY_ADMIN + '&args=' + encodeURIComponent(JSON.stringify({app_id: APP_B})))
+                        .end(function() {
+                            done();
+                        });
+                });
+        }
+        request.get('/i/reports/delete?api_key=' + API_KEY_ADMIN + '&app_id=' + APP_A + '&args=' + encodeURIComponent(JSON.stringify({_id: reportOnB})))
+            .end(function() {
+                request.get('/i/reports/delete?api_key=' + API_KEY_ADMIN + '&app_id=' + APP_A + '&args=' + encodeURIComponent(JSON.stringify({_id: reportOnA})))
+                    .end(function() {
+                        cleanupRest();
+                    });
+            });
+    });
+});

--- a/plugins/reports/tests.js
+++ b/plugins/reports/tests.js
@@ -709,6 +709,12 @@ describe('Testing Reports after access is revoked', function() {
         return Object.assign({}, newReport, {
             title: title,
             apps: apps,
+            //only a metric the reports plugin resolves itself. Anything it does not own
+            //goes out over /email/report, and when no plugin answers - which is what
+            //star-rating and performance do in the plugin test run - the render sits on
+            //the 30s cancel timeout before giving up. The happy path below renders twice,
+            //once to send and once to preview, which is over mocha's 50s cap.
+            metrics: {analytics: true},
             emails: ["revoked-" + uniq + "@mail.test"]
         });
     }
@@ -899,7 +905,10 @@ describe('Testing Reports after access is revoked', function() {
                     return r._id + "" === reportOnA;
                 })[0];
                 should.exist(found);
-                found.enabled.should.not.equal(true);
+                //a report that was never switched on carries no enabled field at all -
+                //create does not write one - so compare rather than dereference. Reading
+                //.should off undefined turned this into a TypeError instead of a verdict.
+                (found.enabled === true).should.equal(false);
                 done();
             });
     });


### PR DESCRIPTION
Backport of #7864 to `release.24.05`. Applied cleanly; only the CHANGELOG heading needed resolving.

## What changes

`/i/reports/create` and `/i/reports/update` authorized the target apps only when the effective `report_type` was `"core"`. A non-core `report_type` names the plugin that owns the report, and those reports were inserted and updated without any authorization of the object they point at.

The authorization path already existed but was unreachable: the dashboards plugin implements `/report/authorize`, which checks view access to the dashboard a report renders, while the reports-side caller that invoked it (`validateNonCoreUser`) had been commented out.

Restores that caller and gates create and update on its result. Update authorizes the merged stored-plus-payload report, so a partial update cannot leave an unauthorized target in place and repointing an existing report is checked too. A copy is passed so the `authorized` flag never reaches the written document. Fails closed, matching the original intent: a report type whose plugin does not answer the event is not authorized, and only `"dashboards"` implements it today.

Also drops `validateCoreUser`, which was commented out and superseded by the inline per-app check.

## Tests

Real end-to-end coverage through the HTTP endpoints with a real non-admin member: refused for a private dashboard they cannot view, allowed for one they own, the `authorized` flag absent from the stored report, and a core report still succeeding as a control.

Not executed locally, since the harness needs `COUNTLY_TEST_API_KEY_ADMIN` and `COUNTLY_TEST_APP_ID`. CI runs them in `test-api-plugins`.



## Second commit: the paths that were still owner-only

`recordUpdateOrDeleteQuery` adds only `user`, so beyond create and update the remaining paths were scoped by ownership alone. Owning a report is not the same as still being allowed to read the apps it covers. A member who scheduled a report while they held an app, then lost that access while keeping reports rights elsewhere, could:

- re-enable it through `/i/reports/status` and let the schedule resume,
- mail themselves that app's figures on demand through `/i/reports/send`,
- read them straight out of the response through `/i/reports/preview` (and `/i/reports/pdf` where that endpoint exists). This is the most direct of them: no email involved, the figures come back in the HTTP response.

Nothing re-checked anything at send time either, so a report enabled before access was revoked kept mailing indefinitely. The scheduled job calls `reports.getReport` **directly** rather than `sendReport`, so both now consult a shared `reports.ownerMayStillSend`; guarding only `sendReport` would have missed the scheduled path entirely, which is the one that matters most.

Deliberately unchanged, with the reasoning recorded in the code:

- **Disabling** stays allowed. It only reduces what the report does, and refusing would leave someone unable to stop mail they no longer want.
- **Delete** stays owner-only. It cannot reach another app's data, and the owner needs a way to clean up.
- `last_sent` is not stamped when a report is skipped, so it resumes on its own if access is restored.

Reports with no apps pass, because those are non-core reports whose target is authorized by their own plugin through `/report/authorize` rather than per app.

A report whose owner no longer exists also stops being sent. A deleted account holds access to nothing, so the same rule applies to it; the `getReport` global-admin fallback stays where it is, because preview and pdf rely on it and both are authorized against the member making the request, but it no longer decides whether scheduled mail keeps going out. This matches alerts, which already stopped in that case.

Also drops a stray `console.log` of the status payload.

### Worth a look separately

That global-admin fallback for an unresolvable owner quietly *raises* the access a report renders with. `/i/users/delete` removes a departing member's reports, so it should only affect orphaned rows, but I left it alone here rather than change send behaviour inside a security fix.

### Tests for this commit

A suite that revokes a member's access to one app mid-test, covering both directions. The exploit: enable, send and preview are each refused, and the stored report is verified to still be disabled afterwards. The happy paths, which have to keep working: the member can still enable, disable, send and preview reports on the app they do hold, can still switch **off** and delete the revoked-app report, and a global admin is unaffected.

This branch has no `/i/reports/pdf` endpoint, so that guard from #7864 does not apply here. The inline allow-list the create and update paths built is extracted into a shared `appsArePermitted`, matching how master expresses it, rather than repeated three more times.

One test assertion differs from master deliberately: the preview happy path asserts "not 401" rather than a specific status, because this branch renders with `if (params && params.res) { var html = res.message; ... }` and lacks master's `else if (res)` guard, so a report for an app with no data can fail inside rendering. That is unrelated to authorization and is left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

