### PR TITLE
docs(security): order the vulnerability levels on what the attacker already has

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,13 +5,18 @@ Security is very important to us. If you discover any issue regarding security, 
 All software related security bugs with severity of medium and higher will be awarded accordingly with a bug bounty reward.
 
 # Vulnerability levels
-**Critical Severity:** software can be exploited at any time without any additional information
 
-**High Severity:** some additional information, access or action required (from the user, like clicking on injected link) for software to be exploited
+The levels are ordered on what an attacker must already have, before impact is considered. A finding that requires no account always grades above one that requires an account. That ordering follows from Countly being deployed as a single-tenant application: whoever holds a dashboard account is someone the deployment has already extended trust to, so a finding that requires an account is bounded by an internal trust boundary, whereas one that requires no account is not bounded at all.
 
-**Medium Severity:** the impact is limited (for example, can only access limited information) or requires special conditions to achieve it (when server is configured in specific way)
+**Critical Severity:** no account is needed, and no additional information or special conditions either. It can be exploited as it stands, and the impact reaches the highest permissions in the system, up to full takeover.
 
-**Low** - no bounty rewards, does not directly lead to vulnerability, but provides a possibility (like exposing software version, which can be mapped to specific vulnerabilities), old dependencies, server misconfiguration
+**High Severity:** no account is needed, but exploitation requires additional information or special conditions. A credential that ships inside the customer's own application, such as an app key, is not an account for this purpose, since it can be read out of any deployed application or website.
+
+**Medium Severity:** an account is required, and the impact is either data an application has collected from its end users, or a credential that grants access. Gaining permissions the account was not granted counts too, whether at a higher level or at the same level on an application where it holds no role.
+
+Descriptive information about the deployment itself, such as which applications and members exist and what they are called, is not sufficient for Medium on its own. In a single-tenant deployment that is ordinarily known to colleagues already, so a finding limited to it is Low.
+
+**Low** - no bounty rewards. Either the business impact is small, or reproduction depends on a chain of conditions so unlikely that it does not amount to a practical attack. This applies at any level of access: a finding that needs no account is still Low when what it yields does not matter, such as exposing a software version, which can be mapped to specific vulnerabilities, old dependencies, or server misconfiguration.
 
 **Exclusions (out of scope — not eligible for bounty)**
 


### PR DESCRIPTION
The levels described what an attack needs in order to work, but mixed that with how much the impact is worth, and said nothing about how the two interact. A recent report sat on every resulting gap at once and took a long argument to grade, which is the wrong amount of work for a triage decision.

### What was ambiguous

- Medium's *"requires special conditions to achieve it (when server is configured in specific way)"* reads as confining the branch to deployment quirks, if the parenthetical is taken as a definition rather than an example. Then a finding whose precondition is of any other kind has nowhere to go but High.
- High's *"clicking on injected link"* does not say whose link, or where. A link every colleague loads in a shared view and a link inside the edit form of a record only the attacker created are very different odds, and both fit those four words.
- Nothing said what happens when preconditions stack. One is plainly High; two had no rule, so the step down to Medium was undefined.
- Nothing said what the single-tenant deployment model means for grading.

### What changed

The levels are now ordered on one question first — does exploitation require an account at all — with impact considered within that. Whoever holds a dashboard account is someone a single-tenant deployment has already extended trust to, so an attack requiring one is bounded by an internal trust boundary, while an attack requiring none is not bounded at all. That ordering is stated up front because everything else follows from it.

Ordering on the account requirement has two useful consequences. It removes the need for any rule about stacked preconditions, since the account test already separates the cases that rule existed to handle. And it gives a home to findings that previously had none: one reachable with no account whose impact stops short of the highest permissions now grades above every authenticated finding, instead of failing the impact test in one row and the account test in the next.

An app key is called out as not being an account. It ships inside the customer's own application and can be read out of it, so treating it as access would put a finding exploitable by anyone on the same footing as one requiring a granted account.

Medium's impact bound is collected data or credentials. "Collected" is the word carrying it: data gathered from an application's end users is what a customer would call a breach, while which applications and members exist and what they are called is ordinarily known to colleagues in a single-tenant deployment, and is not worth a bounty on its own. That holds without listing any field names.

Low now says explicitly that it applies at any level of access. Without that, the ordering rule and the Low row contradict each other: disclosing a software version needs no account and no special conditions, and would read as Critical on the rows alone.

### Scope

Nothing leaves scope and no category narrows; this only decides which level applies to something already in scope. The exclusions list is untouched.

Only `SECURITY.md` on `master` changes. The `release.24.05` copy is already well behind and previous policy commits were not backported, so it is left alone.
