### PR TITLE
Arm auto-merge while retrying failed checks

### DIFF
--- a/.github/scripts/merge-shepherd.js
+++ b/.github/scripts/merge-shepherd.js
@@ -191,7 +191,13 @@ function planForBatchMember(pr) {
         if (retries >= CONFIG.MAX_RETRIES) {
             return [{ type: 'eject', number: pr.number, reason: 'failed-checks' }];
         }
-        return [{ type: 'retry', number: pr.number, nextRetries: retries + 1 }];
+        // arm while retrying too, so a green re-run merges the instant it completes
+        // instead of waiting for the next bot cycle to reach the wait branch
+        if (!pr.autoMergeEnabled) {
+            actions.push({ type: 'enable-automerge', number: pr.number });
+        }
+        actions.push({ type: 'retry', number: pr.number, nextRetries: retries + 1 });
+        return actions;
     }
     if (pr.mergeStateStatus === 'clean' || pr.mergeStateStatus === 'unstable') {
         return [{ type: 'merge', number: pr.number }];

--- a/.github/scripts/merge-shepherd.test.js
+++ b/.github/scripts/merge-shepherd.test.js
@@ -4,8 +4,6 @@ const { test } = require('node:test');
 const assert = require('node:assert');
 const shepherd = require('./merge-shepherd.js');
 
-/** test commend, delete this afterwards */
-
 /**
  * Builds a PR snapshot with sensible defaults for tests
  * @param {object} overrides - fields to override
@@ -122,8 +120,16 @@ test('behind branch updates even when old checks failed', () => {
     assert.deepStrictEqual(actions, [{ type: 'update-branch', number: 1 }]);
 });
 
-test('failed checks with no prior state retries as attempt 1', () => {
+test('failed checks with no prior state arms auto-merge and retries as attempt 1', () => {
     const actions = shepherd.planForBatchMember(makePr({ mergeStateStatus: 'blocked', checksFailed: true }));
+    assert.deepStrictEqual(actions, [
+        { type: 'enable-automerge', number: 1 },
+        { type: 'retry', number: 1, nextRetries: 1 },
+    ]);
+});
+
+test('failed checks with auto-merge already armed only retries', () => {
+    const actions = shepherd.planForBatchMember(makePr({ mergeStateStatus: 'blocked', checksFailed: true, autoMergeEnabled: true }));
     assert.deepStrictEqual(actions, [{ type: 'retry', number: 1, nextRetries: 1 }]);
 });
 
@@ -131,6 +137,7 @@ test('failed checks with one prior retry on same sha retries as attempt 2', () =
     const actions = shepherd.planForBatchMember(makePr({
         mergeStateStatus: 'blocked',
         checksFailed: true,
+        autoMergeEnabled: true,
         state: { sha: 'abc1234', retries: 1 },
     }));
     assert.deepStrictEqual(actions, [{ type: 'retry', number: 1, nextRetries: 2 }]);
@@ -149,6 +156,7 @@ test('retry counter resets when head sha changed since last retry', () => {
     const actions = shepherd.planForBatchMember(makePr({
         mergeStateStatus: 'blocked',
         checksFailed: true,
+        autoMergeEnabled: true,
         state: { sha: 'oldsha99', retries: 2 },
     }));
     assert.deepStrictEqual(actions, [{ type: 'retry', number: 1, nextRetries: 1 }]);

--- a/docs/MERGE_SHEPHERD.md
+++ b/docs/MERGE_SHEPHERD.md
@@ -59,7 +59,10 @@ PR page.
   anything the event triggers missed.
 - For each batch PR: updates the branch via the API if behind, enables
   GitHub **native auto-merge** (merge commit), so no bot action is needed
-  at the moment of green.
+  at the moment of green. Auto-merge is armed in every non-terminal state —
+  while updating, while waiting on checks, and while retrying failed ones —
+  so the instant required checks pass, the PR merges without waiting for
+  the next bot cycle.
 - Retry state is stored in a bot comment on the PR
   (`merge-shepherd-state` marker); pushing new commits resets the count.
 - Logic lives in `.github/scripts/merge-shepherd.js`; unit tests in


### PR DESCRIPTION
Port of the latest Merge Shepherd change from countly-platform ([Countly/countly-platform#1011](https://github.com/Countly/countly-platform/pull/1011)).

## What

The planner armed auto-merge on the *behind* and *waiting-on-checks* paths, but **not on the retry path**: a PR whose required checks failed got its jobs re-run without auto-merge armed, so even when the re-run went green the PR sat unmerged until the next bot cycle (~30 min effective cron) reached the wait branch and armed it. Now auto-merge is armed in every non-terminal batch state — behind, waiting, and retrying — so a green re-run merges the instant it completes.

- `.github/scripts/merge-shepherd.js` — arm auto-merge before the retry action when not already armed
- `.github/scripts/merge-shepherd.test.js` — new/updated planner tests (80/80 passing via `npm run test:merge-shepherd`); also removes the leftover "delete this afterwards" comment from #7896
- `docs/MERGE_SHEPHERD.md` — documents the always-armed behavior

## Reviewer notes

Content is identical to the source PR except the repo's existing `main` → `master` adaptation (one user-facing message in the script, branch names in docs). Note the source PR is still open on countly-platform — if it changes there before merging, this port may need a follow-up sync.