### PR TITLE
[fix][push] bind push action counters to the ingesting app (24.05)

### DIFF
--- a/plugins/push/api/api.js
+++ b/plugins/push/api/api.js
@@ -157,8 +157,14 @@ plugins.register('/i', async ob => {
         let push = events.filter(e => e.key && e.key.indexOf('[CLY]_push_action') === 0 && e.segmentation && e.segmentation.i && e.segmentation.i.length === 24);
         if (push.length) {
             try {
-                let ids = push.map(e => common.db.ObjectID(e.segmentation.i)),
-                    msgs = await Message.findMany({_id: {$in: ids}}),
+                //Bound to the app the event was ingested under. The message id travels to
+                //devices in the notification payload as c.i, so it is not private to the app that
+                //sent it, and without this an event submitted with one app's key could move
+                //another app's action counters. `app` is stored as an ObjectID, so the request's
+                //id is converted rather than compared as a string.
+                let requestApp = common.db.ObjectID(params.app_id + ""),
+                    ids = push.map(e => common.db.ObjectID(e.segmentation.i)),
+                    msgs = await Message.findMany({_id: {$in: ids}, app: requestApp}),
                     updates = {};
                 for (let i = 0; i < push.length; i++) {
                     let event = push[i],
@@ -211,7 +217,7 @@ plugins.register('/i', async ob => {
                     }
                 }
 
-                await Promise.all(Object.keys(updates).map(mid => common.db.collection('messages').updateOne({_id: common.db.ObjectID(mid)}, updates[mid])));
+                await Promise.all(Object.keys(updates).map(mid => common.db.collection('messages').updateOne({_id: common.db.ObjectID(mid), app: requestApp}, updates[mid])));
             }
             catch (e) {
                 log.e('Wrong [CLY]_push_* event i segmentation', e);


### PR DESCRIPTION
The `[CLY]_push_action` handler resolved the message by `_id` and later updated it by `_id`, with no reference to the app the event arrived under:

```js
msgs = await Message.findMany({_id: {$in: ids}}),
...
common.db.collection('messages').updateOne({_id: common.db.ObjectID(mid)}, updates[mid])
```

The message id is delivered to devices in the notification payload as `c.i`, so it is not private to the app that sent the campaign. An event submitted with one app's key could therefore move another app's `result.actioned` and its per-platform and per-language subcounters.

Both the lookup and the write now carry the request's app.

### One detail worth checking in review

`app` is stored as an **ObjectID** on messages — `message.js:42` declares `type: 'ObjectID'`, and `api-reset.js` selects with `dbext.oid(ob.appId)`. So the request's id is converted rather than compared as a string. Comparing a string would have matched nothing and silently stopped all push action counting, which is the failure mode to watch for here.

### What this is and is not

It closes an app boundary rather than a capability. A recipient of a campaign already holds the sending app's public key, since it ships inside the application they installed, and reporting an action against a message id through that key is the intended ingestion path. So these counters were always movable by a recipient; what was wrong is that a *different* app's key could move them.

Related and not addressed here: there is no deduplication by message, device and action, so a single recipient can report the same action repeatedly through the intended path. That is an analytics integrity question rather than an app boundary one, and it applies equally to the star-rating widget counters.
