### PR TITLE
Add Merge Shepherd auto-merge queue workflow

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,4 +1,5 @@
 exclude_paths:
+  - '.github/scripts/**'
   - 'frontend/express/public/javascripts/dom/**'
   - 'frontend/express/public/javascripts/min/**'
   - 'frontend/express/public/javascripts/utils/**'

--- a/.github/scripts/.eslintrc.json
+++ b/.github/scripts/.eslintrc.json
@@ -1,0 +1,13 @@
+{
+    "env": {
+        "node": true,
+        "es2023": true
+    },
+    "parserOptions": {
+        "ecmaVersion": 2023,
+        "sourceType": "script"
+    },
+    "rules": {
+        "no-console": "off"
+    }
+}

--- a/.github/scripts/merge-shepherd.js
+++ b/.github/scripts/merge-shepherd.js
@@ -1,0 +1,972 @@
+'use strict';
+
+/**
+ * Merge Shepherd — opt-in PR merge queue.
+ *
+ * Runs via actions/github-script (see .github/workflows/merge-shepherd.yml).
+ * Pure decision functions (selectBatch, planForBatchMember, parseStateComment,
+ * buildStateCommentBody) are unit-tested in merge-shepherd.test.js; the rest
+ * are thin executors around the GitHub API.
+ */
+
+const CONFIG = {
+    QUEUE_LABEL: 'auto-merge',
+    FAILED_LABEL: 'auto-merge-failed',
+    BATCH_SIZE: 3,
+    MAX_RETRIES: 5,
+    MERGE_METHOD: 'MERGE',
+    STATE_MARKER: 'merge-shepherd-state',
+    // GraphQL CheckRun conclusions that count as a pass for a required check; any other
+    // non-null conclusion (including ones not yet defined by GitHub) counts as a failure
+    PASSING_CHECK_CONCLUSIONS: ['SUCCESS', 'SKIPPED', 'NEUTRAL'],
+};
+
+// Maps a call-site context key to the GitHub App permission(s) that govern it, used to build
+// actionable diagnostics when that call site fails with a permission error.
+const PERMISSION_HINTS = {
+    'preflight-rollup': 'Commit statuses: Read-only and Checks: Read-only (statusCheckRollup)',
+    'preflight-labels': 'Issues: Read & write',
+    'labels': 'Issues: Read & write',
+    'comments': 'Issues: Read & write',
+    'preflight-runs': 'Actions: Read (write is verified at first retry)',
+    'rerun': 'Actions: Read & write',
+    'preflight-contents': 'Contents: Read & write (probe verifies read)',
+    'queue-query': 'Pull requests: Read & write',
+    'automerge': 'Pull requests: Read & write',
+    'update-branch': 'Contents: Read & write',
+    'merge': 'Contents: Read & write',
+    'required-checks': 'Checks: Read-only, Commit statuses: Read-only, Actions: Read (workflow run links), and possibly Administration: Read-only (required-check evaluation)',
+};
+
+// Maps an executed action's type to the permission-hint context key it depends on, used to
+// translate a failed action's error when it turns out to be a permission error. A tagged
+// error's own shepherdContext (see tagContext) always takes precedence over this fallback.
+const ACTION_CONTEXT = {
+    'enable-automerge': 'automerge',
+    'merge': 'merge',
+    'update-branch': 'update-branch',
+    'retry': 'rerun',
+    'eject': 'labels',
+};
+
+/**
+ * Detects whether an error indicates a missing GitHub App permission
+ * @param {*} err - error thrown by an octokit call (REST or GraphQL)
+ * @returns {boolean} true when the error looks like a missing-permission failure
+ */
+function isPermissionError(err) {
+    if (!err) {
+        return false;
+    }
+    if (err.status === 403) {
+        return true;
+    }
+    if (typeof err.message === 'string' && /resource not accessible/i.test(err.message)) {
+        return true;
+    }
+    if (Array.isArray(err.errors)) {
+        return err.errors.some((e) => e && (e.type === 'FORBIDDEN' || (typeof e.message === 'string' && /resource not accessible/i.test(e.message))));
+    }
+    return false;
+}
+
+/**
+ * Builds an actionable message for a permission error in a given context
+ * @param {string} contextKey - which call site the error came from (see PERMISSION_HINTS)
+ * @param {Error} err - the underlying error
+ * @returns {string} actionable message naming the missing permission and the fix path
+ */
+function explainPermissionError(contextKey, err) {
+    const hint = PERMISSION_HINTS[contextKey] || 'unknown permission';
+    const errMessage = (err && typeof err.message === 'string') ? err.message.slice(0, 200) : '';
+    return 'Missing GitHub App permission — ' + hint + '. Fix: org Settings → Developer settings → GitHub Apps → '
+        + 'merge-shepherd → Permissions, then accept the permission update on the repository installation. '
+        + 'See docs/MERGE_SHEPHERD.md. (context: ' + contextKey + '; error: ' + errMessage + ')';
+}
+
+/**
+ * Tags an error with the permission context of the call site that threw it, then rethrows
+ * @param {*} err - error thrown by an octokit call
+ * @param {string} contextKey - the call-site context key to attribute the error to (see PERMISSION_HINTS)
+ * @returns {never} never returns — always rethrows
+ */
+function tagContext(err, contextKey) {
+    if (err && !err.shepherdContext) {
+        err.shepherdContext = contextKey;
+    }
+    throw err;
+}
+
+/**
+ * Parses shepherd retry state from a bot comment body
+ * @param {string|null} body - comment body
+ * @returns {{sha: string, retries: number}|null} parsed state, or null if absent/malformed
+ */
+function parseStateComment(body) {
+    const match = new RegExp('<!--\\s*' + CONFIG.STATE_MARKER + '\\s+(\\{.*?\\})\\s*-->').exec(body || '');
+    if (!match) {
+        return null;
+    }
+    try {
+        const state = JSON.parse(match[1]);
+        if (typeof state.sha === 'string' && typeof state.retries === 'number') {
+            return { sha: state.sha, retries: state.retries };
+        }
+    }
+    catch (e) {
+        // malformed JSON in marker — treat as no state
+    }
+    return null;
+}
+
+/**
+ * Builds the bot state comment body for a retry
+ * @param {{sha: string, retries: number}} state - current retry state
+ * @returns {string} comment body with human text and machine-readable marker
+ */
+function buildStateCommentBody(state) {
+    return '🤖 **Merge Shepherd**: checks failed on `' + state.sha.slice(0, 7) + '` — re-running failed jobs '
+        + '(retry ' + state.retries + '/' + CONFIG.MAX_RETRIES + '). '
+        + 'The PR is ejected from the queue if this keeps failing.\n'
+        + '<!-- ' + CONFIG.STATE_MARKER + ' ' + JSON.stringify(state) + ' -->';
+}
+
+/**
+ * Selects the batch of PRs to shepherd this run
+ * @param {object[]} snapshots - PR snapshots (see Task 1 interface notes)
+ * @param {number} [batchSize] - max PRs to admit into the batch (defaults to CONFIG.BATCH_SIZE)
+ * @returns {{batch: object[], skipped: {number: number, reason: string}[]}} batch members and skipped PRs with reasons
+ */
+function selectBatch(snapshots, batchSize) {
+    const limit = typeof batchSize === 'number' ? batchSize : CONFIG.BATCH_SIZE;
+    const sorted = snapshots.slice().sort((a, b) => (a.createdAt < b.createdAt ? -1 : 1));
+    const batch = [];
+    const skipped = [];
+    for (const pr of sorted) {
+        let reason = null;
+        if (pr.isDraft) {
+            reason = 'draft';
+        }
+        else if (pr.reviewDecision !== 'APPROVED') {
+            reason = 'not approved';
+        }
+        else if (pr.unresolvedThreads > 0) {
+            reason = 'unresolved conversations';
+        }
+        else if (batch.length >= limit) {
+            reason = 'queued behind batch';
+        }
+        if (reason) {
+            skipped.push({ number: pr.number, reason });
+        }
+        else {
+            batch.push(pr);
+        }
+    }
+    return { batch, skipped };
+}
+
+/**
+ * Decides what to do with one batch member
+ * @param {object} pr - PR snapshot enriched with mergeStateStatus and state
+ * @returns {object[]} list of actions to execute for this PR
+ */
+function planForBatchMember(pr) {
+    if (pr.mergeable === 'CONFLICTING' || pr.mergeStateStatus === 'dirty') {
+        return [{ type: 'eject', number: pr.number, reason: 'conflict' }];
+    }
+    if (pr.mergeable === 'UNKNOWN' || pr.mergeStateStatus === 'unknown') {
+        return [{ type: 'wait', number: pr.number, reason: 'mergeability being computed' }];
+    }
+    const actions = [];
+    if (pr.mergeStateStatus === 'behind') {
+        if (!pr.autoMergeEnabled) {
+            actions.push({ type: 'enable-automerge', number: pr.number });
+        }
+        actions.push({ type: 'update-branch', number: pr.number });
+        return actions;
+    }
+    if (pr.checksFailed) {
+        const retries = (pr.state && pr.state.sha === pr.headSha) ? pr.state.retries : 0;
+        if (retries >= CONFIG.MAX_RETRIES) {
+            return [{ type: 'eject', number: pr.number, reason: 'failed-checks' }];
+        }
+        return [{ type: 'retry', number: pr.number, nextRetries: retries + 1 }];
+    }
+    if (pr.mergeStateStatus === 'clean' || pr.mergeStateStatus === 'unstable') {
+        return [{ type: 'merge', number: pr.number }];
+    }
+    if (!pr.autoMergeEnabled) {
+        actions.push({ type: 'enable-automerge', number: pr.number });
+    }
+    actions.push({ type: 'wait', number: pr.number, reason: pr.checksPending ? 'checks running' : 'awaiting merge' });
+    return actions;
+}
+
+const QUEUE_QUERY = `
+query($owner: String!, $repo: String!, $label: String!) {
+    repository(owner: $owner, name: $repo) {
+        pullRequests(states: OPEN, labels: [$label], first: 50, orderBy: {field: CREATED_AT, direction: ASC}) {
+            nodes {
+                id
+                number
+                title
+                createdAt
+                isDraft
+                mergeable
+                reviewDecision
+                headRefOid
+                author { login }
+                autoMergeRequest { enabledAt }
+                labels(first: 20) { nodes { name } }
+                reviewThreads(first: 100) { nodes { isResolved } }
+                commits(last: 1) { nodes { commit { statusCheckRollup { state } } } }
+            }
+        }
+    }
+}`;
+
+const CLOSED_FAILED_LABEL_QUERY = `
+query($owner: String!, $repo: String!, $label: String!) {
+    repository(owner: $owner, name: $repo) {
+        pullRequests(states: [MERGED, CLOSED], labels: [$label], first: 20, orderBy: {field: UPDATED_AT, direction: DESC}) {
+            nodes { number }
+        }
+    }
+}`;
+
+const REQUIRED_CHECKS_QUERY = `
+query($owner: String!, $repo: String!, $number: Int!) {
+    repository(owner: $owner, name: $repo) {
+        pullRequest(number: $number) {
+            commits(last: 1) {
+                nodes {
+                    commit {
+                        statusCheckRollup {
+                            contexts(first: 100) {
+                                nodes {
+                                    __typename
+                                    ... on CheckRun {
+                                        name
+                                        conclusion
+                                        isRequired(pullRequestNumber: $number)
+                                        checkSuite { workflowRun { databaseId url } }
+                                    }
+                                    ... on StatusContext {
+                                        context
+                                        state
+                                        isRequired(pullRequestNumber: $number)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}`;
+
+const ENABLE_AUTOMERGE_MUTATION = `
+mutation($prId: ID!, $mergeMethod: PullRequestMergeMethod!) {
+    enablePullRequestAutoMerge(input: {pullRequestId: $prId, mergeMethod: $mergeMethod}) {
+        pullRequest { number }
+    }
+}`;
+
+const PREFLIGHT_ROLLUP_QUERY = `
+query($owner: String!, $repo: String!) {
+    repository(owner: $owner, name: $repo) {
+        defaultBranchRef {
+            target {
+                ... on Commit { statusCheckRollup { state } }
+            }
+        }
+    }
+}`;
+
+/**
+ * Normalizes a GraphQL PR node into a snapshot for the pure planners
+ * @param {object} node - GraphQL pullRequest node from QUEUE_QUERY
+ * @returns {object} PR snapshot (mergeStateStatus/state filled in later for batch members)
+ */
+function toSnapshot(node) {
+    const commit = node.commits.nodes[0] && node.commits.nodes[0].commit;
+    const rollupState = (commit && commit.statusCheckRollup) ? commit.statusCheckRollup.state : 'PENDING';
+    return {
+        id: node.id,
+        number: node.number,
+        title: node.title,
+        createdAt: node.createdAt,
+        isDraft: node.isDraft,
+        mergeable: node.mergeable,
+        reviewDecision: node.reviewDecision,
+        unresolvedThreads: node.reviewThreads.nodes.filter((t) => !t.isResolved).length,
+        headSha: node.headRefOid,
+        authorLogin: (node.author && node.author.login) || null,
+        autoMergeEnabled: !!node.autoMergeRequest,
+        hasFailedLabel: ((node.labels && node.labels.nodes) || []).some((l) => l.name === CONFIG.FAILED_LABEL),
+        checksFailed: rollupState === 'FAILURE' || rollupState === 'ERROR',
+        checksPending: rollupState === 'PENDING' || rollupState === 'EXPECTED',
+        mergeStateStatus: null,
+        state: null,
+        stateComment: null,
+    };
+}
+
+/**
+ * Evaluates required-only check/status contexts from REQUIRED_CHECKS_QUERY for failure
+ * @param {object[]} contextNodes - contexts.nodes from the query (CheckRun/StatusContext union, may be undefined)
+ * @returns {{failed: boolean, failedRunIds: number[], failedRunUrls: string[], failedNames: string[]}} required-check failure summary
+ */
+function evaluateRequiredChecks(contextNodes) {
+    const failedRunIds = [];
+    const failedRunUrls = [];
+    const failedNames = [];
+    let failed = false;
+    for (const node of (contextNodes || [])) {
+        if (!node || !node.isRequired) {
+            continue;
+        }
+        if (node.__typename === 'CheckRun') {
+            if (node.conclusion !== null && node.conclusion !== undefined && !CONFIG.PASSING_CHECK_CONCLUSIONS.includes(node.conclusion)) {
+                failed = true;
+                if (node.name && !failedNames.includes(node.name)) {
+                    failedNames.push(node.name);
+                }
+                const run = node.checkSuite && node.checkSuite.workflowRun;
+                if (run && typeof run.databaseId !== 'undefined' && run.databaseId !== null && !failedRunIds.includes(run.databaseId)) {
+                    failedRunIds.push(run.databaseId);
+                    if (run.url) {
+                        failedRunUrls.push(run.url);
+                    }
+                }
+            }
+        }
+        else if (node.__typename === 'StatusContext') {
+            if (node.state === 'FAILURE' || node.state === 'ERROR') {
+                failed = true;
+                if (node.context && !failedNames.includes(node.context)) {
+                    failedNames.push(node.context);
+                }
+            }
+        }
+    }
+    return { failed, failedRunIds, failedRunUrls, failedNames };
+}
+
+/**
+ * Probes each read permission the bot depends on; returns diagnoses for missing ones
+ * @param {object} github - octokit client
+ * @param {string} owner - repo owner
+ * @param {string} repo - repo name
+ * @param {object} core - actions core for logging
+ * @returns {Promise<string[]>} actionable diagnoses for probes that failed with a permission error
+ */
+async function preflightPermissionChecks(github, owner, repo, core) {
+    const failures = [];
+    const probes = [
+        { context: 'preflight-rollup', run: () => github.graphql(PREFLIGHT_ROLLUP_QUERY, { owner, repo }) },
+        { context: 'preflight-labels', run: () => github.rest.issues.listLabelsForRepo({ owner, repo, per_page: 1 }) },
+        { context: 'preflight-runs', run: () => github.rest.actions.listWorkflowRunsForRepo({ owner, repo, per_page: 1 }) },
+        { context: 'preflight-contents', run: () => github.rest.repos.getContent({ owner, repo, path: '' }) },
+    ];
+    const results = await Promise.allSettled(probes.map((p) => p.run()));
+    for (let i = 0; i < probes.length; i += 1) {
+        const probe = probes[i];
+        const result = results[i];
+        if (result.status === 'fulfilled') {
+            if (probe.context === 'preflight-rollup') {
+                const data = result.value;
+                if (!data || !data.repository || !data.repository.defaultBranchRef) {
+                    core.warning('preflight rollup probe inconclusive: empty default branch');
+                }
+            }
+            continue;
+        }
+        const err = result.reason;
+        // Every probed resource (repo root, labels, workflow-runs endpoint) exists on any repo
+        // this workflow runs in, so a 404 here means access denial, not absence — GitHub hides
+        // resources the caller isn't authorized to see behind a 404 instead of a 403.
+        if (isPermissionError(err) || err.status === 404) {
+            failures.push(explainPermissionError(probe.context, err));
+        }
+        else {
+            core.warning('Preflight probe ' + probe.context + ' failed (non-permission): ' + err.message);
+        }
+    }
+    return failures;
+}
+
+// Label specs ensured on every non-dry-run cycle (see ensureLabel)
+const LABEL_SPECS = [
+    { name: CONFIG.QUEUE_LABEL, color: '2ea44f', description: 'Opt this PR into the Merge Shepherd auto-merge queue' },
+    { name: CONFIG.FAILED_LABEL, color: 'd73a4a', description: 'Merge Shepherd removed this PR from the queue after its checks failed repeatedly' },
+];
+
+/**
+ * Creates the queue label and the failed-checks marker label if they do not exist yet
+ * @param {object} github - octokit client
+ * @param {string} owner - repo owner
+ * @param {string} repo - repo name
+ * @returns {Promise<void>} resolves when both labels exist
+ */
+async function ensureLabel(github, owner, repo) {
+    for (const spec of LABEL_SPECS) {
+        try {
+            await github.rest.issues.createLabel({
+                owner,
+                repo,
+                name: spec.name,
+                color: spec.color,
+                description: spec.description,
+            });
+        }
+        catch (err) {
+            if (err.status !== 422) {
+                throw err;
+            }
+        }
+    }
+}
+
+/**
+ * Finds the bot's state comment on a PR
+ * @param {object} github - octokit client
+ * @param {string} owner - repo owner
+ * @param {string} repo - repo name
+ * @param {number} number - PR number
+ * @returns {Promise<object|null>} the comment ({id, body}) or null
+ */
+async function findStateComment(github, owner, repo, number) {
+    const comments = await github.paginate(github.rest.issues.listComments, {
+        owner,
+        repo,
+        issue_number: number,
+        per_page: 100,
+    });
+    return comments.find((c) => c.body && c.body.includes(CONFIG.STATE_MARKER)) || null;
+}
+
+/**
+ * Creates or updates the bot's state comment on a PR
+ * @param {object} github - octokit client
+ * @param {string} owner - repo owner
+ * @param {string} repo - repo name
+ * @param {object} pr - PR snapshot (uses pr.number and pr.stateComment)
+ * @param {{sha: string, retries: number}} state - new state to record
+ * @returns {Promise<void>} resolves when written
+ */
+async function upsertStateComment(github, owner, repo, pr, state) {
+    const body = buildStateCommentBody(state);
+    if (pr.stateComment) {
+        await github.rest.issues.updateComment({ owner, repo, comment_id: pr.stateComment.id, body });
+    }
+    else {
+        await github.rest.issues.createComment({ owner, repo, issue_number: pr.number, body });
+    }
+}
+
+/**
+ * Ejects a PR from the queue: removes label, explains why
+ * @param {object} github - octokit client
+ * @param {string} owner - repo owner
+ * @param {string} repo - repo name
+ * @param {object} pr - PR snapshot
+ * @param {string} reason - 'conflict' or 'failed-checks'
+ * @param {object} core - actions core for logging
+ * @returns {Promise<void>} resolves when ejected
+ */
+async function executeEject(github, owner, repo, pr, reason, core) {
+    try {
+        await github.rest.issues.removeLabel({ owner, repo, issue_number: pr.number, name: CONFIG.QUEUE_LABEL });
+    }
+    catch (err) {
+        if (err.status !== 404) {
+            tagContext(err, 'labels');
+        }
+    }
+    if (reason === 'failed-checks') {
+        try {
+            await github.rest.issues.addLabels({ owner, repo, issue_number: pr.number, labels: [CONFIG.FAILED_LABEL] });
+        }
+        catch (err) {
+            tagContext(err, 'labels');
+        }
+    }
+    const reasonText = reason === 'conflict'
+        ? 'it has **merge conflicts** with `master`. Resolve the conflicts, then re-add the `' + CONFIG.QUEUE_LABEL + '` label to re-enter the queue.'
+        : 'required checks **failed ' + (CONFIG.MAX_RETRIES + 1) + ' times** on the current head commit. Investigate the failures, push a fix, then re-add the `' + CONFIG.QUEUE_LABEL + '` label to re-enter the queue.';
+    // @-mention the author on retry exhaustion so they get a direct notification,
+    // not just the weak participating-in-thread one
+    const mention = (reason === 'failed-checks' && pr.authorLogin) ? '@' + pr.authorLogin + ' ' : '';
+    let body = mention + '🤖 **Merge Shepherd** removed this PR from the merge queue because ' + reasonText;
+    if (reason === 'failed-checks' && pr.failedNames && pr.failedNames.length) {
+        // check/context names can come from external CI systems — strip backticks and collapse
+        // whitespace so a crafted name cannot break out of the inline code span
+        const safeNames = pr.failedNames.map((n) => '`' + String(n).replace(/`/g, '‘').replace(/\s+/g, ' ').trim() + '`');
+        body += '\n\nFailing required check(s): ' + safeNames.join(', ');
+    }
+    if (reason === 'failed-checks' && pr.failedRunUrls && pr.failedRunUrls.length) {
+        body += '\n\nFailing runs:\n' + pr.failedRunUrls.map((url) => '- ' + url).join('\n');
+    }
+    if (pr.autoMergeEnabled) {
+        // The bot never disables auto-merge itself (see docs/MERGE_SHEPHERD.md), so a PR that
+        // leaves the queue with auto-merge already armed can still merge itself later — make
+        // that explicit instead of leaving it as a silent surprise.
+        body += '\n\n⚠️ Auto-merge is still enabled on this PR — if its required checks later pass '
+            + '(and branch protection is satisfied), GitHub will merge it even though it left the '
+            + 'queue. Click "Disable auto-merge" on the PR page if you don\'t want that.';
+    }
+    try {
+        await github.rest.issues.createComment({
+            owner,
+            repo,
+            issue_number: pr.number,
+            body,
+        });
+    }
+    catch (err) {
+        tagContext(err, 'comments');
+    }
+    if (pr.stateComment) {
+        try {
+            await github.rest.issues.deleteComment({ owner, repo, comment_id: pr.stateComment.id });
+        }
+        catch (err) {
+            core.warning('Could not delete state comment on #' + pr.number + ': ' + err.message);
+        }
+    }
+}
+
+/**
+ * Re-runs failed CI jobs for the PR head and records the retry in the state comment
+ * @param {object} github - octokit client
+ * @param {string} owner - repo owner
+ * @param {string} repo - repo name
+ * @param {object} pr - PR snapshot
+ * @param {number} nextRetries - retry counter to record
+ * @param {object} core - actions core for logging
+ * @returns {Promise<void>} resolves when re-runs are requested
+ */
+async function executeRetry(github, owner, repo, pr, nextRetries, core) {
+    const runIds = pr.failedRunIds || [];
+    let accepted = 0;
+    let permissionErr = null;
+    for (const runId of runIds) {
+        try {
+            await github.rest.actions.reRunWorkflowFailedJobs({ owner, repo, run_id: runId });
+            accepted += 1;
+        }
+        catch (err) {
+            core.warning('Could not re-run failed jobs of run ' + runId + ' for #' + pr.number + ': ' + err.message);
+            if (!permissionErr && isPermissionError(err)) {
+                permissionErr = err;
+            }
+        }
+    }
+    // There WERE runs to re-run but every attempt failed: treat as transient and do not
+    // advance the counter (a missing-permission failure is propagated so run() can surface it).
+    if (runIds.length > 0 && accepted === 0) {
+        if (permissionErr) {
+            tagContext(permissionErr, 'rerun');
+        }
+        core.warning('no reruns started for #' + pr.number + ' — retry not counted');
+        return;
+    }
+    // When a required check has no re-runnable workflow run (e.g. a failed external
+    // StatusContext), there is nothing to re-run — but the counter must still advance so the PR
+    // climbs toward ejection rather than looping forever. We simply wait out MAX_RETRIES cycles
+    // for the external check to resolve on its own before ejecting.
+    if (runIds.length === 0) {
+        core.info('#' + pr.number + ': no re-runnable workflow runs for the failed required check(s) — '
+            + 'counting retry ' + nextRetries + '/' + CONFIG.MAX_RETRIES + ' while waiting for them to resolve');
+    }
+    try {
+        await upsertStateComment(github, owner, repo, pr, { sha: pr.headSha, retries: nextRetries });
+    }
+    catch (err) {
+        tagContext(err, 'comments');
+    }
+}
+
+/**
+ * Executes one planned action against the GitHub API
+ * @param {object} github - octokit client
+ * @param {string} owner - repo owner
+ * @param {string} repo - repo name
+ * @param {object} action - planned action
+ * @param {object} pr - PR snapshot the action targets
+ * @param {object} core - actions core for logging
+ * @returns {Promise<void>} resolves when executed
+ */
+async function executeAction(github, owner, repo, action, pr, core) {
+    switch (action.type) {
+    case 'enable-automerge':
+        await github.graphql(ENABLE_AUTOMERGE_MUTATION, { prId: pr.id, mergeMethod: CONFIG.MERGE_METHOD });
+        break;
+    case 'merge':
+        await github.rest.pulls.merge({ owner, repo, pull_number: pr.number, merge_method: 'merge' });
+        break;
+    case 'update-branch':
+        try {
+            await github.rest.pulls.updateBranch({ owner, repo, pull_number: pr.number });
+        }
+        catch (err) {
+            if (err.status === 422) {
+                if (/merge conflict/i.test(err.message)) {
+                    core.warning('#' + pr.number + ' update-branch returned 422 (conflict) — ejecting');
+                    await executeEject(github, owner, repo, pr, 'conflict', core);
+                }
+                else {
+                    core.warning('#' + pr.number + ' update-branch returned 422 (no conflict): ' + err.message);
+                }
+            }
+            else {
+                throw err;
+            }
+        }
+        break;
+    case 'retry':
+        await executeRetry(github, owner, repo, pr, action.nextRetries, core);
+        break;
+    case 'eject':
+        await executeEject(github, owner, repo, pr, action.reason, core);
+        break;
+    default:
+        break;
+    }
+}
+
+/**
+ * Escapes HTML-significant characters so untrusted PR titles are safe in the job summary
+ * @param {string} str - raw string
+ * @returns {string} string with &, <, > escaped
+ */
+function escapeHtml(str) {
+    return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+/**
+ * Writes the queue table (and, if any, an Errors section) to the workflow job summary
+ * @param {object} core - actions core
+ * @param {object[]} batch - batch member snapshots
+ * @param {{number: number, reason: string}[]} skipped - skipped PRs
+ * @param {object[]} actions - all planned actions
+ * @param {string[]} errors - collected error/diagnosis messages for this run
+ * @returns {Promise<void>} resolves when written
+ */
+async function writeSummary(core, batch, skipped, actions, errors) {
+    const rows = [[
+        { data: 'PR', header: true },
+        { data: 'Status', header: true },
+        { data: 'Actions', header: true },
+    ]];
+    for (const pr of batch) {
+        const prActions = actions.filter((a) => a.number === pr.number);
+        rows.push(['#' + pr.number + ' ' + escapeHtml(pr.title), 'in batch', prActions.map((a) => a.type + (a.reason ? ' (' + a.reason + ')' : '')).join(', ') || 'none']);
+    }
+    for (const s of skipped) {
+        rows.push(['#' + s.number, 'skipped', s.reason]);
+    }
+    let chain = core.summary
+        .addHeading('Merge Shepherd')
+        .addTable(rows);
+    if (errors && errors.length) {
+        chain = chain.addHeading('Errors', 3).addList(errors.map(escapeHtml));
+    }
+    await chain.write();
+}
+
+/**
+ * Writes the job summary, failing the run (without throwing) if the write itself fails, so a
+ * lost summary can never leave the run green
+ * @param {object} core - actions core
+ * @param {object[]} batch - batch member snapshots
+ * @param {{number: number, reason: string}[]} skipped - skipped PRs
+ * @param {object[]} actions - all planned actions
+ * @param {string[]} errors - collected error/diagnosis messages for this run
+ * @returns {Promise<void>} resolves when the write attempt finishes
+ */
+async function safeWriteSummary(core, batch, skipped, actions, errors) {
+    try {
+        await writeSummary(core, batch, skipped, actions, errors);
+    }
+    catch (err) {
+        // core.setFailed never throws, so it cannot mask an original error already propagating
+        // through the caller's finally block.
+        core.setFailed('failed to write job summary: ' + err.message);
+    }
+}
+
+/**
+ * Records a fatal permission diagnosis and fails the run
+ * @param {object} core - actions core
+ * @param {string[]} errors - collected error/diagnosis messages for this run (mutated)
+ * @param {string} msg - the actionable message to record and fail the run with
+ * @returns {void}
+ */
+function failRun(core, errors, msg) {
+    errors.push(msg);
+    core.setFailed(msg);
+}
+
+/**
+ * Removes the stale auto-merge-failed marker from any queued PR that still carries it — the
+ * label is only meaningful for the run that ejected the PR; re-adding the queue label (which is
+ * how the PR re-enters QUEUE_QUERY's results at all) means it's back in the running, so the
+ * marker no longer applies
+ * @param {object} github - octokit client
+ * @param {string} owner - repo owner
+ * @param {string} repo - repo name
+ * @param {object[]} snapshots - PR snapshots from the queue query (all still carry QUEUE_LABEL)
+ * @param {boolean} dryRun - when true, log planned removals but execute nothing
+ * @param {object} core - actions core for logging
+ * @param {string[]} errors - collected error/diagnosis messages for this run (mutated)
+ * @returns {Promise<void>} resolves when every labeled snapshot has been considered
+ */
+async function cleanupStaleFailedLabels(github, owner, repo, snapshots, dryRun, core, errors) {
+    for (const snap of snapshots) {
+        if (!snap.hasFailedLabel) {
+            continue;
+        }
+        if (dryRun) {
+            core.info('[dry-run] would remove ' + CONFIG.FAILED_LABEL + ' from #' + snap.number);
+            continue;
+        }
+        try {
+            await github.rest.issues.removeLabel({ owner, repo, issue_number: snap.number, name: CONFIG.FAILED_LABEL });
+        }
+        catch (err) {
+            if (err.status === 404) {
+                continue;
+            }
+            try {
+                tagContext(err, 'labels');
+            }
+            catch (tagged) {
+                const msg = isPermissionError(tagged)
+                    ? explainPermissionError(tagged.shepherdContext, tagged)
+                    : ('#' + snap.number + ' could not remove ' + CONFIG.FAILED_LABEL + ' label: ' + tagged.message);
+                core.warning(msg);
+                errors.push(msg);
+            }
+        }
+    }
+}
+
+/**
+ * Removes the auto-merge-failed marker from recently-updated merged or closed PRs that still
+ * carry it — cleanupStaleFailedLabels only ever sees PRs that still carry QUEUE_LABEL, so a PR
+ * that was ejected for failed checks and then merged or was closed without re-entering the queue
+ * would otherwise keep the red marker label forever
+ * @param {object} github - octokit client
+ * @param {string} owner - repo owner
+ * @param {string} repo - repo name
+ * @param {boolean} dryRun - when true, log planned removals but execute nothing
+ * @param {object} core - actions core for logging
+ * @param {string[]} errors - collected error/diagnosis messages for this run (mutated)
+ * @returns {Promise<void>} resolves when the 20 most recently updated merged/closed labeled
+ *   PRs have been considered; older stragglers converge over later runs, because cleaned PRs
+ *   leave the label filter and stop occupying the window
+ */
+async function cleanupClosedFailedLabels(github, owner, repo, dryRun, core, errors) {
+    let data;
+    try {
+        data = await github.graphql(CLOSED_FAILED_LABEL_QUERY, { owner, repo, label: CONFIG.FAILED_LABEL });
+    }
+    catch (err) {
+        const msg = isPermissionError(err)
+            ? explainPermissionError('labels', err)
+            : ('could not query merged/closed PRs for stale ' + CONFIG.FAILED_LABEL + ' labels: ' + err.message);
+        core.warning(msg);
+        errors.push(msg);
+        return;
+    }
+    const nodes = (data && data.repository && data.repository.pullRequests && data.repository.pullRequests.nodes) || [];
+    for (const node of nodes) {
+        if (dryRun) {
+            core.info('[dry-run] would remove ' + CONFIG.FAILED_LABEL + ' from #' + node.number + ' (merged/closed)');
+            continue;
+        }
+        try {
+            await github.rest.issues.removeLabel({ owner, repo, issue_number: node.number, name: CONFIG.FAILED_LABEL });
+        }
+        catch (err) {
+            if (err.status === 404) {
+                continue;
+            }
+            try {
+                tagContext(err, 'labels');
+            }
+            catch (tagged) {
+                const msg = isPermissionError(tagged)
+                    ? explainPermissionError(tagged.shepherdContext, tagged)
+                    : ('#' + node.number + ' could not remove ' + CONFIG.FAILED_LABEL + ' label: ' + tagged.message);
+                core.warning(msg);
+                errors.push(msg);
+            }
+        }
+    }
+}
+
+/**
+ * Entry point — runs one shepherd cycle
+ * @param {object} args - injected by the workflow
+ * @param {object} args.github - github-script octokit client
+ * @param {object} args.context - github-script context
+ * @param {object} args.core - actions core
+ * @param {boolean} args.dryRun - when true, log planned actions but execute nothing
+ * @param {number} [args.batchSize] - max PRs to shepherd this run (must be an integer >= 1;
+ *   falls back to CONFIG.BATCH_SIZE when omitted or invalid)
+ * @returns {Promise<object[]>} the planned actions
+ */
+async function run({ github, context, core, dryRun, batchSize }) {
+    const { owner, repo } = context.repo;
+    const effectiveBatchSize = (Number.isInteger(batchSize) && batchSize >= 1) ? batchSize : CONFIG.BATCH_SIZE;
+    const errors = [];
+    let batch = [];
+    let skipped = [];
+    const allActions = [];
+
+    try {
+        const preflightFailures = await preflightPermissionChecks(github, owner, repo, core);
+        if (preflightFailures.length) {
+            for (const failure of preflightFailures) {
+                core.error(failure);
+            }
+            errors.push(...preflightFailures);
+            core.setFailed(preflightFailures[0] + (preflightFailures.length > 1
+                ? ' (and ' + (preflightFailures.length - 1) + ' more — see summary)'
+                : ''));
+            return [];
+        }
+
+        if (!dryRun) {
+            try {
+                await ensureLabel(github, owner, repo);
+            }
+            catch (err) {
+                if (isPermissionError(err)) {
+                    failRun(core, errors, explainPermissionError('labels', err));
+                    return allActions;
+                }
+                throw err;
+            }
+        }
+
+        let data;
+        try {
+            data = await github.graphql(QUEUE_QUERY, { owner, repo, label: CONFIG.QUEUE_LABEL });
+        }
+        catch (err) {
+            if (isPermissionError(err)) {
+                failRun(core, errors, explainPermissionError('queue-query', err));
+                return allActions;
+            }
+            throw err;
+        }
+        const snapshots = data.repository.pullRequests.nodes.map(toSnapshot);
+        core.info('Queue: ' + snapshots.length + ' labeled PR(s)');
+
+        await cleanupStaleFailedLabels(github, owner, repo, snapshots, dryRun, core, errors);
+        await cleanupClosedFailedLabels(github, owner, repo, dryRun, core, errors);
+
+        const selection = selectBatch(snapshots, effectiveBatchSize);
+        batch = selection.batch;
+        skipped = selection.skipped;
+        for (const s of skipped) {
+            core.info('#' + s.number + ' skipped: ' + s.reason);
+        }
+
+        for (const pr of batch) {
+            try {
+                let details;
+                try {
+                    details = await github.rest.pulls.get({ owner, repo, pull_number: pr.number });
+                }
+                catch (err) {
+                    tagContext(err, 'queue-query');
+                }
+                pr.mergeStateStatus = details.data.mergeable_state;
+                try {
+                    pr.stateComment = await findStateComment(github, owner, repo, pr.number);
+                }
+                catch (err) {
+                    tagContext(err, 'comments');
+                }
+                pr.state = pr.stateComment ? parseStateComment(pr.stateComment.body) : null;
+
+                let requiredData;
+                try {
+                    requiredData = await github.graphql(REQUIRED_CHECKS_QUERY, { owner, repo, number: pr.number });
+                }
+                catch (err) {
+                    tagContext(err, 'required-checks');
+                }
+                const requiredPr = requiredData.repository.pullRequest;
+                const requiredCommit = requiredPr && requiredPr.commits.nodes[0] && requiredPr.commits.nodes[0].commit;
+                const rollup = requiredCommit && requiredCommit.statusCheckRollup;
+                const requiredResult = evaluateRequiredChecks(rollup ? rollup.contexts.nodes : []);
+                pr.checksFailed = requiredResult.failed;
+                pr.failedRunIds = requiredResult.failedRunIds;
+                pr.failedRunUrls = requiredResult.failedRunUrls;
+                pr.failedNames = requiredResult.failedNames;
+
+                const actions = planForBatchMember(pr);
+                allActions.push(...actions);
+                for (const action of actions) {
+                    if (dryRun) {
+                        core.info('[dry-run] #' + pr.number + ': would ' + action.type + (action.reason ? ' (' + action.reason + ')' : ''));
+                        continue;
+                    }
+                    core.info('#' + pr.number + ': ' + action.type + (action.reason ? ' (' + action.reason + ')' : ''));
+                    try {
+                        await executeAction(github, owner, repo, action, pr, core);
+                        if (action.type === 'enable-automerge') {
+                            pr.autoMergeEnabled = true;
+                        }
+                    }
+                    catch (err) {
+                        const contextKey = err.shepherdContext || ACTION_CONTEXT[action.type];
+                        const msg = (isPermissionError(err) && contextKey)
+                            ? explainPermissionError(contextKey, err)
+                            : ('#' + pr.number + ' ' + action.type + ' failed: ' + err.message);
+                        core.warning(msg);
+                        errors.push(msg);
+                    }
+                }
+            }
+            catch (err) {
+                const isPerm = isPermissionError(err);
+                const msg = isPerm
+                    ? explainPermissionError(err.shepherdContext || 'queue-query', err)
+                    : ('#' + pr.number + ' processing failed: ' + err.message);
+                if (isPerm) {
+                    // A permission failure here recurs for every remaining PR in the batch —
+                    // the run must go red, not quietly report SUCCESS while doing nothing.
+                    core.setFailed(msg);
+                }
+                core.warning(msg);
+                errors.push(msg);
+            }
+        }
+
+        return allActions;
+    }
+    finally {
+        await safeWriteSummary(core, batch, skipped, allActions, errors);
+    }
+}
+
+module.exports = {
+    CONFIG,
+    parseStateComment,
+    buildStateCommentBody,
+    selectBatch,
+    planForBatchMember,
+    evaluateRequiredChecks,
+    isPermissionError,
+    explainPermissionError,
+    run,
+};

--- a/.github/scripts/merge-shepherd.test.js
+++ b/.github/scripts/merge-shepherd.test.js
@@ -1,0 +1,1217 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const shepherd = require('./merge-shepherd.js');
+
+/**
+ * Builds a PR snapshot with sensible defaults for tests
+ * @param {object} overrides - fields to override
+ * @returns {object} PR snapshot
+ */
+function makePr(overrides) {
+    return Object.assign({
+        id: 'PR_node1',
+        number: 1,
+        title: 'Test PR',
+        createdAt: '2026-07-01T00:00:00Z',
+        isDraft: false,
+        mergeable: 'MERGEABLE',
+        reviewDecision: 'APPROVED',
+        unresolvedThreads: 0,
+        headSha: 'abc1234',
+        autoMergeEnabled: false,
+        checksFailed: false,
+        checksPending: false,
+        mergeStateStatus: 'behind',
+        state: null,
+        stateComment: null,
+    }, overrides);
+}
+
+test('parseStateComment round-trips buildStateCommentBody', () => {
+    const state = { sha: 'abc1234', retries: 1 };
+    const body = shepherd.buildStateCommentBody(state);
+    assert.deepStrictEqual(shepherd.parseStateComment(body), state);
+});
+
+test('parseStateComment returns null for missing or malformed marker', () => {
+    assert.strictEqual(shepherd.parseStateComment('just a comment'), null);
+    assert.strictEqual(shepherd.parseStateComment(''), null);
+    assert.strictEqual(shepherd.parseStateComment(null), null);
+    assert.strictEqual(shepherd.parseStateComment('<!-- merge-shepherd-state {not json} -->'), null);
+    assert.strictEqual(shepherd.parseStateComment('<!-- merge-shepherd-state {"sha": 5, "retries": "x"} -->'), null);
+});
+
+test('selectBatch takes first 3 eligible PRs oldest-first', () => {
+    const prs = [
+        makePr({ number: 4, createdAt: '2026-07-04T00:00:00Z' }),
+        makePr({ number: 1, createdAt: '2026-07-01T00:00:00Z' }),
+        makePr({ number: 3, createdAt: '2026-07-03T00:00:00Z' }),
+        makePr({ number: 2, createdAt: '2026-07-02T00:00:00Z' }),
+    ];
+    const { batch, skipped } = shepherd.selectBatch(prs);
+    assert.deepStrictEqual(batch.map((p) => p.number), [1, 2, 3]);
+    assert.deepStrictEqual(skipped, [{ number: 4, reason: 'queued behind batch' }]);
+});
+
+test('selectBatch skips ineligible PRs without consuming batch slots', () => {
+    const prs = [
+        makePr({ number: 1, createdAt: '2026-07-01T00:00:00Z', isDraft: true }),
+        makePr({ number: 2, createdAt: '2026-07-02T00:00:00Z', reviewDecision: 'REVIEW_REQUIRED' }),
+        makePr({ number: 3, createdAt: '2026-07-03T00:00:00Z', reviewDecision: 'CHANGES_REQUESTED' }),
+        makePr({ number: 4, createdAt: '2026-07-04T00:00:00Z', unresolvedThreads: 2 }),
+        makePr({ number: 5, createdAt: '2026-07-05T00:00:00Z' }),
+    ];
+    const { batch, skipped } = shepherd.selectBatch(prs);
+    assert.deepStrictEqual(batch.map((p) => p.number), [5]);
+    assert.deepStrictEqual(skipped, [
+        { number: 1, reason: 'draft' },
+        { number: 2, reason: 'not approved' },
+        { number: 3, reason: 'not approved' },
+        { number: 4, reason: 'unresolved conversations' },
+    ]);
+});
+
+test('selectBatch honors a custom batchSize, taking only the oldest eligible PR', () => {
+    const prs = [
+        makePr({ number: 2, createdAt: '2026-07-02T00:00:00Z' }),
+        makePr({ number: 1, createdAt: '2026-07-01T00:00:00Z' }),
+        makePr({ number: 3, createdAt: '2026-07-03T00:00:00Z' }),
+    ];
+    const { batch, skipped } = shepherd.selectBatch(prs, 1);
+    assert.deepStrictEqual(batch.map((p) => p.number), [1]);
+    assert.deepStrictEqual(skipped, [
+        { number: 2, reason: 'queued behind batch' },
+        { number: 3, reason: 'queued behind batch' },
+    ]);
+});
+
+test('conflicting PR is ejected', () => {
+    const actions = shepherd.planForBatchMember(makePr({ mergeable: 'CONFLICTING' }));
+    assert.deepStrictEqual(actions, [{ type: 'eject', number: 1, reason: 'conflict' }]);
+});
+
+test('dirty merge state is ejected even if mergeable is stale', () => {
+    const actions = shepherd.planForBatchMember(makePr({ mergeStateStatus: 'dirty' }));
+    assert.deepStrictEqual(actions, [{ type: 'eject', number: 1, reason: 'conflict' }]);
+});
+
+test('unknown mergeability waits', () => {
+    const actions = shepherd.planForBatchMember(makePr({ mergeable: 'UNKNOWN', mergeStateStatus: 'unknown' }));
+    assert.deepStrictEqual(actions, [{ type: 'wait', number: 1, reason: 'mergeability being computed' }]);
+});
+
+test('behind branch gets auto-merge enabled and updated', () => {
+    const actions = shepherd.planForBatchMember(makePr({ mergeStateStatus: 'behind' }));
+    assert.deepStrictEqual(actions, [
+        { type: 'enable-automerge', number: 1 },
+        { type: 'update-branch', number: 1 },
+    ]);
+});
+
+test('behind branch with auto-merge already on only updates', () => {
+    const actions = shepherd.planForBatchMember(makePr({ mergeStateStatus: 'behind', autoMergeEnabled: true }));
+    assert.deepStrictEqual(actions, [{ type: 'update-branch', number: 1 }]);
+});
+
+test('behind branch updates even when old checks failed', () => {
+    const actions = shepherd.planForBatchMember(makePr({ mergeStateStatus: 'behind', autoMergeEnabled: true, checksFailed: true }));
+    assert.deepStrictEqual(actions, [{ type: 'update-branch', number: 1 }]);
+});
+
+test('failed checks with no prior state retries as attempt 1', () => {
+    const actions = shepherd.planForBatchMember(makePr({ mergeStateStatus: 'blocked', checksFailed: true }));
+    assert.deepStrictEqual(actions, [{ type: 'retry', number: 1, nextRetries: 1 }]);
+});
+
+test('failed checks with one prior retry on same sha retries as attempt 2', () => {
+    const actions = shepherd.planForBatchMember(makePr({
+        mergeStateStatus: 'blocked',
+        checksFailed: true,
+        state: { sha: 'abc1234', retries: 1 },
+    }));
+    assert.deepStrictEqual(actions, [{ type: 'retry', number: 1, nextRetries: 2 }]);
+});
+
+test('failed checks after MAX_RETRIES on same sha ejects', () => {
+    const actions = shepherd.planForBatchMember(makePr({
+        mergeStateStatus: 'blocked',
+        checksFailed: true,
+        state: { sha: 'abc1234', retries: shepherd.CONFIG.MAX_RETRIES },
+    }));
+    assert.deepStrictEqual(actions, [{ type: 'eject', number: 1, reason: 'failed-checks' }]);
+});
+
+test('retry counter resets when head sha changed since last retry', () => {
+    const actions = shepherd.planForBatchMember(makePr({
+        mergeStateStatus: 'blocked',
+        checksFailed: true,
+        state: { sha: 'oldsha99', retries: 2 },
+    }));
+    assert.deepStrictEqual(actions, [{ type: 'retry', number: 1, nextRetries: 1 }]);
+});
+
+test('clean PR is merged directly', () => {
+    const actions = shepherd.planForBatchMember(makePr({ mergeStateStatus: 'clean' }));
+    assert.deepStrictEqual(actions, [{ type: 'merge', number: 1 }]);
+});
+
+test('up-to-date PR with checks running waits with auto-merge on', () => {
+    const actions = shepherd.planForBatchMember(makePr({ mergeStateStatus: 'blocked', checksPending: true }));
+    assert.deepStrictEqual(actions, [
+        { type: 'enable-automerge', number: 1 },
+        { type: 'wait', number: 1, reason: 'checks running' },
+    ]);
+});
+
+test('up-to-date blocked PR with green checks just waits', () => {
+    const actions = shepherd.planForBatchMember(makePr({ mergeStateStatus: 'blocked', autoMergeEnabled: true }));
+    assert.deepStrictEqual(actions, [{ type: 'wait', number: 1, reason: 'awaiting merge' }]);
+});
+
+test('unstable PR (required checks green) is merged directly', () => {
+    const actions = shepherd.planForBatchMember(makePr({ mergeStateStatus: 'unstable' }));
+    assert.deepStrictEqual(actions, [{ type: 'merge', number: 1 }]);
+});
+
+test('has_hooks merge state falls through to wait', () => {
+    const actions = shepherd.planForBatchMember(makePr({ mergeStateStatus: 'has_hooks' }));
+    assert.deepStrictEqual(actions, [
+        { type: 'enable-automerge', number: 1 },
+        { type: 'wait', number: 1, reason: 'awaiting merge' },
+    ]);
+});
+
+test('evaluateRequiredChecks: required CheckRun FAILURE is failed with run id/url', () => {
+    const result = shepherd.evaluateRequiredChecks([
+        {
+            __typename: 'CheckRun',
+            name: 'build',
+            conclusion: 'FAILURE',
+            isRequired: true,
+            checkSuite: { workflowRun: { databaseId: 42, url: 'https://github.com/Countly/countly-platform/actions/runs/42' } },
+        },
+    ]);
+    assert.deepStrictEqual(result, {
+        failed: true,
+        failedRunIds: [42],
+        failedRunUrls: ['https://github.com/Countly/countly-platform/actions/runs/42'],
+        failedNames: ['build'],
+    });
+});
+
+test('evaluateRequiredChecks: required CheckRun CANCELLED is failed', () => {
+    const result = shepherd.evaluateRequiredChecks([
+        {
+            __typename: 'CheckRun',
+            name: 'build',
+            conclusion: 'CANCELLED',
+            isRequired: true,
+            checkSuite: { workflowRun: { databaseId: 7, url: 'https://example.test/runs/7' } },
+        },
+    ]);
+    assert.strictEqual(result.failed, true);
+    assert.deepStrictEqual(result.failedRunIds, [7]);
+});
+
+test('evaluateRequiredChecks: non-required failure alongside required success is not failed', () => {
+    const result = shepherd.evaluateRequiredChecks([
+        {
+            __typename: 'CheckRun',
+            name: 'lint',
+            conclusion: 'FAILURE',
+            isRequired: false,
+            checkSuite: { workflowRun: { databaseId: 99, url: 'https://example.test/runs/99' } },
+        },
+        {
+            __typename: 'CheckRun',
+            name: 'build',
+            conclusion: 'SUCCESS',
+            isRequired: true,
+            checkSuite: { workflowRun: { databaseId: 100, url: 'https://example.test/runs/100' } },
+        },
+    ]);
+    assert.deepStrictEqual(result, { failed: false, failedRunIds: [], failedRunUrls: [], failedNames: [] });
+});
+
+test('evaluateRequiredChecks: required StatusContext ERROR is failed with its context name', () => {
+    const result = shepherd.evaluateRequiredChecks([
+        { __typename: 'StatusContext', context: 'ci/legacy', state: 'ERROR', isRequired: true },
+    ]);
+    assert.deepStrictEqual(result, { failed: true, failedRunIds: [], failedRunUrls: [], failedNames: ['ci/legacy'] });
+});
+
+test('evaluateRequiredChecks: empty or missing contexts is not failed', () => {
+    assert.deepStrictEqual(shepherd.evaluateRequiredChecks([]), { failed: false, failedRunIds: [], failedRunUrls: [], failedNames: [] });
+    assert.deepStrictEqual(shepherd.evaluateRequiredChecks(undefined), { failed: false, failedRunIds: [], failedRunUrls: [], failedNames: [] });
+});
+
+const PASSING_CONCLUSIONS = ['SUCCESS', 'SKIPPED', 'NEUTRAL'];
+const FAILING_CONCLUSIONS = ['FAILURE', 'CANCELLED', 'TIMED_OUT', 'ACTION_REQUIRED', 'STARTUP_FAILURE', 'STALE'];
+
+for (const conclusion of PASSING_CONCLUSIONS) {
+    test('evaluateRequiredChecks: required CheckRun conclusion ' + conclusion + ' is not failed', () => {
+        const result = shepherd.evaluateRequiredChecks([
+            { __typename: 'CheckRun', name: 'build', conclusion, isRequired: true, checkSuite: { workflowRun: { databaseId: 1, url: 'https://example.test/runs/1' } } },
+        ]);
+        assert.strictEqual(result.failed, false);
+    });
+}
+
+for (const conclusion of FAILING_CONCLUSIONS) {
+    test('evaluateRequiredChecks: required CheckRun conclusion ' + conclusion + ' is failed', () => {
+        const result = shepherd.evaluateRequiredChecks([
+            { __typename: 'CheckRun', name: 'build', conclusion, isRequired: true, checkSuite: { workflowRun: { databaseId: 1, url: 'https://example.test/runs/1' } } },
+        ]);
+        assert.strictEqual(result.failed, true);
+    });
+}
+
+test('evaluateRequiredChecks: required CheckRun with null conclusion (still running) is not failed', () => {
+    const result = shepherd.evaluateRequiredChecks([
+        { __typename: 'CheckRun', name: 'build', conclusion: null, isRequired: true, checkSuite: { workflowRun: { databaseId: 1, url: 'https://example.test/runs/1' } } },
+    ]);
+    assert.strictEqual(result.failed, false);
+});
+
+/**
+ * Builds a GraphQL PR node as returned by the queue query
+ * @param {object} overrides - fields to override
+ * @returns {object} GraphQL-shaped PR node
+ */
+function makeNode(overrides) {
+    return Object.assign({
+        id: 'PR_node1',
+        number: 1,
+        title: 'Test PR',
+        createdAt: '2026-07-01T00:00:00Z',
+        isDraft: false,
+        mergeable: 'MERGEABLE',
+        reviewDecision: 'APPROVED',
+        headRefOid: 'abc1234',
+        author: { login: 'octocat' },
+        autoMergeRequest: null,
+        labels: { nodes: [{ name: 'auto-merge' }] },
+        reviewThreads: { nodes: [] },
+        commits: { nodes: [{ commit: { statusCheckRollup: { state: 'PENDING' } } }] },
+    }, overrides);
+}
+
+/**
+ * Builds an error shaped like an octokit GraphqlResponseError for a missing App permission
+ * @returns {Error} error with status-less shape but errors[] carrying a FORBIDDEN entry
+ */
+function makePermissionError() {
+    return Object.assign(
+        new Error('Request failed due to following response errors:\n - Resource not accessible by integration'),
+        { errors: [{ type: 'FORBIDDEN', message: 'Resource not accessible by integration' }] },
+    );
+}
+
+/**
+ * Resolves a fixture that toggles a probe/call failure: true uses the default permission-shaped
+ * error, an Error instance is thrown as-is, and falsy means "succeed"
+ * @param {boolean|Error} fixture - the opts.*Fails value
+ * @returns {Error|null} the error to throw, or null if the call should succeed
+ */
+function resolveFailure(fixture) {
+    if (!fixture) {
+        return null;
+    }
+    return fixture instanceof Error ? fixture : makePermissionError();
+}
+
+/**
+ * Builds a fake github-script Octokit that records mutating calls
+ * @param {object} opts - fixtures
+ * @param {object[]} opts.nodes - GraphQL PR nodes for the queue query
+ * @param {object[]} [opts.closedFailedLabelNodes] - GraphQL PR nodes ({number}) for the merged/closed failed-label cleanup query
+ * @param {boolean|Error} [opts.closedFailedLabelFails] - make the merged/closed failed-label cleanup query throw
+ * @param {object} [opts.pullsByNumber] - REST pulls.get fixtures keyed by PR number
+ * @param {object} [opts.commentsByNumber] - listComments fixtures keyed by PR number
+ * @param {object} [opts.requiredChecksByNumber] - REQUIRED_CHECKS_QUERY contexts.nodes fixtures keyed by PR number
+ * @param {object} [opts.requiredChecksFails] - REQUIRED_CHECKS_QUERY failure fixtures keyed by PR number
+ * @param {boolean} [opts.updateBranchFails] - make updateBranch throw a 422
+ * @param {string} [opts.updateBranchFailMessage] - message for the updateBranch 422 (default 'merge conflict')
+ * @param {boolean|Error} [opts.preflightRollupFails] - make the preflight rollup probe throw (true = permission-shaped)
+ * @param {boolean} [opts.preflightRollupEmptyDefaultBranch] - make the rollup probe resolve with a null defaultBranchRef
+ * @param {boolean|Error} [opts.preflightLabelsFails] - make the preflight labels probe throw
+ * @param {boolean|Error} [opts.preflightRunsFails] - make the preflight runs probe throw
+ * @param {boolean|Error} [opts.preflightContentsFails] - make the preflight contents probe throw
+ * @param {boolean|Error} [opts.queueQueryFails] - make the queue query throw (true = permission-shaped)
+ * @param {boolean|Error} [opts.removeLabelFails] - make issues.removeLabel throw (non-404 by default)
+ * @param {boolean|Error} [opts.addLabelsFails] - make issues.addLabels throw
+ * @param {boolean|Error} [opts.createCommentFails] - make issues.createComment throw
+ * @param {boolean|Error} [opts.rerunFails] - make reRunWorkflowFailedJobs throw
+ * @param {boolean|Error} [opts.automergeFails] - make the enablePullRequestAutoMerge mutation throw
+ * @returns {{github: object, calls: string[]}} fake client and recorded call log
+ */
+function makeFakeGithub(opts) {
+    const calls = [];
+    const createdComments = [];
+    const github = {
+        graphql: async(query, vars) => {
+            // @octokit/graphql reserves these keys as request options and
+            // rejects them as GraphQL variable names — mirror that here
+            const reserved = ['method', 'url', 'query', 'headers', 'request', 'baseUrl', 'mediaType'];
+            for (const key of Object.keys(vars || {})) {
+                if (reserved.includes(key)) {
+                    throw new Error('[@octokit/graphql] "' + key + '" cannot be used as variable name');
+                }
+            }
+            const kind = query.includes('defaultBranchRef') ? 'preflight'
+                : query.includes('states: [MERGED, CLOSED]') ? 'closed-failed-label'
+                    : query.includes('pullRequests(') ? 'queue'
+                        : query.includes('pullRequest(') ? 'required-checks'
+                            : query.includes('enablePullRequestAutoMerge') ? 'enable-automerge'
+                                : query.includes('disablePullRequestAutoMerge') ? 'disable-automerge'
+                                    : 'other';
+            calls.push('graphql:' + kind + ':' + JSON.stringify(vars.number || vars.prId || ''));
+            if (kind === 'preflight') {
+                const err = resolveFailure(opts.preflightRollupFails);
+                if (err) {
+                    throw err;
+                }
+                if (opts.preflightRollupEmptyDefaultBranch) {
+                    return { repository: { defaultBranchRef: null } };
+                }
+                return { repository: { defaultBranchRef: { target: { statusCheckRollup: { state: 'SUCCESS' } } } } };
+            }
+            if (kind === 'queue') {
+                const err = resolveFailure(opts.queueQueryFails);
+                if (err) {
+                    throw err;
+                }
+                return { repository: { pullRequests: { nodes: opts.nodes } } };
+            }
+            if (kind === 'closed-failed-label') {
+                const err = resolveFailure(opts.closedFailedLabelFails);
+                if (err) {
+                    throw err;
+                }
+                return { repository: { pullRequests: { nodes: opts.closedFailedLabelNodes || [] } } };
+            }
+            if (kind === 'required-checks') {
+                const err = resolveFailure(opts.requiredChecksFails && opts.requiredChecksFails[vars.number]);
+                if (err) {
+                    throw err;
+                }
+                const contexts = (opts.requiredChecksByNumber && opts.requiredChecksByNumber[vars.number]) || null;
+                return {
+                    repository: {
+                        pullRequest: {
+                            commits: { nodes: [{ commit: { statusCheckRollup: contexts ? { contexts: { nodes: contexts } } : null } }] },
+                        },
+                    },
+                };
+            }
+            if (kind === 'enable-automerge') {
+                const err = resolveFailure(opts.automergeFails);
+                if (err) {
+                    throw err;
+                }
+                return {};
+            }
+            return {};
+        },
+        paginate: async(fn, params) => {
+            const res = await fn(params);
+            return res.data;
+        },
+        rest: {
+            issues: {
+                createLabel: async(p) => {
+                    calls.push('createLabel:' + p.name);
+                    const err = new Error('already_exists');
+                    err.status = 422;
+                    throw err;
+                },
+                listComments: async(p) => ({ data: (opts.commentsByNumber && opts.commentsByNumber[p.issue_number]) || [] }),
+                createComment: async(p) => {
+                    calls.push('createComment:' + p.issue_number);
+                    createdComments.push({ number: p.issue_number, body: p.body });
+                    const err = resolveFailure(opts.createCommentFails);
+                    if (err) {
+                        throw err;
+                    }
+                    return { data: {} };
+                },
+                updateComment: async(p) => {
+                    calls.push('updateComment:' + p.comment_id);
+                    return { data: {} };
+                },
+                deleteComment: async(p) => {
+                    calls.push('deleteComment:' + p.comment_id);
+                    return { data: {} };
+                },
+                removeLabel: async(p) => {
+                    calls.push('removeLabel:' + p.issue_number + ':' + p.name);
+                    const err = resolveFailure(opts.removeLabelFails);
+                    if (err) {
+                        throw err;
+                    }
+                    return { data: {} };
+                },
+                addLabels: async(p) => {
+                    calls.push('addLabels:' + p.issue_number + ':' + p.labels.join(','));
+                    const err = resolveFailure(opts.addLabelsFails);
+                    if (err) {
+                        throw err;
+                    }
+                    return { data: {} };
+                },
+                listLabelsForRepo: async() => {
+                    const err = resolveFailure(opts.preflightLabelsFails);
+                    if (err) {
+                        throw err;
+                    }
+                    return { data: [] };
+                },
+            },
+            pulls: {
+                get: async(p) => ({ data: (opts.pullsByNumber && opts.pullsByNumber[p.pull_number]) || { mergeable_state: 'behind' } }),
+                updateBranch: async(p) => {
+                    calls.push('updateBranch:' + p.pull_number);
+                    if (opts.updateBranchFails) {
+                        const err = new Error(opts.updateBranchFailMessage || 'merge conflict');
+                        err.status = 422;
+                        throw err;
+                    }
+                    return { data: {} };
+                },
+                merge: async(p) => {
+                    calls.push('merge:' + p.pull_number);
+                    return { data: {} };
+                },
+            },
+            actions: {
+                reRunWorkflowFailedJobs: async(p) => {
+                    calls.push('rerunFailedJobs:' + p.run_id);
+                    const err = resolveFailure(opts.rerunFails);
+                    if (err) {
+                        throw err;
+                    }
+                    return { data: {} };
+                },
+                listWorkflowRunsForRepo: async() => {
+                    const err = resolveFailure(opts.preflightRunsFails);
+                    if (err) {
+                        throw err;
+                    }
+                    return { data: { workflow_runs: [] } };
+                },
+            },
+            repos: {
+                getContent: async() => {
+                    const err = resolveFailure(opts.preflightContentsFails);
+                    if (err) {
+                        throw err;
+                    }
+                    return { data: {} };
+                },
+            },
+        },
+    };
+    return { github, calls, createdComments };
+}
+
+const fakeContext = { repo: { owner: 'Countly', repo: 'countly-platform' } };
+
+/**
+ * Builds a fake actions core with a no-op chainable summary that records headings/lists/writes
+ * @param {object} [opts] - fixtures
+ * @param {boolean|Error} [opts.summaryWriteFails] - make summary.write() throw
+ * @returns {object} fake core
+ */
+function makeFakeCore(opts) {
+    opts = opts || {};
+    const summary = {
+        headings: [],
+        lists: [],
+        tables: [],
+        writeCount: 0,
+        addHeading: (text) => {
+            summary.headings.push(text);
+            return summary;
+        },
+        addTable: (rows) => {
+            summary.tables.push(rows);
+            return summary;
+        },
+        addList: (items) => {
+            summary.lists.push(items);
+            return summary;
+        },
+        addRaw: () => summary,
+        write: async() => {
+            if (opts.summaryWriteFails) {
+                throw (opts.summaryWriteFails instanceof Error ? opts.summaryWriteFails : new Error('could not write summary'));
+            }
+            summary.writeCount += 1;
+            return summary;
+        },
+    };
+    const setFailedCalls = [];
+    const errorCalls = [];
+    const warningCalls = [];
+    return {
+        info: () => {},
+        warning: (msg) => warningCalls.push(msg),
+        error: (msg) => errorCalls.push(msg),
+        setFailed: (msg) => setFailedCalls.push(msg),
+        summary,
+        setFailedCalls,
+        errorCalls,
+        warningCalls,
+    };
+}
+
+test('run() updates a behind PR and enables auto-merge', async() => {
+    const { github, calls } = makeFakeGithub({
+        nodes: [makeNode({})],
+        pullsByNumber: { 1: { mergeable_state: 'behind' } },
+    });
+    const actions = await shepherd.run({ github, context: fakeContext, core: makeFakeCore(), dryRun: false });
+    assert.ok(calls.includes('graphql:enable-automerge:"PR_node1"'));
+    assert.ok(calls.includes('updateBranch:1'));
+    assert.deepStrictEqual(actions.filter((a) => a.type !== 'wait' && a.type !== 'skip').map((a) => a.type), ['enable-automerge', 'update-branch']);
+});
+
+test('run() in dry-run mode performs no mutating calls', async() => {
+    const { github, calls } = makeFakeGithub({
+        nodes: [makeNode({})],
+        pullsByNumber: { 1: { mergeable_state: 'behind' } },
+    });
+    await shepherd.run({ github, context: fakeContext, core: makeFakeCore(), dryRun: true });
+    assert.deepStrictEqual(calls.filter((c) => !c.startsWith('graphql:queue') && !c.startsWith('graphql:required-checks') && !c.startsWith('graphql:preflight') && !c.startsWith('graphql:closed-failed-label')), []);
+});
+
+test('run() ejects on update-branch 422 conflict', async() => {
+    const { github, calls } = makeFakeGithub({
+        nodes: [makeNode({ autoMergeRequest: { enabledAt: '2026-07-01T00:00:00Z' } })],
+        pullsByNumber: { 1: { mergeable_state: 'behind' } },
+        updateBranchFails: true,
+        updateBranchFailMessage: 'merge conflict',
+    });
+    await shepherd.run({ github, context: fakeContext, core: makeFakeCore(), dryRun: false });
+    assert.ok(calls.includes('removeLabel:1:auto-merge'));
+    assert.ok(calls.includes('createComment:1'));
+    assert.ok(!calls.some((c) => c.startsWith('addLabels')));
+});
+
+test('run() never disables auto-merge on a conflict eject, even when auto-merge is armed', async() => {
+    const { github, calls } = makeFakeGithub({
+        nodes: [makeNode({ autoMergeRequest: { enabledAt: '2026-07-01T00:00:00Z' } })],
+        pullsByNumber: { 1: { mergeable_state: 'behind' } },
+        updateBranchFails: true,
+        updateBranchFailMessage: 'merge conflict',
+    });
+    await shepherd.run({ github, context: fakeContext, core: makeFakeCore(), dryRun: false });
+    assert.ok(calls.includes('removeLabel:1:auto-merge'));
+    assert.ok(!calls.some((c) => c.startsWith('graphql:disable-automerge')));
+});
+
+test('run() does not eject on update-branch 422 that is not a conflict', async() => {
+    const { github, calls } = makeFakeGithub({
+        nodes: [makeNode({ autoMergeRequest: { enabledAt: '2026-07-01T00:00:00Z' } })],
+        pullsByNumber: { 1: { mergeable_state: 'behind' } },
+        updateBranchFails: true,
+        updateBranchFailMessage: 'There are no new commits on the base branch.',
+    });
+    await shepherd.run({ github, context: fakeContext, core: makeFakeCore(), dryRun: false });
+    assert.ok(calls.includes('updateBranch:1'));
+    assert.ok(!calls.includes('removeLabel:1:auto-merge'));
+    assert.ok(!calls.includes('createComment:1'));
+    assert.ok(!calls.includes('graphql:disable-automerge:"PR_node1"'));
+});
+
+test('run() with only a non-required check failing waits without retrying or ejecting', async() => {
+    const { github, calls } = makeFakeGithub({
+        nodes: [makeNode({ autoMergeRequest: { enabledAt: '2026-07-01T00:00:00Z' } })],
+        pullsByNumber: { 1: { mergeable_state: 'blocked' } },
+        requiredChecksByNumber: {
+            1: [
+                { __typename: 'CheckRun', name: 'lint', conclusion: 'FAILURE', isRequired: false, checkSuite: { workflowRun: { databaseId: 99, url: 'https://example.test/runs/99' } } },
+                { __typename: 'CheckRun', name: 'build', conclusion: 'SUCCESS', isRequired: true, checkSuite: { workflowRun: { databaseId: 100, url: 'https://example.test/runs/100' } } },
+            ],
+        },
+    });
+    const actions = await shepherd.run({ github, context: fakeContext, core: makeFakeCore(), dryRun: false });
+    assert.ok(!calls.some((c) => c.startsWith('rerunFailedJobs')));
+    assert.ok(!calls.includes('removeLabel:1:auto-merge'));
+    assert.deepStrictEqual(actions.map((a) => a.type), ['wait']);
+});
+
+test('run() retries only the workflow run behind the failed required check', async() => {
+    const { github, calls } = makeFakeGithub({
+        nodes: [makeNode({ autoMergeRequest: { enabledAt: '2026-07-01T00:00:00Z' } })],
+        pullsByNumber: { 1: { mergeable_state: 'blocked' } },
+        requiredChecksByNumber: {
+            1: [
+                { __typename: 'CheckRun', name: 'build', conclusion: 'FAILURE', isRequired: true, checkSuite: { workflowRun: { databaseId: 42, url: 'https://example.test/runs/42' } } },
+                { __typename: 'CheckRun', name: 'lint', conclusion: 'SUCCESS', isRequired: true, checkSuite: { workflowRun: { databaseId: 43, url: 'https://example.test/runs/43' } } },
+            ],
+        },
+    });
+    await shepherd.run({ github, context: fakeContext, core: makeFakeCore(), dryRun: false });
+    assert.ok(calls.includes('rerunFailedJobs:42'));
+    assert.ok(!calls.includes('rerunFailedJobs:43'));
+    assert.ok(calls.includes('createComment:1'));
+});
+
+test('run() does not count a retry when every rerun request fails', async() => {
+    const { github, calls } = makeFakeGithub({
+        nodes: [makeNode({ autoMergeRequest: { enabledAt: '2026-07-01T00:00:00Z' } })],
+        pullsByNumber: { 1: { mergeable_state: 'blocked' } },
+        requiredChecksByNumber: {
+            1: [{ __typename: 'CheckRun', name: 'build', conclusion: 'FAILURE', isRequired: true, checkSuite: { workflowRun: { databaseId: 42, url: 'https://example.test/runs/42' } } }],
+        },
+    });
+    github.rest.actions.reRunWorkflowFailedJobs = async(p) => {
+        calls.push('rerunFailedJobs:' + p.run_id);
+        const err = new Error('workflow run is not failed');
+        err.status = 422;
+        throw err;
+    };
+    await shepherd.run({ github, context: fakeContext, core: makeFakeCore(), dryRun: false });
+    assert.ok(calls.includes('rerunFailedJobs:42'));
+    assert.ok(!calls.includes('createComment:1'));
+    assert.ok(!calls.includes('updateComment:1'));
+});
+
+test('run() counts a retry (without re-running) when the failed required check has no workflow run', async() => {
+    const { github, calls } = makeFakeGithub({
+        nodes: [makeNode({ autoMergeRequest: { enabledAt: '2026-07-01T00:00:00Z' } })],
+        pullsByNumber: { 1: { mergeable_state: 'blocked' } },
+        requiredChecksByNumber: {
+            1: [{ __typename: 'StatusContext', context: 'ci/legacy', state: 'FAILURE', isRequired: true }],
+        },
+    });
+    await shepherd.run({ github, context: fakeContext, core: makeFakeCore(), dryRun: false });
+    // Nothing is re-runnable, but the retry counter must still advance so the PR is not stuck
+    // in an infinite no-op retry loop — a fresh state comment records the retry.
+    assert.ok(!calls.some((c) => c.startsWith('rerunFailedJobs')));
+    assert.ok(calls.includes('createComment:1'));
+});
+
+test('run() ejects a non-re-runnable required-check failure once retries are exhausted', async() => {
+    const stateBody = shepherd.buildStateCommentBody({ sha: 'abc1234', retries: shepherd.CONFIG.MAX_RETRIES });
+    const { github, calls, createdComments } = makeFakeGithub({
+        nodes: [makeNode({ autoMergeRequest: { enabledAt: '2026-07-01T00:00:00Z' } })],
+        pullsByNumber: { 1: { mergeable_state: 'blocked' } },
+        commentsByNumber: { 1: [{ id: 88, body: stateBody }] },
+        requiredChecksByNumber: {
+            1: [{ __typename: 'StatusContext', context: 'ci/legacy', state: 'FAILURE', isRequired: true }],
+        },
+    });
+    await shepherd.run({ github, context: fakeContext, core: makeFakeCore(), dryRun: false });
+    // retries already at MAX on the current head sha → eject instead of counting further
+    assert.ok(!calls.some((c) => c.startsWith('rerunFailedJobs')));
+    assert.ok(calls.includes('removeLabel:1:auto-merge'));
+    assert.ok(calls.includes('addLabels:1:auto-merge-failed'));
+    // a StatusContext failure has no run link, so the eject comment must at least name the check
+    const ejectComment = createdComments.find((c) => c.number === 1 && c.body.includes('removed this PR from the merge queue'));
+    assert.ok(ejectComment, 'expected an eject comment');
+    assert.ok(ejectComment.body.includes('`ci/legacy`'), 'eject comment must name the failing required check');
+});
+
+test('run() sanitizes backticks and newlines in failing check names in the eject comment', async() => {
+    const stateBody = shepherd.buildStateCommentBody({ sha: 'abc1234', retries: shepherd.CONFIG.MAX_RETRIES });
+    const { github, createdComments } = makeFakeGithub({
+        nodes: [makeNode({})],
+        pullsByNumber: { 1: { mergeable_state: 'blocked' } },
+        commentsByNumber: { 1: [{ id: 88, body: stateBody }] },
+        requiredChecksByNumber: {
+            1: [{ __typename: 'StatusContext', context: 'ci/legacy` @evil\ninjected', state: 'FAILURE', isRequired: true }],
+        },
+    });
+    await shepherd.run({ github, context: fakeContext, core: makeFakeCore(), dryRun: false });
+    const ejectComment = createdComments.find((c) => c.number === 1 && c.body.includes('removed this PR from the merge queue'));
+    assert.ok(ejectComment, 'expected an eject comment');
+    const nameLine = ejectComment.body.split('\n').find((l) => l.startsWith('Failing required check(s):'));
+    assert.ok(nameLine, 'expected a failing-checks line');
+    const namesPart = nameLine.slice('Failing required check(s): '.length);
+    // exactly one code span for the one failing check: the only backticks are its two delimiters
+    assert.strictEqual((namesPart.match(/`/g) || []).length, 2, 'raw backticks in the name must not survive sanitization');
+    assert.ok(nameLine.includes('`ci/legacy‘ @evil injected`'), 'backticks replaced and newline collapsed inside one code span');
+    assert.ok(!nameLine.includes('``'), 'no empty/broken code spans from raw backticks');
+});
+
+test('run() ejects after retries are exhausted, with failing run links in the comment', async() => {
+    const stateBody = shepherd.buildStateCommentBody({ sha: 'abc1234', retries: shepherd.CONFIG.MAX_RETRIES });
+    const { github, calls, createdComments } = makeFakeGithub({
+        nodes: [makeNode({ autoMergeRequest: { enabledAt: '2026-07-01T00:00:00Z' } })],
+        pullsByNumber: { 1: { mergeable_state: 'blocked' } },
+        commentsByNumber: { 1: [{ id: 77, body: stateBody }] },
+        requiredChecksByNumber: {
+            1: [{ __typename: 'CheckRun', name: 'build', conclusion: 'FAILURE', isRequired: true, checkSuite: { workflowRun: { databaseId: 42, url: 'https://example.test/runs/42' } } }],
+        },
+    });
+    await shepherd.run({ github, context: fakeContext, core: makeFakeCore(), dryRun: false });
+    assert.ok(calls.includes('removeLabel:1:auto-merge'));
+    assert.ok(calls.includes('deleteComment:77'));
+    assert.ok(calls.includes('createComment:1'));
+    assert.ok(calls.includes('addLabels:1:auto-merge-failed'));
+    assert.ok(calls.indexOf('removeLabel:1:auto-merge') < calls.indexOf('addLabels:1:auto-merge-failed'));
+    assert.ok(!calls.some((c) => c.startsWith('graphql:disable-automerge')), 'failed-checks eject must not disable auto-merge');
+    const ejectComment = createdComments.find((c) => c.number === 1 && c.body.includes('removed this PR from the merge queue'));
+    assert.ok(ejectComment, 'expected an eject comment');
+    assert.ok(ejectComment.body.startsWith('@octocat '), 'eject comment must @-mention the PR author');
+    assert.ok(ejectComment.body.includes('https://example.test/runs/42'));
+    assert.ok(ejectComment.body.includes('Auto-merge is still enabled on this PR'), 'armed failed-checks eject must warn auto-merge stays on');
+});
+
+test('run() failed-checks eject comment omits the still-armed warning when auto-merge was never enabled', async() => {
+    const stateBody = shepherd.buildStateCommentBody({ sha: 'abc1234', retries: shepherd.CONFIG.MAX_RETRIES });
+    const { github, createdComments } = makeFakeGithub({
+        nodes: [makeNode({})],
+        pullsByNumber: { 1: { mergeable_state: 'blocked' } },
+        commentsByNumber: { 1: [{ id: 77, body: stateBody }] },
+        requiredChecksByNumber: {
+            1: [{ __typename: 'CheckRun', name: 'build', conclusion: 'FAILURE', isRequired: true, checkSuite: { workflowRun: { databaseId: 42, url: 'https://example.test/runs/42' } } }],
+        },
+    });
+    await shepherd.run({ github, context: fakeContext, core: makeFakeCore(), dryRun: false });
+    const ejectComment = createdComments.find((c) => c.number === 1 && c.body.includes('removed this PR from the merge queue'));
+    assert.ok(ejectComment, 'expected an eject comment');
+    assert.ok(!ejectComment.body.includes('Auto-merge is still enabled'), 'unarmed failed-checks eject must not warn about auto-merge');
+    assert.ok(ejectComment.body.includes('`build`'), 'eject comment must name the failing required check');
+});
+
+test('run() conflict ejection comment does not @-mention the author', async() => {
+    const { github, createdComments } = makeFakeGithub({
+        nodes: [makeNode({ mergeable: 'CONFLICTING' })],
+        pullsByNumber: { 1: { mergeable_state: 'dirty' } },
+    });
+    await shepherd.run({ github, context: fakeContext, core: makeFakeCore(), dryRun: false });
+    const ejectComment = createdComments.find((c) => c.number === 1 && c.body.includes('removed this PR from the merge queue'));
+    assert.ok(ejectComment, 'expected an eject comment');
+    assert.ok(!ejectComment.body.includes('@octocat'), 'conflict ejection must not mention the author');
+    assert.ok(!ejectComment.body.includes('Auto-merge is still enabled'), 'unarmed conflict eject must not warn about auto-merge');
+});
+
+test('run() conflict ejection comment warns that auto-merge stays armed when it is already enabled', async() => {
+    const { github, createdComments } = makeFakeGithub({
+        nodes: [makeNode({ mergeable: 'CONFLICTING', autoMergeRequest: { enabledAt: '2026-07-01T00:00:00Z' } })],
+        pullsByNumber: { 1: { mergeable_state: 'dirty' } },
+    });
+    await shepherd.run({ github, context: fakeContext, core: makeFakeCore(), dryRun: false });
+    const ejectComment = createdComments.find((c) => c.number === 1 && c.body.includes('removed this PR from the merge queue'));
+    assert.ok(ejectComment, 'expected an eject comment');
+    assert.ok(ejectComment.body.includes('Auto-merge is still enabled on this PR'), 'armed conflict eject must warn auto-merge stays on');
+    assert.ok(ejectComment.body.includes('Disable auto-merge'), 'warning must point at the manual disable action');
+});
+
+test('run() eject comment omits the mention when the author login is unavailable', async() => {
+    const stateBody = shepherd.buildStateCommentBody({ sha: 'abc1234', retries: shepherd.CONFIG.MAX_RETRIES });
+    const { github, createdComments } = makeFakeGithub({
+        nodes: [makeNode({ author: null })],
+        pullsByNumber: { 1: { mergeable_state: 'blocked' } },
+        commentsByNumber: { 1: [{ id: 77, body: stateBody }] },
+        requiredChecksByNumber: {
+            1: [{ __typename: 'CheckRun', name: 'build', conclusion: 'FAILURE', isRequired: true, checkSuite: { workflowRun: { databaseId: 42, url: 'https://example.test/runs/42' } } }],
+        },
+    });
+    await shepherd.run({ github, context: fakeContext, core: makeFakeCore(), dryRun: false });
+    const ejectComment = createdComments.find((c) => c.number === 1 && c.body.includes('removed this PR from the merge queue'));
+    assert.ok(ejectComment, 'expected an eject comment');
+    assert.ok(ejectComment.body.startsWith('🤖'), 'comment must start cleanly without a dangling mention');
+});
+
+test('run() merges a clean PR directly', async() => {
+    const { github, calls } = makeFakeGithub({
+        nodes: [makeNode({})],
+        pullsByNumber: { 1: { mergeable_state: 'clean' } },
+    });
+    await shepherd.run({ github, context: fakeContext, core: makeFakeCore(), dryRun: false });
+    assert.ok(calls.includes('merge:1'));
+});
+
+test('run() leaves an ineligible (unapproved) PR with auto-merge already armed alone — no disable call', async() => {
+    const nodes = [
+        makeNode({
+            id: 'PR_5',
+            number: 5,
+            createdAt: '2026-07-05T00:00:00Z',
+            reviewDecision: 'REVIEW_REQUIRED',
+            autoMergeRequest: { enabledAt: '2026-07-01T00:00:00Z' },
+        }),
+    ];
+    const { github, calls } = makeFakeGithub({ nodes });
+    await shepherd.run({ github, context: fakeContext, core: makeFakeCore(), dryRun: false });
+    assert.ok(!calls.some((c) => c.startsWith('graphql:disable-automerge')));
+    assert.ok(!calls.some((c) => c.startsWith('updateBranch') || c.startsWith('merge:')));
+});
+
+test('run() with batchSize: 1 mutates only the older of two eligible behind PRs', async() => {
+    const nodes = [
+        makeNode({ id: 'PR_1', number: 1, createdAt: '2026-07-01T00:00:00Z' }),
+        makeNode({ id: 'PR_2', number: 2, createdAt: '2026-07-02T00:00:00Z' }),
+    ];
+    const { github, calls } = makeFakeGithub({
+        nodes,
+        pullsByNumber: {
+            1: { mergeable_state: 'behind' },
+            2: { mergeable_state: 'behind' },
+        },
+    });
+    await shepherd.run({ github, context: fakeContext, core: makeFakeCore(), dryRun: false, batchSize: 1 });
+    assert.ok(calls.includes('graphql:enable-automerge:"PR_1"'));
+    assert.ok(calls.includes('updateBranch:1'));
+    assert.ok(!calls.includes('graphql:enable-automerge:"PR_2"'));
+    assert.ok(!calls.includes('updateBranch:2'));
+});
+
+test('run() falls back to CONFIG.BATCH_SIZE (3) when batchSize is invalid', async() => {
+    for (const invalidBatchSize of [0, NaN, undefined]) {
+        const nodes = [
+            makeNode({ id: 'PR_1', number: 1, createdAt: '2026-07-01T00:00:00Z' }),
+            makeNode({ id: 'PR_2', number: 2, createdAt: '2026-07-02T00:00:00Z' }),
+            makeNode({ id: 'PR_3', number: 3, createdAt: '2026-07-03T00:00:00Z' }),
+            makeNode({ id: 'PR_4', number: 4, createdAt: '2026-07-04T00:00:00Z' }),
+        ];
+        const { github, calls } = makeFakeGithub({
+            nodes,
+            pullsByNumber: {
+                1: { mergeable_state: 'behind' },
+                2: { mergeable_state: 'behind' },
+                3: { mergeable_state: 'behind' },
+            },
+        });
+        await shepherd.run({ github, context: fakeContext, core: makeFakeCore(), dryRun: false, batchSize: invalidBatchSize });
+        assert.ok(calls.includes('updateBranch:1'), 'batchSize ' + invalidBatchSize);
+        assert.ok(calls.includes('updateBranch:2'), 'batchSize ' + invalidBatchSize);
+        assert.ok(calls.includes('updateBranch:3'), 'batchSize ' + invalidBatchSize);
+        assert.ok(!calls.includes('updateBranch:4'), 'batchSize ' + invalidBatchSize);
+    }
+});
+
+test('isPermissionError detects 403 status, FORBIDDEN GraphQL errors, and message-only matches; false otherwise', () => {
+    assert.strictEqual(shepherd.isPermissionError(Object.assign(new Error('nope'), { status: 403 })), true);
+    assert.strictEqual(shepherd.isPermissionError(makePermissionError()), true);
+    assert.strictEqual(shepherd.isPermissionError(new Error('Resource not accessible by integration')), true);
+    assert.strictEqual(shepherd.isPermissionError(new Error('some other failure')), false);
+    assert.strictEqual(shepherd.isPermissionError(null), false);
+    assert.strictEqual(shepherd.isPermissionError(undefined), false);
+});
+
+test('explainPermissionError includes the permission hint, fix path, and context key', () => {
+    const err = new Error('Resource not accessible by integration');
+    const msg = shepherd.explainPermissionError('preflight-rollup', err);
+    assert.match(msg, /Commit statuses: Read-only and Checks: Read-only/);
+    assert.match(msg, /org Settings.*Developer settings.*GitHub Apps.*merge-shepherd.*Permissions/);
+    assert.match(msg, /accept the permission update on the repository installation/);
+    assert.match(msg, /docs\/MERGE_SHEPHERD\.md/);
+    assert.match(msg, /context: preflight-rollup/);
+    assert.match(msg, /Resource not accessible by integration/);
+});
+
+test('run() fails fast when the preflight rollup probe hits a permission error, without touching the queue', async() => {
+    const { github, calls } = makeFakeGithub({
+        nodes: [makeNode({})],
+        pullsByNumber: { 1: { mergeable_state: 'behind' } },
+        preflightRollupFails: true,
+    });
+    const core = makeFakeCore();
+    const actions = await shepherd.run({ github, context: fakeContext, core, dryRun: false });
+    assert.deepStrictEqual(actions, []);
+    assert.strictEqual(core.setFailedCalls.length, 1);
+    assert.match(core.setFailedCalls[0], /Missing GitHub App permission/i);
+    assert.match(core.setFailedCalls[0], /Commit statuses: Read-only/);
+    assert.deepStrictEqual(calls, ['graphql:preflight:""']);
+    assert.strictEqual(core.summary.writeCount, 1);
+    assert.ok(core.summary.lists.some((list) => list.some((item) => /Commit statuses: Read-only/.test(item))));
+});
+
+test('run() proceeds normally when a preflight probe fails with a non-permission error', async() => {
+    const { github, calls } = makeFakeGithub({
+        nodes: [makeNode({})],
+        pullsByNumber: { 1: { mergeable_state: 'behind' } },
+        preflightRollupFails: Object.assign(new Error('server error'), { status: 500 }),
+    });
+    const core = makeFakeCore();
+    const actions = await shepherd.run({ github, context: fakeContext, core, dryRun: false });
+    assert.strictEqual(core.setFailedCalls.length, 0);
+    assert.ok(core.warningCalls.some((w) => /Preflight probe preflight-rollup failed/.test(w)));
+    assert.ok(calls.includes('graphql:enable-automerge:"PR_node1"'));
+    assert.ok(calls.includes('updateBranch:1'));
+    assert.deepStrictEqual(actions.filter((a) => a.type !== 'wait').map((a) => a.type), ['enable-automerge', 'update-branch']);
+});
+
+test('run() translates a permission error from the queue query instead of throwing it raw', async() => {
+    const { github, calls } = makeFakeGithub({
+        nodes: [],
+        queueQueryFails: true,
+    });
+    const core = makeFakeCore();
+    const actions = await shepherd.run({ github, context: fakeContext, core, dryRun: false });
+    assert.deepStrictEqual(actions, []);
+    assert.strictEqual(core.setFailedCalls.length, 1);
+    assert.match(core.setFailedCalls[0], /Pull requests: Read & write/);
+    assert.match(core.setFailedCalls[0], /context: queue-query/);
+    assert.ok(calls.includes('graphql:queue:""'));
+    assert.strictEqual(core.summary.writeCount, 1);
+});
+
+test('run() records a translated permission error for a failed action without failing the run', async() => {
+    const { github } = makeFakeGithub({
+        nodes: [makeNode({})],
+        pullsByNumber: { 1: { mergeable_state: 'behind' } },
+        automergeFails: true,
+    });
+    const core = makeFakeCore();
+    const actions = await shepherd.run({ github, context: fakeContext, core, dryRun: false });
+    assert.strictEqual(core.setFailedCalls.length, 0);
+    assert.ok(actions.some((a) => a.type === 'update-branch'));
+    assert.strictEqual(core.summary.writeCount, 1);
+    assert.ok(core.summary.headings.includes('Errors'));
+    assert.ok(core.summary.lists.some((list) => list.some((item) => /Pull requests: Read &amp; write/.test(item) && /context: automerge/.test(item))));
+});
+
+test('writeSummary still includes the queue table on the happy path after the try/finally restructure', async() => {
+    const { github } = makeFakeGithub({
+        nodes: [makeNode({})],
+        pullsByNumber: { 1: { mergeable_state: 'clean' } },
+    });
+    const core = makeFakeCore();
+    await shepherd.run({ github, context: fakeContext, core, dryRun: false });
+    assert.strictEqual(core.summary.writeCount, 1);
+    assert.strictEqual(core.summary.tables.length, 1);
+    assert.deepStrictEqual(core.summary.tables[0][0], [
+        { data: 'PR', header: true },
+        { data: 'Status', header: true },
+        { data: 'Actions', header: true },
+    ]);
+    assert.ok(!core.summary.headings.includes('Errors'));
+});
+
+test('run() propagates an all-reruns-denied permission error as the rerun (Actions) hint, without writing a state comment', async() => {
+    const { github, calls } = makeFakeGithub({
+        nodes: [makeNode({ autoMergeRequest: { enabledAt: '2026-07-01T00:00:00Z' } })],
+        pullsByNumber: { 1: { mergeable_state: 'blocked' } },
+        requiredChecksByNumber: {
+            1: [{ __typename: 'CheckRun', name: 'build', conclusion: 'FAILURE', isRequired: true, checkSuite: { workflowRun: { databaseId: 42, url: 'https://example.test/runs/42' } } }],
+        },
+        rerunFails: true,
+    });
+    const core = makeFakeCore();
+    await shepherd.run({ github, context: fakeContext, core, dryRun: false });
+    assert.ok(calls.includes('rerunFailedJobs:42'));
+    assert.ok(!calls.includes('createComment:1'));
+    assert.ok(!calls.includes('updateComment:1'));
+    assert.ok(core.summary.lists.some((list) => list.some((item) => /Actions: Read &amp; write/.test(item) && /context: rerun/.test(item))));
+});
+
+test('run() attributes a state-comment write failure after successful reruns to Issues (comments), not Actions', async() => {
+    const { github, calls } = makeFakeGithub({
+        nodes: [makeNode({ autoMergeRequest: { enabledAt: '2026-07-01T00:00:00Z' } })],
+        pullsByNumber: { 1: { mergeable_state: 'blocked' } },
+        requiredChecksByNumber: {
+            1: [{ __typename: 'CheckRun', name: 'build', conclusion: 'FAILURE', isRequired: true, checkSuite: { workflowRun: { databaseId: 42, url: 'https://example.test/runs/42' } } }],
+        },
+        createCommentFails: true,
+    });
+    const core = makeFakeCore();
+    await shepherd.run({ github, context: fakeContext, core, dryRun: false });
+    assert.ok(calls.includes('rerunFailedJobs:42'));
+    assert.ok(calls.includes('createComment:1'));
+    assert.ok(core.summary.lists.some((list) => list.some((item) => /Issues: Read &amp; write/.test(item) && /context: comments/.test(item))));
+    assert.ok(!core.summary.lists.some((list) => list.some((item) => /context: rerun/.test(item))));
+});
+
+test('run() attributes a removeLabel failure during eject to Issues (labels), not the eject action', async() => {
+    const { github, calls } = makeFakeGithub({
+        nodes: [makeNode({ mergeable: 'CONFLICTING' })],
+        removeLabelFails: true,
+    });
+    const core = makeFakeCore();
+    await shepherd.run({ github, context: fakeContext, core, dryRun: false });
+    assert.ok(calls.includes('removeLabel:1:auto-merge'));
+    assert.ok(core.summary.lists.some((list) => list.some((item) => /Issues: Read &amp; write/.test(item) && /context: labels/.test(item))));
+});
+
+test('run() fails the run when the required-checks query 403s for one PR, but still processes the other batch member', async() => {
+    const nodes = [
+        makeNode({ id: 'PR_1', number: 1, createdAt: '2026-07-01T00:00:00Z' }),
+        makeNode({ id: 'PR_2', number: 2, createdAt: '2026-07-02T00:00:00Z' }),
+    ];
+    const { github, calls } = makeFakeGithub({
+        nodes,
+        pullsByNumber: {
+            1: { mergeable_state: 'behind' },
+            2: { mergeable_state: 'behind' },
+        },
+        requiredChecksFails: { 1: true },
+    });
+    const core = makeFakeCore();
+    await shepherd.run({ github, context: fakeContext, core, dryRun: false });
+    assert.strictEqual(core.setFailedCalls.length, 1);
+    assert.match(core.setFailedCalls[0], /context: required-checks/);
+    assert.ok(core.summary.lists.some((list) => list.some((item) => /context: required-checks/.test(item))));
+    assert.ok(calls.includes('updateBranch:2'));
+    assert.ok(!calls.includes('updateBranch:1'));
+});
+
+test('run() fails preflight when the Contents probe fails, without touching the queue', async() => {
+    const { github, calls } = makeFakeGithub({
+        nodes: [makeNode({})],
+        preflightContentsFails: true,
+    });
+    const core = makeFakeCore();
+    const actions = await shepherd.run({ github, context: fakeContext, core, dryRun: false });
+    assert.deepStrictEqual(actions, []);
+    assert.strictEqual(core.setFailedCalls.length, 1);
+    assert.match(core.setFailedCalls[0], /Contents: Read & write/);
+    assert.match(core.setFailedCalls[0], /context: preflight-contents/);
+    assert.ok(!calls.some((c) => c.startsWith('graphql:queue')));
+});
+
+test('run() treats a preflight probe 404 as a permission failure since probed resources always exist', async() => {
+    const { github } = makeFakeGithub({
+        nodes: [makeNode({})],
+        preflightLabelsFails: Object.assign(new Error('Not Found'), { status: 404 }),
+    });
+    const core = makeFakeCore();
+    const actions = await shepherd.run({ github, context: fakeContext, core, dryRun: false });
+    assert.deepStrictEqual(actions, []);
+    assert.strictEqual(core.setFailedCalls.length, 1);
+    assert.match(core.setFailedCalls[0], /Issues: Read & write/);
+    assert.match(core.setFailedCalls[0], /context: preflight-labels/);
+});
+
+test('run() warns but proceeds when the rollup preflight probe resolves with an empty default branch', async() => {
+    const { github, calls } = makeFakeGithub({
+        nodes: [makeNode({})],
+        pullsByNumber: { 1: { mergeable_state: 'behind' } },
+        preflightRollupEmptyDefaultBranch: true,
+    });
+    const core = makeFakeCore();
+    await shepherd.run({ github, context: fakeContext, core, dryRun: false });
+    assert.strictEqual(core.setFailedCalls.length, 0);
+    assert.ok(core.warningCalls.some((w) => /preflight rollup probe inconclusive/.test(w)));
+    assert.ok(calls.includes('updateBranch:1'));
+});
+
+test('run() HTML-escapes error strings before writing them to the job summary', async() => {
+    const { github } = makeFakeGithub({
+        nodes: [makeNode({})],
+        pullsByNumber: { 1: { mergeable_state: 'behind' } },
+        automergeFails: new Error('boom <b>bad</b>'),
+    });
+    const core = makeFakeCore();
+    await shepherd.run({ github, context: fakeContext, core, dryRun: false });
+    assert.ok(core.summary.lists.some((list) => list.some((item) => item.includes('&lt;b&gt;bad&lt;/b&gt;'))));
+    assert.ok(!core.summary.lists.some((list) => list.some((item) => item.includes('<b>bad</b>'))));
+});
+
+test('run() fails the run when writing the job summary itself throws', async() => {
+    const { github } = makeFakeGithub({
+        nodes: [makeNode({})],
+        pullsByNumber: { 1: { mergeable_state: 'clean' } },
+    });
+    const core = makeFakeCore({ summaryWriteFails: true });
+    await shepherd.run({ github, context: fakeContext, core, dryRun: false });
+    assert.ok(core.setFailedCalls.some((m) => /failed to write job summary/.test(m)));
+});
+
+test('run() ensures both the queue label and the failed-checks marker label exist', async() => {
+    const { github, calls } = makeFakeGithub({
+        nodes: [makeNode({})],
+        pullsByNumber: { 1: { mergeable_state: 'clean' } },
+    });
+    await shepherd.run({ github, context: fakeContext, core: makeFakeCore(), dryRun: false });
+    assert.ok(calls.includes('createLabel:auto-merge'));
+    assert.ok(calls.includes('createLabel:auto-merge-failed'));
+});
+
+test('run() removes the stale auto-merge-failed label from both a batch member and a skipped-ineligible PR that still carry it', async() => {
+    const nodes = [
+        makeNode({
+            id: 'PR_1',
+            number: 1,
+            createdAt: '2026-07-01T00:00:00Z',
+            labels: { nodes: [{ name: 'auto-merge' }, { name: 'auto-merge-failed' }] },
+        }),
+        makeNode({
+            id: 'PR_2',
+            number: 2,
+            createdAt: '2026-07-02T00:00:00Z',
+            isDraft: true,
+            labels: { nodes: [{ name: 'auto-merge' }, { name: 'auto-merge-failed' }] },
+        }),
+    ];
+    const { github, calls } = makeFakeGithub({
+        nodes,
+        pullsByNumber: { 1: { mergeable_state: 'clean' } },
+    });
+    await shepherd.run({ github, context: fakeContext, core: makeFakeCore(), dryRun: false });
+    assert.ok(calls.includes('removeLabel:1:auto-merge-failed'));
+    assert.ok(calls.includes('removeLabel:2:auto-merge-failed'));
+});
+
+test('run() in dry-run mode does not remove a stale auto-merge-failed label', async() => {
+    const nodes = [
+        makeNode({ labels: { nodes: [{ name: 'auto-merge' }, { name: 'auto-merge-failed' }] } }),
+    ];
+    const { github, calls } = makeFakeGithub({ nodes });
+    await shepherd.run({ github, context: fakeContext, core: makeFakeCore(), dryRun: true });
+    assert.deepStrictEqual(calls.filter((c) => !c.startsWith('graphql:queue') && !c.startsWith('graphql:required-checks') && !c.startsWith('graphql:preflight') && !c.startsWith('graphql:closed-failed-label')), []);
+});
+
+test('run() removes the auto-merge-failed label from a merged PR that already left the queue', async() => {
+    const { github, calls } = makeFakeGithub({
+        nodes: [],
+        closedFailedLabelNodes: [{ number: 42 }],
+    });
+    await shepherd.run({ github, context: fakeContext, core: makeFakeCore(), dryRun: false });
+    assert.ok(calls.includes('graphql:closed-failed-label:""'));
+    assert.ok(calls.includes('removeLabel:42:auto-merge-failed'));
+});
+
+test('run() in dry-run mode does not remove the auto-merge-failed label from a merged/closed PR', async() => {
+    const { github, calls } = makeFakeGithub({
+        nodes: [],
+        closedFailedLabelNodes: [{ number: 42 }],
+    });
+    await shepherd.run({ github, context: fakeContext, core: makeFakeCore(), dryRun: true });
+    assert.ok(!calls.includes('removeLabel:42:auto-merge-failed'));
+});
+
+test('run() cleans up a merged PR\'s stale label without affecting an open PR still in the queue', async() => {
+    const { github, calls } = makeFakeGithub({
+        nodes: [makeNode({})],
+        pullsByNumber: { 1: { mergeable_state: 'clean' } },
+        closedFailedLabelNodes: [{ number: 99 }],
+    });
+    await shepherd.run({ github, context: fakeContext, core: makeFakeCore(), dryRun: false });
+    assert.ok(calls.includes('merge:1'));
+    assert.ok(calls.includes('removeLabel:99:auto-merge-failed'));
+});
+
+test('run() tolerates a 404 when removing the auto-merge-failed label from a merged/closed PR', async() => {
+    const { github, calls } = makeFakeGithub({
+        nodes: [],
+        closedFailedLabelNodes: [{ number: 42 }],
+        removeLabelFails: Object.assign(new Error('Not Found'), { status: 404 }),
+    });
+    const core = makeFakeCore();
+    await shepherd.run({ github, context: fakeContext, core, dryRun: false });
+    assert.ok(calls.includes('removeLabel:42:auto-merge-failed'));
+    assert.strictEqual(core.setFailedCalls.length, 0);
+    assert.deepStrictEqual(core.warningCalls, []);
+});
+
+test('run() warns and records the error when the merged/closed failed-label query itself fails', async() => {
+    const { github } = makeFakeGithub({
+        nodes: [makeNode({})],
+        pullsByNumber: { 1: { mergeable_state: 'clean' } },
+        closedFailedLabelFails: true,
+    });
+    const core = makeFakeCore();
+    const actions = await shepherd.run({ github, context: fakeContext, core, dryRun: false });
+    assert.strictEqual(core.setFailedCalls.length, 0);
+    assert.ok(core.warningCalls.some((w) => /context: labels/.test(w)));
+    // the rest of the run must proceed unaffected by this cleanup query failing
+    assert.deepStrictEqual(actions.map((a) => a.type), ['merge']);
+});

--- a/.github/workflows/merge-shepherd.yml
+++ b/.github/workflows/merge-shepherd.yml
@@ -1,0 +1,73 @@
+name: Merge Shepherd
+
+on:
+  schedule:
+    - cron: '*/10 * * * *'
+  push:
+    branches: [master]
+  pull_request:
+    types: [labeled]
+  pull_request_review:
+    types: [submitted]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Log planned actions without executing them'
+        type: boolean
+        default: false
+
+concurrency:
+  group: merge-shepherd
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  shepherd:
+    # PR events only matter when they can change queue membership: the
+    # auto-merge label being added, or an approval landing
+    if: >
+      (github.event_name != 'pull_request' && github.event_name != 'pull_request_review') ||
+      (github.event_name == 'pull_request' && github.event.label.name == 'auto-merge') ||
+      (github.event_name == 'pull_request_review' && github.event.review.state == 'approved')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check App secrets are configured
+        env:
+          APP_ID: ${{ secrets.MERGE_SHEPHERD_APP_ID }}
+        run: |
+          if [ -z "$APP_ID" ]; then
+            echo "::error::MERGE_SHEPHERD_APP_ID / MERGE_SHEPHERD_APP_PRIVATE_KEY secrets are not configured. See docs/MERGE_SHEPHERD.md"
+            exit 1
+          fi
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7 (= v7.0.1)
+        with:
+          # always run the shepherd logic from master, even on pull_request
+          # events (whose default checkout is the PR's merge ref)
+          ref: master
+          sparse-checkout: .github/scripts
+
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3 (= v3.2.0)
+        id: app-token
+        with:
+          app-id: ${{ secrets.MERGE_SHEPHERD_APP_ID }}
+          private-key: ${{ secrets.MERGE_SHEPHERD_APP_PRIVATE_KEY }}
+
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9 (= v9.0.0)
+        env:
+          DRY_RUN: ${{ inputs.dry_run == true && '1' || '' }}
+          MERGE_SHEPHERD_BATCH_SIZE: ${{ vars.MERGE_SHEPHERD_BATCH_SIZE }}
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            const shepherd = require('${{ github.workspace }}/.github/scripts/merge-shepherd.js');
+            return await shepherd.run({
+              github,
+              context,
+              core,
+              dryRun: !!process.env.DRY_RUN,
+              batchSize: parseInt(process.env.MERGE_SHEPHERD_BATCH_SIZE, 10) || undefined,
+            });

--- a/.github/workflows/merge-shepherd.yml
+++ b/.github/workflows/merge-shepherd.yml
@@ -50,13 +50,25 @@ jobs:
           ref: master
           sparse-checkout: .github/scripts
 
+      - name: Check shepherd script exists on master
+        id: script-check
+        run: |
+          if [ -f .github/scripts/merge-shepherd.js ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::.github/scripts/merge-shepherd.js is not on master yet — nothing to run"
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3 (= v3.2.0)
+        if: steps.script-check.outputs.exists == 'true'
         id: app-token
         with:
           app-id: ${{ secrets.MERGE_SHEPHERD_APP_ID }}
           private-key: ${{ secrets.MERGE_SHEPHERD_APP_PRIVATE_KEY }}
 
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9 (= v9.0.0)
+        if: steps.script-check.outputs.exists == 'true'
         env:
           DRY_RUN: ${{ inputs.dry_run == true && '1' || '' }}
           MERGE_SHEPHERD_BATCH_SIZE: ${{ vars.MERGE_SHEPHERD_BATCH_SIZE }}

--- a/docs/MERGE_SHEPHERD.md
+++ b/docs/MERGE_SHEPHERD.md
@@ -1,0 +1,134 @@
+# Merge Shepherd
+
+Merge Shepherd is an in-repo bot (`.github/workflows/merge-shepherd.yml`)
+that merges PRs into `master` automatically, without humans watching for merge
+windows. It exists because `master` requires branches to be up to date and
+passing CI — every merge invalidates every other open PR.
+
+## Using it (PR authors)
+
+1. Get your PR **approved** and resolve all review conversations.
+2. Add the **`auto-merge` label**.
+3. Walk away. The bot will keep your branch updated with `master`, re-run
+   flaky CI failures (up to 5 retries per head commit), and GitHub merges
+   the PR the moment all required checks pass.
+
+The queue is processed **oldest PR first**, up to **3 PRs at a time** (batch
+size is configurable via the repository Actions variable
+`MERGE_SHEPHERD_BATCH_SIZE`, default 3).
+
+Your PR is **ejected from the queue** (label removed, comment explains why —
+and, if auto-merge was already armed on it, the comment says so too, since
+ejection never disables auto-merge) if:
+
+- it has **merge conflicts** with `master` — resolve them and re-add the label;
+- its **required checks failed 6 times** (1 run + 5 retries) on the same
+  head commit — push a fix and re-add the label. (When a failing required
+  check is an external status with no re-runnable workflow run, the bot
+  can't re-run it; it instead waits out the same number of cycles for the
+  check to resolve on its own, then ejects.) This kind of ejection also
+  adds the **`auto-merge-failed`** marker label, so failed queue runs are
+  visible at a glance in PR lists (conflict ejections don't get it — they
+  didn't fail any runs), and the ejection comment **@-mentions the PR
+  author** so they get a direct notification with links to the failing
+  runs. After the PR merges or is closed, the marker is removed by a
+  best-effort sweep on a subsequent bot run (even if the label is never
+  re-added) — it may persist briefly until the next run picks it up.
+
+Draft, unapproved, or unresolved-conversation PRs keep the label but are
+skipped (and don't block others) until they become eligible. The bot
+**never disables auto-merge**, for any reason — not because a PR became
+ineligible, and not on ejection (conflict or failed-checks). Once auto-merge
+is armed on a PR, it stays armed until the PR merges or is closed — the only
+way to revoke it before then is a human clicking "Disable auto-merge" on the
+PR page.
+
+> **Removing the label does not cancel auto-merge.** Once the bot has told
+> GitHub to auto-merge your PR, removing the `auto-merge` label only stops
+> the bot from managing the PR further — it does **not** revoke the
+> auto-merge request you already gave GitHub. If you want to fully opt out
+> after the bot has armed your PR, also click **"Disable auto-merge"** on
+> the PR page yourself.
+
+## How it works
+
+- Runs immediately when a PR gets the `auto-merge` label, when a PR is
+  approved, and after every push to `master` — plus a scheduled sweep
+  (nominally every 10 minutes; GitHub's cron is best-effort and in
+  practice fires roughly every half hour) that handles retries and
+  anything the event triggers missed.
+- For each batch PR: updates the branch via the API if behind, enables
+  GitHub **native auto-merge** (merge commit), so no bot action is needed
+  at the moment of green.
+- Retry state is stored in a bot comment on the PR
+  (`merge-shepherd-state` marker); pushing new commits resets the count.
+- Logic lives in `.github/scripts/merge-shepherd.js`; unit tests in
+  `.github/scripts/merge-shepherd.test.js` — run with `npm run
+  test:merge-shepherd` (or directly:
+  `node --test .github/scripts/merge-shepherd.test.js`).
+
+## One-time setup (org admin)
+
+1. **Create a GitHub App** (org Settings → Developer settings → GitHub
+   Apps → New): name `merge-shepherd`, uncheck Webhook. Repository
+   permissions: **Contents: Read & write**, **Pull requests: Read &
+   write**, **Issues: Read & write**, **Actions: Read & write**, **Checks:
+   Read-only**, **Commit statuses: Read-only**.
+
+   Commit statuses is required because the bot reads each PR's
+   `statusCheckRollup`, which aggregates check runs *and* legacy commit
+   statuses — without it the queue query fails with "Resource not
+   accessible by integration" whenever a labeled PR exists.
+2. **Install** the App on the `countly-server` repository.
+3. Generate a **private key** (App settings → Private keys).
+4. Add repo **Actions secrets**: `MERGE_SHEPHERD_APP_ID` (the App ID) and
+   `MERGE_SHEPHERD_APP_PRIVATE_KEY` (full PEM contents).
+5. In repo Settings → General, enable **"Always suggest updating pull
+   request branches"** (optional quality-of-life for manual updates).
+
+Why an App and not `GITHUB_TOKEN`: pushes made with the default workflow
+token do not trigger other workflows, so updated PRs would never get CI
+runs. App-token pushes trigger CI normally.
+
+## Dry run
+
+Actions → Merge Shepherd → Run workflow → check **dry_run**. The run logs
+every action it would take and mutates nothing. Check the run's job summary
+for the queue table.
+
+## Troubleshooting
+
+Every run starts with a **permission preflight**: before touching the queue,
+the bot probes **read** access for Contents, Issues (labels), Actions
+(workflow runs), and Checks/Commit statuses (status rollups). A read probe
+passing does not prove the corresponding write permission is present —
+write-level access (and any per-PR-only permission) is verified the first
+time it's actually used, not upfront. If a preflight probe comes back with a
+missing-permission error, the run **fails immediately** — it does not fall
+through to an empty, green queue run. The specific missing permission is
+named both in the job summary (under an "Errors" section) and in the run's
+log, so you don't have to guess from a stack trace.
+
+The same translation applies to permission errors encountered later in a
+run — while merging, updating a branch, re-running checks, retrying,
+ejecting, writing state/eject comments, or evaluating a PR's required
+checks. These are caught, translated into an actionable message naming the
+missing permission, and surfaced in the job summary; a permission failure
+during per-PR processing **fails the run** rather than being reported as a
+warning, since it would otherwise recur silently for every PR on every
+subsequent run.
+
+If per-PR processing fails on the required-checks query specifically, the
+App may additionally need **Administration: Read-only** — evaluating which
+checks are required consults the repository's branch protection rules, and
+GitHub's `isRequired` lookup needs Administration access to read that
+configuration. Check the run summary for the named permission.
+
+If you ever see **"Resource not accessible by integration"** anywhere —
+in a run's logs or in the job summary — it always means the GitHub App is
+missing a permission it needs. Check the job summary for which permission
+is named, add it to the App (org Settings → Developer settings → GitHub
+Apps → merge-shepherd → Permissions), then **re-accept the permission
+update** on the repository installation (the App owner/admin gets a
+prompt for this after permissions change — installed permissions don't
+take effect until accepted).

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "scripts": {
     "test": "grunt --verbose",
+    "test:merge-shepherd": "node --test .github/scripts/merge-shepherd.test.js",
     "prepare": "husky",
     "postinstall": "mkdir -p frontend/express/public/sdk/web && cp -rf node_modules/countly-sdk-web/lib/* frontend/express/public/sdk/web/"
   },


### PR DESCRIPTION
## What

Ports the **Merge Shepherd** bot from [countly-platform](https://github.com/Countly/countly-platform) to this repo:

- `.github/workflows/merge-shepherd.yml` — runs on a 10-minute schedule, on pushes to `master`, when a PR gets the `auto-merge` label, on approvals, and via manual dispatch (with a dry-run option)
- `.github/scripts/merge-shepherd.js` — the bot logic (copied from countly-platform)
- `.github/scripts/merge-shepherd.test.js` — unit tests (79 tests, all passing via `npm run test:merge-shepherd`)
- `docs/MERGE_SHEPHERD.md` — usage + one-time setup docs
- `.github/scripts/.eslintrc.json` — local ESLint override (ES2023, node), since the root legacy config can't parse the script; countly-platform carries the equivalent in its flat config

## Why

Opt-in PR merge queue: label an approved PR with `auto-merge` and the bot keeps its branch updated with `master`, re-runs flaky CI failures (up to 5 retries per head commit), enables GitHub native auto-merge, and ejects PRs that conflict or keep failing (with an explanatory comment and the `auto-merge-failed` marker label).

## Adaptations from the source repo

- Default branch `main` → `master` in the workflow push trigger, checkout ref, and the conflict-ejection comment
- Docs updated to reference countly-server and `master`; dropped a platform-specific CI-suite detail

## Reviewer notes / setup required before this can run

The workflow needs the `merge-shepherd` GitHub App installed on this repository and two Actions secrets: `MERGE_SHEPHERD_APP_ID` and `MERGE_SHEPHERD_APP_PRIVATE_KEY` (see `docs/MERGE_SHEPHERD.md`). Without them the run fails fast with a pointer to the docs. Batch size is configurable via the `MERGE_SHEPHERD_BATCH_SIZE` Actions variable (default 3).

A safe first validation after merge: Actions → Merge Shepherd → Run workflow → check **dry_run** — logs planned actions without mutating anything.