### PR TITLE
[fix][core] test for a plain container by prototype, not by reading constructor (24.05)

### DIFF
--- a/api/utils/common.js
+++ b/api/utils/common.js
@@ -114,6 +114,31 @@ common.decode_html = function(string) {
 };
 
 /**
+ * Whether a value is a plain object or an array, and so should be walked rather than escaped
+ * as a scalar.
+ *
+ * Tested by prototype identity rather than by reading value.constructor. `constructor` is an
+ * ordinary property name, so a JSON body can carry its own: {"constructor": true, ...} makes
+ * value.constructor evaluate to true, which used to fail the check and return the object with
+ * its keys and values unescaped. Since escape_html_entities is the replacer for every
+ * returnOutput and returnMessage, that turned any user controlled property name into markup
+ * wherever a response is rendered.
+ *
+ * Prototype identity cannot be spoofed by an own property, and it keeps the original intent:
+ * ObjectIDs, Dates and other class instances are still escaped as scalars rather than walked.
+ *
+ * @param {Any} value - value under inspection
+ * @returns {boolean} true when it should be recursed into
+ */
+function isPlainContainer(value) {
+    if (Array.isArray(value)) {
+        return true;
+    }
+    const proto = Object.getPrototypeOf(value);
+    return proto === Object.prototype || proto === null;
+}
+
+/**
 * Escape special characters in the given value, may be nested object
 * @param  {string} key - key of the value
 * @param  {vary} value - value to escape
@@ -121,7 +146,7 @@ common.decode_html = function(string) {
 * @returns {vary} escaped value
 **/
 function escape_html_entities(key, value, more) {
-    if (typeof value === 'object' && value && (value.constructor === Object || value.constructor === Array)) {
+    if (typeof value === 'object' && value && isPlainContainer(value)) {
         if (Array.isArray(value)) {
             let replacement = [];
             for (let k = 0; k < value.length; k++) {

--- a/plugins/compliance-hub/frontend/public/javascripts/countly.views.js
+++ b/plugins/compliance-hub/frontend/public/javascripts/countly.views.js
@@ -13,6 +13,13 @@
             this.$store.dispatch("countlyConsentManager/fetchUserDataResource");
         },
         methods: {
+            // Consent feature names are sdk supplied and rendered as text. The api
+            // escapes them on the way out, so undo that to keep the label readable.
+            consentFeatures: function(features) {
+                return (features || []).map(function(name) {
+                    return countlyCommon.unescapeHtml(name);
+                }).join(",");
+            },
             switchToConsentHistory: function(uid) {
                 window.location.hash = "#/manage/compliance/history/" + uid;
             },

--- a/plugins/compliance-hub/frontend/public/templates/user.html
+++ b/plugins/compliance-hub/frontend/public/templates/user.html
@@ -20,9 +20,9 @@
                     <template v-slot="rowScope">
                         <div v-if="rowScope.row.consent">
                             <p class="color-primary-green text-smaller text-uppercase bu-mb-1" style="margin-top: 0px; font-weight: 700">{{i18n("consent.opt-i")}}</p>
-                            <span class="text-small bu-mb-4" v-html="rowScope.row.optin.join(',')"></span>
+                            <span class="text-small bu-mb-4">{{consentFeatures(rowScope.row.optin)}}</span>
                             <p class="color-red-100 text-smaller text-uppercase bu-mb-1" style="font-weight: 700;">{{i18n("consent.opt-o")}}</p>
-                            <span class="text-small" v-html="rowScope.row.optout.join(',')"></span>
+                            <span class="text-small">{{consentFeatures(rowScope.row.optout)}}</span>
                         </div>
                         <div v-if="!rowScope.row.consent">
                             -


### PR DESCRIPTION
`escape_html_entities` decided whether to walk into a value by reading its `constructor`:

```js
if (typeof value === 'object' && value && (value.constructor === Object || value.constructor === Array)) {
```

`constructor` is an ordinary property name, so a JSON body can carry its own. `{"constructor": true, ...}` makes `value.constructor` evaluate to `true`, the comparison fails, and the object is returned **with its keys and values unescaped**.

### Why this is not a local problem

This function is the replacer passed to `JSON.stringify` by every `returnOutput` and `returnMessage`. It is the control that lets the rest of the product assume API output is escaped. So any response object whose property names originate in ingested data could carry markup through it untouched, and any consumer rendering those names would render the markup.

The public ingestion endpoint accepts arbitrary property names inside the `consent` object, so planting one needs no account.

### The fix

Prototype identity, which an own property cannot spoof:

```js
function isPlainContainer(value) {
    if (Array.isArray(value)) { return true; }
    const proto = Object.getPrototypeOf(value);
    return proto === Object.prototype || proto === null;
}
```

This keeps the original intent exactly. The alternative of `Object.prototype.toString.call(value) === '[object Object]'` would have been wrong: a MongoDB ObjectID reports `[object Object]` and would start being walked into rather than serialized as an id, changing responses across the API.

### Verification

The real function was lifted and run through `JSON.stringify` before and after. Before, the attack input serializes with the markup key verbatim: `{"constructor":true,"<img src=x onerror=alert(1)>":true}`. After, it is escaped, both at the top level and nested one level down as a consent object would be.

Unchanged, checked explicitly: plain nested objects, arrays of strings, plain text, numbers, booleans, `ObjectID` still serializing as a scalar id, and `Date` still serializing as a date string.

### Second commit: the sink

The Compliance Hub users table bound the consent feature names with `v-html`. It was the only one of the four consent tables doing so; `consentHistory`, `userConsentHistory` and the history summary all render the same values as text. Nothing there needs markup, so it now renders as text, decoding the api escaping first so a name containing `&` or a quote still reads exactly as it was sent.

That is defence in depth rather than the fix. The encoder change above is what closes the report. Worth doing anyway, since this table was relying on the encoder alone.

For anyone checking the same class elsewhere: the other `v-html` bindings fed by ingested data (crash group names in `plugins/crashes`) sit next to server-set keys, so an own `constructor` property cannot be planted as a sibling and they were not reachable this way.
