### PR TITLE
[fix][push] render message text as text in the notification preview (24.05)

### DIFF
--- a/plugins/push/frontend/public/javascripts/countly.models.js
+++ b/plugins/push/frontend/public/javascripts/countly.models.js
@@ -924,7 +924,15 @@
                     message = "";
                 }
                 if (!userPropertiesDto) {
-                    return message;
+                    //the same round trip the personalization path makes below, for the same
+                    //reason: the result is handed to innerHTML in
+                    //getPreviewMessageComponentsList. Returning the value untouched relied on
+                    //the api having escaped it, which holds for a stored notification and not
+                    //for text typed into the editor, whose state this preview also renders.
+                    //
+                    //Decode then escape rather than escape alone: escaping an already escaped
+                    //message would show &lt;b&gt; to the user instead of what they wrote.
+                    return self.escapeMessageText(self.decodeHtml(message));
                 }
                 // var html = '',
                 //     keys = this.sortUserProperties(userPropertiesDto),
@@ -965,11 +973,19 @@
                 //length purposes, so every position it computes is the position it computed
                 //before. Only markup generated here survives the escape.
                 var messageInHTMLString = this.decodeHtml(message);
+                //A fixed token could be typed into the message. Then the replacement below
+                //cannot tell the author's text from ours: it becomes an extra personalization
+                //span, or disappears when the index is out of range, and the edit state carries
+                //that corruption back on save. A per call nonce cannot be guessed or typed.
+                //
+                //Length is not constrained - the arithmetic below measures the token it
+                //actually inserted - so this changes nothing about the offsets.
+                var tokenNonce = "CLYPERS" + Math.random().toString(36).slice(2, 10);
                 var placeholderElements = [];
                 var buildMessageLength = 0;
                 var previousIndex = undefined;
                 this.sortUserProperties(userPropertiesDto).forEach(function(currentUserPropertyIndex, index) {
-                    var userPropertyStringElement = "@@CLY_PERS_" + placeholderElements.length + "@@";
+                    var userPropertyStringElement = "@@" + tokenNonce + "_" + placeholderElements.length + "@@";
                     placeholderElements.push(self.getUserPropertyElement(currentUserPropertyIndex, userPropertiesDto[currentUserPropertyIndex]));
                     if (index === 0) {
                         messageInHTMLString = self.insertUserPropertyAtIndex(messageInHTMLString, currentUserPropertyIndex, userPropertyStringElement);
@@ -987,7 +1003,7 @@
                     previousIndex = currentUserPropertyIndex;
                 });
                 //The token has no character the escape touches, so it comes through intact.
-                return self.escapeMessageText(messageInHTMLString).replace(/@@CLY_PERS_(\d+)@@/g, function(match, tokenIndex) {
+                return self.escapeMessageText(messageInHTMLString).replace(new RegExp("@@" + tokenNonce + "_(\\d+)@@", "g"), function(match, tokenIndex) {
                     return placeholderElements[Number(tokenIndex)] || "";
                 });
             },

--- a/plugins/push/frontend/public/javascripts/countly.models.js
+++ b/plugins/push/frontend/public/javascripts/countly.models.js
@@ -900,6 +900,24 @@
                     return map[m];
                 });
             },
+            /**
+             * Escape text so it cannot contribute markup once the result reaches innerHTML.
+             *
+             * Deliberately a string replacement rather than countlyCommon.encodeHtml, which
+             * round-trips through innerText and would normalise newlines into <br>, changing
+             * the text and the offsets the personalization indexes rely on.
+             *
+             * @param {string} str - untrusted text
+             * @returns {string} the text, safe to place in an html string
+             */
+            escapeMessageText: function(str) {
+                return String(str)
+                    .replace(/&/g, "&amp;")
+                    .replace(/</g, "&lt;")
+                    .replace(/>/g, "&gt;")
+                    .replace(/"/g, "&quot;")
+                    .replace(/'/g, "&#39;");
+            },
             buildMessageText: function(message, userPropertiesDto) {
                 var self = this;
                 if (!message) {
@@ -936,11 +954,23 @@
                 //     }
                 // });
                 // return html;
+                //The indexes in userPropertiesDto are offsets into the message as it was typed,
+                //so the escaping the api applied has to come off before they can line up. The
+                //result is handed to innerHTML further along, in
+                //getPreviewMessageComponentsList, which is what made a tag in the message run.
+                //
+                //So the placeholders go in as opaque tokens first, the whole string is escaped,
+                //and the tokens are swapped for their elements afterwards. The arithmetic below
+                //is untouched: a token takes the element's place and is the same string for
+                //length purposes, so every position it computes is the position it computed
+                //before. Only markup generated here survives the escape.
                 var messageInHTMLString = this.decodeHtml(message);
+                var placeholderElements = [];
                 var buildMessageLength = 0;
                 var previousIndex = undefined;
                 this.sortUserProperties(userPropertiesDto).forEach(function(currentUserPropertyIndex, index) {
-                    var userPropertyStringElement = self.getUserPropertyElement(currentUserPropertyIndex, userPropertiesDto[currentUserPropertyIndex]);
+                    var userPropertyStringElement = "@@CLY_PERS_" + placeholderElements.length + "@@";
+                    placeholderElements.push(self.getUserPropertyElement(currentUserPropertyIndex, userPropertiesDto[currentUserPropertyIndex]));
                     if (index === 0) {
                         messageInHTMLString = self.insertUserPropertyAtIndex(messageInHTMLString, currentUserPropertyIndex, userPropertyStringElement);
                         buildMessageLength = Number(currentUserPropertyIndex) + userPropertyStringElement.length;
@@ -956,7 +986,10 @@
                     }
                     previousIndex = currentUserPropertyIndex;
                 });
-                return messageInHTMLString;
+                //The token has no character the escape touches, so it comes through intact.
+                return self.escapeMessageText(messageInHTMLString).replace(/@@CLY_PERS_(\d+)@@/g, function(match, tokenIndex) {
+                    return placeholderElements[Number(tokenIndex)] || "";
+                });
             },
             mapType: function(dto) {
                 if (dto.triggers[0].kind === 'plain') {


### PR DESCRIPTION
The push details view builds its phone-style preview by splicing personalization elements into the message and handing the result to `innerHTML`, so it can walk the child nodes back out and turn each into a component:

```js
// countly.models.js
var messageInHTMLString = this.decodeHtml(message);      // then placeholders spliced in
...
htmlTitle.innerHTML = content;                            // parsed back out here
```

The message text travels inside that string, so a tag in the message was parsed as markup rather than shown as text, and its event handlers ran.

### Why the decode has to stay

It looks like the obvious thing to remove, but it is load-bearing. The keys in `messagePers` and `titlePers` are character offsets into the message *as it was typed*, and the API escapes on output, so `&` arrives as five characters instead of one. Decoding is what puts the string back into the coordinate space those offsets refer to. Drop it and every element after an escaped character lands in the wrong place.

That also rules out the simpler-looking `textContent = content`, which would remove the markup the walk exists to find and take the personalization chips with it.

### What changed

Placeholders now go in as opaque tokens, the whole string is escaped, and the tokens are swapped for their elements afterwards. Only markup generated by this code survives the escape.

The offset arithmetic is untouched — a token stands in for an element and is measured the same way, so every position it computes is the position it computed before. Escaping is a plain string replacement rather than `countlyCommon.encodeHtml`, which round-trips through `innerText` and would fold newlines into `<br>`, changing both the text and those offsets.

This covers the title as well as the message, since both go through `buildMessageText`. The element markup itself was already safe: `getUserPropertyElement` builds it with `setAttribute` and `innerText` and serialises with `outerHTML`, so the label, key and fallback were already escaped by the serialiser.

### Verification

Compared against the pre-change source, in a real DOM:

- the pre-change source does produce the element, which confirms the harness reaches the code path
- after the change no element and no event-handler attribute are produced, and the value shows as the text that was typed
- preview components are byte-identical across a single placeholder mid-text, one at the start, two placeholders, adjacent placeholders, text containing an ampersand, and a message with no personalization at all

`node --check` and `npx eslint` clean on all three branches. Not covered by an automated test in-repo: the push frontend has no DOM test harness, and adding one is out of scope here.
