### PR TITLE
[fix][core] keep caller input out of the export query specification (24.05)

### DIFF
--- a/api/parts/data/exports.js
+++ b/api/parts/data/exports.js
@@ -741,19 +741,30 @@ exports.fromRequest = function(options) {
  * hidden one level down. Names are matched as object keys, which is the only place a stage
  * operator appears.
  *
+ * The node budget is a stop on runaway work, not a verdict. Exhausting it means the
+ * pipeline could not be verified, which is a reason to refuse rather than to proceed:
+ * returning "nothing found" there would let a large enough structure in front of an
+ * $out carry the write through.
+ *
  * @param {Array} pipeline - aggregation pipeline to inspect
- * @returns {string|null} the offending stage name, or null when there is none
+ * @returns {string|null} why the pipeline must be refused, or null when it is safe
  */
 function findWriteStage(pipeline) {
     var WRITE_STAGES = ["$out", "$merge"];
+    var MAX_NODES = 10000;
     var seen = 0;
+    var exhausted = false;
 
     /**
      * @param {*} node - value to walk
      * @returns {string|null} offending stage name or null
      */
     function walk(node) {
-        if (seen++ > 10000 || !node || typeof node !== "object") {
+        if (seen++ > MAX_NODES) {
+            exhausted = true;
+            return null;
+        }
+        if (!node || typeof node !== "object") {
             return null;
         }
         if (Array.isArray(node)) {
@@ -776,7 +787,12 @@ function findWriteStage(pipeline) {
         }
         return null;
     }
-    return walk(pipeline);
+    var found = walk(pipeline);
+    if (found) {
+        return "write stage " + found;
+    }
+    //fail closed: unverified is not the same as verified safe
+    return exhausted ? "pipeline too large to verify (over " + MAX_NODES + " nodes)" : null;
 }
 
 exports.fromRequestQuery = function(options) {
@@ -815,7 +831,7 @@ exports.fromRequestQuery = function(options) {
                 //or tampered spec from turning a read into a write.
                 var writeStage = findWriteStage(body.pipeline);
                 if (writeStage) {
-                    log.e("Refusing export query containing a write stage: " + writeStage);
+                    log.e("Refusing export query: " + writeStage);
                     var refused = new Transform({
                         objectMode: true,
                         transform: (data, _, done) => {

--- a/api/parts/data/exports.js
+++ b/api/parts/data/exports.js
@@ -776,7 +776,14 @@ function findWriteStage(pipeline) {
             }
             return null;
         }
-        for (var key in node) {
+        //Object.keys rather than for...in: node is a parsed request payload, and an
+        //inherited enumerable key is not part of the pipeline the caller sent. Walking
+        //one would let a poisoned prototype decide what this scan looks at, which is the
+        //opposite of what a guard should allow. The platform copy of this function
+        //already reads it this way.
+        var keys = Object.keys(node);
+        for (var k = 0; k < keys.length; k++) {
+            var key = keys[k];
             if (WRITE_STAGES.indexOf(key) !== -1) {
                 return key;
             }

--- a/api/parts/data/exports.js
+++ b/api/parts/data/exports.js
@@ -734,6 +734,51 @@ exports.fromRequest = function(options) {
 };
 
 
+/**
+ * Look for an aggregation stage that writes, at any nesting depth.
+ *
+ * Sub-pipelines inside $lookup, $unionWith and $facet are searched too, so a write cannot be
+ * hidden one level down. Names are matched as object keys, which is the only place a stage
+ * operator appears.
+ *
+ * @param {Array} pipeline - aggregation pipeline to inspect
+ * @returns {string|null} the offending stage name, or null when there is none
+ */
+function findWriteStage(pipeline) {
+    var WRITE_STAGES = ["$out", "$merge"];
+    var seen = 0;
+
+    /**
+     * @param {*} node - value to walk
+     * @returns {string|null} offending stage name or null
+     */
+    function walk(node) {
+        if (seen++ > 10000 || !node || typeof node !== "object") {
+            return null;
+        }
+        if (Array.isArray(node)) {
+            for (var i = 0; i < node.length; i++) {
+                var fromItem = walk(node[i]);
+                if (fromItem) {
+                    return fromItem;
+                }
+            }
+            return null;
+        }
+        for (var key in node) {
+            if (WRITE_STAGES.indexOf(key) !== -1) {
+                return key;
+            }
+            var fromValue = walk(node[key]);
+            if (fromValue) {
+                return fromValue;
+            }
+        }
+        return null;
+    }
+    return walk(pipeline);
+}
+
 exports.fromRequestQuery = function(options) {
     options.db = options.db || common.db;
     options.path = options.path || "/";
@@ -748,7 +793,15 @@ exports.fromRequestQuery = function(options) {
         //providing data in request object
         'req': {
             url: options.path,
-            body: options.data || {},
+            //Deliberately empty. The endpoint being re-run supplies the collection and the
+            //pipeline, and that is only trustworthy while the caller cannot influence what it
+            //returns. processRequest copies every key of this body onto the inner request's
+            //params.qstring, so anything here reaches the endpoint as if it were a query
+            //parameter: an endpoint that keeps unrecognised parameters and returns what it
+            //stored would echo a caller-supplied collection and pipeline back to us. Every
+            //caller in the product passes its parameters in the path's query string instead,
+            //so there is nothing to forward.
+            body: {},
             method: "export"
         },
         //adding custom processing for API responses
@@ -757,6 +810,22 @@ exports.fromRequestQuery = function(options) {
                 log.e(err);
             }
             if (body) {
+                //A spec is the endpoint's own work, so its stages are trusted, but no endpoint
+                //has any reason to write. Refusing $out and $merge at any depth keeps a buggy
+                //or tampered spec from turning a read into a write.
+                var writeStage = findWriteStage(body.pipeline);
+                if (writeStage) {
+                    log.e("Refusing export query containing a write stage: " + writeStage);
+                    var refused = new Transform({
+                        objectMode: true,
+                        transform: (data, _, done) => {
+                            done(null, data);
+                        }
+                    });
+                    refused.end();
+                    options.output(refused);
+                    return;
+                }
                 if (body.transformFunction) {
                     options.transformFunction = body.transformFunction;
                 }

--- a/api/utils/requestProcessor.js
+++ b/api/utils/requestProcessor.js
@@ -2382,64 +2382,119 @@ const processRequest = (params) => {
                             common.returnMessage(params, 400, 'Missing parameter "path"');
                             return false;
                         }
-                        if (typeof params.qstring.data === "string") {
+
+                        //The endpoint named here supplies the collection and pipeline that get
+                        //executed, so it decides what this export reads. That is only safe for
+                        //endpoints written to build an export query, which authorize the request
+                        //and construct the query themselves. Those endpoints say so by answering
+                        //this hook; anything else is refused rather than re-run.
+                        var exportProducers = {params: params, producers: []};
+                        plugins.dispatch("/export/query/producers", exportProducers, function() {
+                            var requested;
                             try {
-                                params.qstring.data = JSON.parse(params.qstring.data);
+                                //parse rather than match on substrings: a repeated parameter
+                                //makes "method=views" present in a string whose effective value
+                                //is something else entirely
+                                requested = new URL(params.qstring.path + "", "http://localhost");
                             }
                             catch (ex) {
-                                console.log("Error parsing export request data", params.qstring.data, ex);
-                                params.qstring.data = {};
+                                common.returnMessage(params, 400, 'Invalid parameter "path"');
+                                return false;
                             }
+                            //a write endpoint is never an export query producer
+                            if (requested.pathname !== "/o" && requested.pathname.indexOf("/o/") !== 0) {
+                                common.returnMessage(params, 400, "Path is not an export query producer");
+                                return false;
+                            }
+                            var producer = exportProducers.producers.filter(function(candidate) {
+                                if (!candidate || candidate.path !== requested.pathname) {
+                                    return false;
+                                }
+                                var required = candidate.require || {};
+                                return Object.keys(required).every(function(key) {
+                                    return requested.searchParams.get(key) === required[key];
+                                });
+                            })[0];
+                            if (!producer) {
+                                common.returnMessage(params, 400, "Path is not an export query producer");
+                                return false;
+                            }
+                            //pin the values that select the producer's export branch, so the
+                            //caller cannot steer it into a different mode
+                            Object.keys(producer.require || {}).forEach(function(key) {
+                                requested.searchParams.set(key, producer.require[key]);
+                            });
+                            params.qstring.path = requested.pathname + "?" + requested.searchParams.toString();
+                            runExportQuery(producer);
+                        });
+
+                        /**
+                         * Re-run the producer and stream its query's results.
+                         *
+                         * @param {object} producer - the matched producer declaration
+                         * @returns {void}
+                         */
+                        function runExportQuery(producer) {
+                            var exportDbs = {countly: common.db, countly_drill: common.drillDb, countly_out: common.outDb};
+                            if (typeof params.qstring.data === "string") {
+                                try {
+                                    params.qstring.data = JSON.parse(params.qstring.data);
+                                }
+                                catch (ex) {
+                                    console.log("Error parsing export request data", params.qstring.data, ex);
+                                    params.qstring.data = {};
+                                }
+                            }
+                            var my_name = JSON.stringify(params.qstring);
+
+                            var ff = taskmanager.longtask({
+                                db: common.db,
+                                threshold: plugins.getConfig("api").request_threshold,
+                                force: true,
+                                gridfs: true,
+                                binary: true,
+                                app_id: params.qstring.app_id,
+                                params: params,
+                                type: params.qstring.type_name || "tableExport",
+                                report_name: params.qstring.filename + "." + params.qstring.type,
+                                meta: JSON.stringify({
+                                    "app_id": params.qstring.app_id,
+                                    "query": params.qstring.query || {}
+                                }),
+                                name: my_name,
+                                view: "#/exportedData/tableExport/",
+                                processData: function(err, res, callback) {
+                                    if (!err) {
+                                        callback(null, res);
+                                    }
+                                    else {
+                                        callback(err, '');
+                                    }
+                                },
+                                outputData: function(err, data) {
+                                    if (err) {
+                                        common.returnMessage(params, 400, err);
+                                    }
+                                    else {
+                                        common.returnMessage(params, 200, data);
+                                    }
+                                }
+                            });
+
+                            countlyApi.data.exports.fromRequestQuery({
+                                db: exportDbs[producer.db] || common.db,
+                                params: params,
+                                path: params.qstring.path,
+                                data: params.qstring.data,
+                                method: params.qstring.method,
+                                prop: params.qstring.prop,
+                                type: params.qstring.type,
+                                filename: params.qstring.filename + "." + params.qstring.type,
+                                output: function(data) {
+                                    ff(null, data);
+                                }
+                            });
                         }
-                        var my_name = JSON.stringify(params.qstring);
-
-                        var ff = taskmanager.longtask({
-                            db: common.db,
-                            threshold: plugins.getConfig("api").request_threshold,
-                            force: true,
-                            gridfs: true,
-                            binary: true,
-                            app_id: params.qstring.app_id,
-                            params: params,
-                            type: params.qstring.type_name || "tableExport",
-                            report_name: params.qstring.filename + "." + params.qstring.type,
-                            meta: JSON.stringify({
-                                "app_id": params.qstring.app_id,
-                                "query": params.qstring.query || {}
-                            }),
-                            name: my_name,
-                            view: "#/exportedData/tableExport/",
-                            processData: function(err, res, callback) {
-                                if (!err) {
-                                    callback(null, res);
-                                }
-                                else {
-                                    callback(err, '');
-                                }
-                            },
-                            outputData: function(err, data) {
-                                if (err) {
-                                    common.returnMessage(params, 400, err);
-                                }
-                                else {
-                                    common.returnMessage(params, 200, data);
-                                }
-                            }
-                        });
-
-                        countlyApi.data.exports.fromRequestQuery({
-                            db: (params.qstring.db === "countly_drill") ? common.drillDb : (params.qstring.dbs === "countly_drill") ? common.drillDb : common.db,
-                            params: params,
-                            path: params.qstring.path,
-                            data: params.qstring.data,
-                            method: params.qstring.method,
-                            prop: params.qstring.prop,
-                            type: params.qstring.type,
-                            filename: params.qstring.filename + "." + params.qstring.type,
-                            output: function(data) {
-                                ff(null, data);
-                            }
-                        });
                     }, params);
                     break;
                 case 'download': {

--- a/plugins/views/api/api.js
+++ b/plugins/views/api/api.js
@@ -15,6 +15,18 @@ const FEATURE_NAME = 'views';
 const escapedViewSegments = { "name": true, "segment": true, "height": true, "width": true, "y": true, "x": true, "visit": true, "uvc": true, "start": true, "bounce": true, "exit": true, "type": true, "view": true, "domain": true, "dur": true, "_id": true, "_idv": true, "utm_source": true, "utm_medium": true, "utm_campaign": true, "utm_term": true, "utm_content": true, "referrer": true};
 //keys to not use as segmentation
 (function() {
+    //Declares this plugin as an export query producer. /o/export/requestQuery re-runs the
+    //endpoint named here and executes the collection and pipeline it returns, so only endpoints
+    //that build such a query and authorize it themselves may be named. `require` pins the
+    //parameters that select the branch below which returns the query rather than the rows.
+    plugins.register("/export/query/producers", function(ob) {
+        ob.producers.push({
+            path: "/o",
+            require: {method: "views", action: "getExportQuery"},
+            db: "countly"
+        });
+    });
+
     plugins.register("/permissions/features", function(ob) {
         ob.features.push(FEATURE_NAME);
     });


### PR DESCRIPTION
`/o/export/requestQuery` re-runs an internal endpoint and uses the collection and pipeline that endpoint returns. That is sound while the specification is the endpoint's own work: the endpoint authorises the request and builds the query itself, so the query inherits that authorisation. `views`, `heatmaps` and `surveys` all work this way, returning `{db, collection, pipeline, projection}` from a dedicated branch.

It stopped being the endpoint's own work because the caller's `data` was forwarded as the inner request's body, and `processRequest` copies every body key onto `params.qstring`:

```js
if (params.req.body && typeof params.req.body === "object") {
    for (let i in params.req.body) { params.qstring[i] = params.req.body[i]; }
}
```

So anything in `data` reaches the endpoint indistinguishable from a query parameter. An endpoint that keeps parameters it does not recognise and then returns what it stored will hand a caller-supplied `collection` and `pipeline` straight back, and the export runs it. The authorisation that took place was for the endpoint's own action and had nothing to do with the resulting read.

### What changed

**`data` is no longer forwarded.** No caller sends it: `views`, `heatmaps`, `surveys`, the shared datatable export and `countly.helpers` all pass their parameters in the path's query string. So the inner body is empty and there is nothing for any endpoint to echo.

**Write stages are refused**, as a second and independent check. No endpoint building an export query has any reason to write, and none of the three emits one, so a specification containing `$out` or `$merge` is a bug or worse. The search covers sub-pipelines inside `$lookup`, `$unionWith` and `$facet`, so a write cannot sit one level down.

`exports.fromRequest` forges the same request shape but exports the endpoint's *response* rather than running a query built from it, so it is deliberately untouched here.

### Also included: only declared producers may be named

The endpoint named in `path` decides what the export reads, so it is now refused unless it declares itself by answering `/export/query/producers`, giving the path it answers on, the parameter values that select its export branch, and the database its query targets. `views` declares itself here; `heatmaps` and `surveys` do so in countly-enterprise-plugins (PRs #3344 and #3345), and `heatmaps` also in countly-platform.

The path is parsed rather than substring-matched, since a repeated parameter leaves `method=views` present in a string whose effective value is something else. Paths outside `/o` are refused outright, because a write endpoint is never a producer. The declared parameters are then pinned into the inner request so the caller cannot select a producer and steer it into a different mode. `db` comes from the declaration too: the surveys client sends `db=countly_drill` from the browser today, which is why that had to move to the producer.

The three producers have no shared convention — `views` is `/o` plus `method=views&action=getExportQuery`, `heatmaps` is its own path `/o/heatmaps/export` with no parameters, `surveys` is `/o/surveys/survey/data` plus `method=export` — so the contract is path plus required parameter values rather than fixed fields.

### Deliberately not included

- **Restricting pipeline stages by role.** The existing `dbviewer` aggregation guard cannot be reused as-is: `views` legitimately emits `$lookup` and `surveys` legitimately emits `$unionWith`, both of which `ALLOWED_STAGES_USER` excludes, and `sanitizeAggregation` strips rather than rejects. Applying it would quietly return wrong export data to non-global members.

### Verification

The write-stage walk was exercised against pipelines shaped like all three real producers (which pass untouched) and against `$out`/`$merge` at the top level, inside a `$unionWith` sub-pipeline, inside `$facet`, and two levels down inside `$lookup`, plus non-array and null inputs. `node --check` and `npx eslint` clean on the countly-server branches. On countly-platform, `tsc` reports the same 2 pre-existing errors in this file and the same 5876 repo-wide, before and after.
