### PR TITLE
[fix][hooks] index endpoint rules by path, and let the older hook keep it (24.05)

### DIFF
--- a/plugins/hooks/api/api.js
+++ b/plugins/hooks/api/api.js
@@ -56,6 +56,7 @@ class Hooks {
         this._effects = {};
         this._queue = [];
 
+        this.ensureEndpointPathIndex();
         this.fetchRules();
         setInterval(() => {
             this.fetchRules();
@@ -96,6 +97,37 @@ class Hooks {
             const t = new Effects[type]();
             this._effects[type] = t;
         }
+    }
+
+    /**
+     * Keep api endpoint paths unique at the database level.
+     *
+     * Saving already refuses a path another hook holds, but that check is a read followed by a
+     * write, so two saves racing can still slip a duplicate through. A unique index closes
+     * that, and costs nothing at dispatch since rules are served from cache.
+     *
+     * Partial, so it constrains only api endpoint hooks: every other trigger type has no path
+     * and would otherwise collide on null. Instances that already hold a duplicate cannot build
+     * it, and that is deliberate rather than handled: the error is logged and everything carries
+     * on working, with the save-time check still preventing new duplicates. Nothing breaks, and
+     * the collision is resolved at dispatch by serving the older hook.
+     *
+     * @returns {void}
+     */
+    ensureEndpointPathIndex() {
+        common.db.collection("hooks").createIndex(
+            {"trigger.configuration.path": 1},
+            {
+                unique: true,
+                name: "hooks_api_endpoint_path_unique",
+                partialFilterExpression: {"trigger.type": "APIEndPointTrigger"}
+            },
+            function(err) {
+                if (err) {
+                    log.w("Could not create the unique index on api endpoint paths, most likely because two hooks already share one. New duplicates are still refused on save. %j", err.message || err);
+                }
+            }
+        );
     }
 
     /**
@@ -346,7 +378,8 @@ plugins.register("/i/hook/save", function(ob) {
                     //change only the trigger or only the apps
                     const updatedTriggerValidation = await validateTriggerConfiguration(
                         hookConfig.trigger || existingHook.trigger,
-                        hookConfig.apps || existingHook.apps
+                        hookConfig.apps || existingHook.apps,
+                        existingHook._id
                     );
                     if (!updatedTriggerValidation.valid) {
                         common.returnMessage(params, 400, updatedTriggerValidation.error);
@@ -402,7 +435,8 @@ plugins.register("/i/hook/save", function(ob) {
 });
 
 /**
- * Validate an InternalEventTrigger's configuration against the hook's own apps.
+ * Validate a trigger's configuration: an APIEndPointTrigger's path must be unused, and an
+ * InternalEventTrigger's event type must be known and scoped to the hook's own apps.
  *
  * The event type itself was never checked, so any string was accepted and stored.
  * More importantly, the events that name a target object matched on that id alone
@@ -418,9 +452,30 @@ plugins.register("/i/hook/save", function(ob) {
  *
  * @param {object} trigger - the effective trigger, payload merged over stored
  * @param {array} apps - the effective app ids the hook is scoped to
+ * @param {ObjectID} [hookId] - the hook being updated, so it does not clash with itself
  * @returns {Promise<object>} {valid, error}
  */
-async function validateTriggerConfiguration(trigger, apps) {
+async function validateTriggerConfiguration(trigger, apps, hookId) {
+    if (trigger && trigger.type === "APIEndPointTrigger") {
+        //Endpoint paths are global while hooks belong to apps, so nothing stops a hook on
+        //one app claiming a path already used by a hook on another. Dispatch matches on the
+        //path alone, so a second claimant receives the first one's callback parameters and
+        //the first one stops firing. Keep paths unique instead.
+        const path = (trigger.configuration || {}).path;
+        if (!path) {
+            return {valid: false, error: "Missing path for this trigger type"};
+        }
+        const clash = {"trigger.type": "APIEndPointTrigger", "trigger.configuration.path": path + ""};
+        if (hookId) {
+            //an update must not collide with the hook it is updating
+            clash._id = {$ne: hookId};
+        }
+        const taken = await common.db.collection("hooks").findOne(clash, {projection: {_id: 1}});
+        if (taken) {
+            return {valid: false, error: "This endpoint path is already in use. Choose another path."};
+        }
+        return {valid: true};
+    }
     if (!trigger || trigger.type !== "InternalEventTrigger") {
         return {valid: true};
     }

--- a/plugins/hooks/api/parts/triggers/api_endpoint.js
+++ b/plugins/hooks/api/parts/triggers/api_endpoint.js
@@ -3,6 +3,44 @@ const common = require('../../../../../api/utils/common.js');
 const utils = require('../../utils.js');
 const log = common.log('hooks:api_endpoint_trigger');
 /**
+ * Index rules by their endpoint path, so dispatch is a lookup rather than a scan.
+ *
+ * The path is global while a hook belongs to apps, so two hooks can claim the same one.
+ * Resolving that here rather than per request means the winner does not depend on the order
+ * an unsorted find returned the hooks in, which is not stable across updates or compaction.
+ *
+ * The oldest hook wins. Whoever claimed the path first keeps serving it, so a hook added
+ * later cannot take over a path already in use, and nothing that works today stops working.
+ *
+ * @param {Array} rules - api endpoint rules
+ * @returns {Map} path to the single rule that serves it
+ */
+function indexRulesByPath(rules) {
+    const byPath = new Map();
+    (rules || []).forEach(rule => {
+        const path = rule && rule.trigger && rule.trigger.configuration && rule.trigger.configuration.path;
+        if (!path) {
+            return;
+        }
+        const held = byPath.get(path);
+        if (!held) {
+            byPath.set(path, rule);
+            return;
+        }
+        //created_at is absent on hooks predating it, so fall back to the id, whose leading
+        //bytes are the creation time anyway
+        const heldAge = held.created_at || String(held._id);
+        const ruleAge = rule.created_at || String(rule._id);
+        const winner = ruleAge < heldAge ? rule : held;
+        const loser = winner === rule ? held : rule;
+        log.e("Two hooks claim endpoint path %j: serving %j, ignoring %j. Give each hook its own path.",
+            path, String(winner._id), String(loser._id));
+        byPath.set(path, winner);
+    });
+    return byPath;
+}
+
+/**
  * API endpoint  trigger
  */
 class APIEndPointTrigger {
@@ -13,6 +51,7 @@ class APIEndPointTrigger {
      */
     constructor(options) {
         this._rules = options.rules || [];
+        this._rulesByPath = indexRulesByPath(this._rules);
         this.pipeline = (() => {});
         if (options.pipeline) {
             this.pipeline = (data) => {
@@ -38,6 +77,7 @@ class APIEndPointTrigger {
                 return r.trigger.type === 'APIEndPointTrigger';
             });
             this._rules = newRules;
+            this._rulesByPath = indexRulesByPath(newRules);
         }
     }
 
@@ -52,12 +92,9 @@ class APIEndPointTrigger {
         const hookPath = paths.length >= 4 ? paths[3] : null;
         const {qstring} = params || {};
 
-        let rule = null;
-        this._rules.forEach(r => {
-            if (r.trigger.configuration.path === hookPath) {
-                rule = r;
-            }
-        });
+        //A lookup, not a scan: the map is built once per rule refresh, so a path collision
+        //is resolved there rather than on every request. See indexRulesByPath.
+        const rule = hookPath ? this._rulesByPath.get(hookPath) : null;
         if (!rule || !hookPath) {
             return false;
         }

--- a/plugins/hooks/api/parts/triggers/api_endpoint.js
+++ b/plugins/hooks/api/parts/triggers/api_endpoint.js
@@ -3,6 +3,34 @@ const common = require('../../../../../api/utils/common.js');
 const utils = require('../../utils.js');
 const log = common.log('hooks:api_endpoint_trigger');
 /**
+ * When a hook was created, in milliseconds.
+ *
+ * created_at is absent on hooks predating it, and an ObjectId's leading four bytes are
+ * the creation time in seconds, so the id stands in. Both are reduced to the same unit
+ * before anything is compared: a number against an id string coerces the string to NaN,
+ * every comparison is then false, and the hook already held would keep winning - which is
+ * the opposite of the oldest-wins rule, and only for the legacy hooks the fallback exists
+ * to serve.
+ *
+ * An age that cannot be determined at all sorts last rather than first, so an unknown
+ * does not displace a hook whose age is known.
+ *
+ * @param {object} rule - hook document
+ * @returns {number} creation time in milliseconds
+ */
+function hookCreatedAt(rule) {
+    const createdAt = Number(rule && rule.created_at);
+    if (Number.isFinite(createdAt) && createdAt > 0) {
+        return createdAt;
+    }
+    const id = String((rule && rule._id) || "");
+    if (/^[a-f0-9]{24}$/i.test(id)) {
+        return parseInt(id.substring(0, 8), 16) * 1000;
+    }
+    return Infinity;
+}
+
+/**
  * Index rules by their endpoint path, so dispatch is a lookup rather than a scan.
  *
  * The path is global while a hook belongs to apps, so two hooks can claim the same one.
@@ -27,11 +55,7 @@ function indexRulesByPath(rules) {
             byPath.set(path, rule);
             return;
         }
-        //created_at is absent on hooks predating it, so fall back to the id, whose leading
-        //bytes are the creation time anyway
-        const heldAge = held.created_at || String(held._id);
-        const ruleAge = rule.created_at || String(rule._id);
-        const winner = ruleAge < heldAge ? rule : held;
+        const winner = hookCreatedAt(rule) < hookCreatedAt(held) ? rule : held;
         const loser = winner === rule ? held : rule;
         log.e("Two hooks claim endpoint path %j: serving %j, ignoring %j. Give each hook its own path.",
             path, String(winner._id), String(loser._id));


### PR DESCRIPTION
An api endpoint hook's path is global while the hook belongs to apps, and nothing stopped a hook on one app claiming a path already held by a hook on another. Dispatch then matched on the path alone, assigning on every match with no break, so the winner was whichever the hooks query returned last — and that query is `find({"enabled": true}).toArray()` with no sort, so the order is undefined.

Where the colliding hooks belong to different apps, whichever wins receives the other's callback parameters, and the default email effect sends the whole parameter object, so a webhook's payload leaves the instance to an address chosen by the other app's hook. The losing hook stops firing. Between two hooks on the same app it is simply unpredictable, and natural order is not stable across updates or compaction, so a hook can stop working with nothing logged.

### Dispatch is now a lookup, not a scan

The rules are indexed by path where the rule list is already rebuilt, every `refreshRulesPeriod`. So a collision is resolved once per refresh rather than re-decided on every callback, and dispatch is an O(1) `get`. At a million callbacks a minute that removes a linear scan per request, which makes this faster than before the report rather than slower. The only added cost is one reference per hook in memory, and one extra pass over an array the refresh had just materialised anyway — next to the database query it already performs, that is noise.

### Collisions resolve to the older hook

By `created_at`, falling back to `_id` for hooks predating that field, since an ObjectID's leading bytes are the creation time. That gives three properties:

- **deterministic** — no dependence on query order, so no flipping after an update or compaction
- **non-breaking** — the hook that has been serving a path keeps serving it
- **closes the issue** — a hook created later is by definition the later claimant, so it never fires and cannot take over a path in use

Refusing both matches, which an earlier revision of this branch did, punishes the app that did nothing wrong. Serving the newest is the defect itself.

### Uniqueness at save, backed by an index

Saving already refuses a path another hook holds, on create and on update, with the update excluding the hook being edited. That is a read then a write, so two concurrent saves could still slip a duplicate through; a partial unique index closes it. Partial because only api endpoint hooks have a path and every other trigger type would otherwise collide on null.

An instance that already holds a duplicate cannot build the index. That is deliberately left alone rather than special-cased: the error is logged as a warning, everything keeps working, new duplicates are still refused on save, and the existing collision resolves to the older hook at dispatch.

### Verification

Nine checks on the collision resolution: the older hook wins whether it appears first or last in the array, the fallback to `_id` when `created_at` is absent, the oldest of three, distinct paths both surviving, pathless rules skipped, empty and undefined input, and that a log is emitted on collision and not otherwise. `node --check` and `npx eslint` clean.
