### PR TITLE
[fix][core] let only a preset's editors change it, and stop copying request parameters onto it (24.05)

### DIFF
--- a/api/parts/mgmt/date_presets.js
+++ b/api/parts/mgmt/date_presets.js
@@ -278,12 +278,6 @@ presetsApi.create = function(params) {
         return false;
     }
 
-    for (let i in params.qstring) {
-        if (typeof newPreset[i] === "undefined" && !["app_id"].includes(i)) {
-            newPreset[i] = params.qstring[i];
-        }
-    }
-
     newPreset.created_at = Math.floor(((new Date()).getTime()) / 1000);
 
     newPreset.owner_id = params.member._id + "";
@@ -396,12 +390,13 @@ presetsApi.update = function(params) {
         memberEmail = member.email,
         filterCond = {};
 
+    var groups = member.group_id || [];
+    if (!Array.isArray(groups)) {
+        groups = [groups];
+    }
+    groups = groups.map(group_id => group_id + "");
+
     if (!member.global_admin) {
-        var groups = member.group_id || [];
-        if (!Array.isArray(groups)) {
-            groups = [groups];
-        }
-        groups = groups.map(group_id => group_id + "");
         filterCond = {
             $or: [
                 {owner_id: memberId},
@@ -507,19 +502,35 @@ presetsApi.update = function(params) {
             return false;
         }
 
-        for (let i in params.qstring) {
-            if (typeof updatedPreset[i] === "undefined" && !["preset_id", "fav", "app_id"].includes(i)) {
-                updatedPreset[i] = params.qstring[i];
+        //The selector above is wider than edit rights on purpose, so it cannot decide
+        //them. Two changes are open to anybody who can see a preset, and both reach
+        //this same handler: marking it a favourite, which is stored on the preset as an
+        //entry in fav per member, and dragging it in the management table, which writes
+        //the shared sort_order. Everything else belongs to the owner and the members
+        //named in the edit lists, which is what the drawer offers and what the delete
+        //handler already requires.
+        //
+        //Both of those send the whole row, so a viewer's request carries the fields
+        //they may not change as well. Those are dropped rather than refused, because
+        //refusing would fail the two actions the UI does offer them.
+        var canEdit = canEditPreset(presetBefore, member, groups);
+
+        if (canEdit) {
+            updatedPreset.edited_at = Math.floor(((new Date()).getTime()) / 1000);
+
+            if (updatedPreset.share_with !== "selected-users") {
+                updatedPreset.shared_email_edit = [];
+                updatedPreset.shared_email_view = [];
+                updatedPreset.shared_user_groups_edit = [];
+                updatedPreset.shared_user_groups_view = [];
             }
         }
-
-        updatedPreset.edited_at = Math.floor(((new Date()).getTime()) / 1000);
-
-        if (updatedPreset.share_with !== "selected-users") {
-            updatedPreset.shared_email_edit = [];
-            updatedPreset.shared_email_view = [];
-            updatedPreset.shared_user_groups_edit = [];
-            updatedPreset.shared_user_groups_view = [];
+        else {
+            //sort_order is the list's shared ordering, and the management table lets
+            //anybody who can see a preset drag it, so it stays writable here next to
+            //fav. Everything the report is about, the content, the sharing lists and
+            //owner_id, does not.
+            updatedPreset = typeof updatedPreset.sort_order === "undefined" ? {} : {sort_order: updatedPreset.sort_order};
         }
 
         //Handle fav
@@ -532,6 +543,11 @@ presetsApi.update = function(params) {
                 fav.splice(fav.indexOf(params.member._id + ""), 1);
             }
             updatedPreset.fav = fav;
+        }
+
+        if (!Object.keys(updatedPreset).length) {
+            common.returnMessage(params, 403, 'Not allowed to edit this preset');
+            return false;
         }
 
         common.db.collection('date_presets').update({_id: presetBefore._id}, {$set: updatedPreset}, {safe: true}, function(err1) {
@@ -670,7 +686,7 @@ presetsApi.getById = function(params) {
 
     filterCond._id = common.db.ObjectID(params.qstring.preset_id);
 
-    common.db.collection('date_presets').findOne(filterCond, function(err, preset) {
+    common.db.collection('date_presets').findOne(filterCond, {projection: PRESET_FIELDS}, function(err, preset) {
         if (err || !preset) {
             common.returnMessage(params, 500, 'Could not find preset');
             return false;
@@ -682,5 +698,47 @@ presetsApi.getById = function(params) {
         return true;
     });
 };
+
+/**
+* The fields a preset is made of. Used as a projection so a stored document cannot
+* return anything beyond them, and as the shape both write handlers persist.
+**/
+const PRESET_FIELDS = {
+    name: 1,
+    range: 1,
+    exclude_current_day: 1,
+    share_with: 1,
+    shared_email_edit: 1,
+    shared_email_view: 1,
+    shared_user_groups_edit: 1,
+    shared_user_groups_view: 1,
+    owner_id: 1,
+    fav: 1,
+    sort_order: 1,
+    created_at: 1,
+    edited_at: 1
+};
+
+/**
+* Whether a member may change a preset rather than only see it. Mirrors what the
+* drawer offers and what the delete handler already requires: the owner, a global
+* admin, or somebody named in one of the edit lists. Being in a view list, or the
+* preset being shared with all users, grants no write.
+* @param {object} preset - the stored preset
+* @param {object} member - params.member
+* @param {array} groups - the member's group ids, as strings
+* @returns {boolean} true when the member may edit the preset
+**/
+function canEditPreset(preset, member, groups) {
+    if (member.global_admin || preset.owner_id === member._id + "") {
+        return true;
+    }
+    if ((preset.shared_email_edit || []).includes(member.email)) {
+        return true;
+    }
+    return (preset.shared_user_groups_edit || []).some(function(group) {
+        return groups.includes(group + "");
+    });
+}
 
 module.exports = presetsApi;

--- a/api/parts/mgmt/date_presets.js
+++ b/api/parts/mgmt/date_presets.js
@@ -545,7 +545,7 @@ presetsApi.update = function(params) {
             updatedPreset.fav = fav;
         }
 
-        if (!Object.keys(updatedPreset).length) {
+        if (Object.keys(updatedPreset).length === 0) {
             common.returnMessage(params, 403, 'Not allowed to edit this preset');
             return false;
         }

--- a/bin/scripts/clean_date_preset_credentials.js
+++ b/bin/scripts/clean_date_preset_credentials.js
@@ -1,0 +1,80 @@
+/**
+ * Removes authentication values that earlier versions of the date preset handlers
+ * stored inside the preset document.
+ *
+ * Both write handlers used to copy every unrecognised request parameter onto the
+ * document. api_key and auth_token are accepted as request parameters, so a preset
+ * created or updated through URL authentication kept the caller's credential, and the
+ * read endpoint returned the whole document to everybody the preset was shared with.
+ * The handlers no longer do this, but a value stored before the fix stays there.
+ *
+ * The dashboard sends its token as a header and posts a fixed field list, so most
+ * installs will find nothing. Anything scripted against the API may have stored one.
+ *
+ * Safe to run more than once. Only the two credential fields are removed; any other
+ * unexpected field is reported and left alone, so nothing an operator or a plugin put
+ * there on purpose is lost.
+ *
+ * Usage: node bin/scripts/clean_date_preset_credentials.js
+ */
+
+var plugins = require('../../plugins/pluginManager.js');
+
+var CREDENTIAL_FIELDS = ['api_key', 'auth_token'];
+
+var KNOWN_FIELDS = [
+    '_id', 'name', 'range', 'exclude_current_day', 'share_with', 'shared_email_edit',
+    'shared_email_view', 'shared_user_groups_edit', 'shared_user_groups_view',
+    'owner_id', 'fav', 'sort_order', 'created_at', 'edited_at'
+];
+
+plugins.dbConnection("countly").then(async function(countlyDb) {
+    try {
+        var presets = await countlyDb.collection('date_presets').find({}).toArray();
+        console.log("Checking", presets.length, "date presets");
+
+        var affected = presets.filter(function(preset) {
+            return CREDENTIAL_FIELDS.some(function(field) {
+                return typeof preset[field] !== "undefined";
+            });
+        });
+
+        for (let i = 0; i < affected.length; i++) {
+            var unset = {};
+            CREDENTIAL_FIELDS.forEach(function(field) {
+                if (typeof affected[i][field] !== "undefined") {
+                    unset[field] = "";
+                }
+            });
+            await countlyDb.collection('date_presets').updateOne(
+                {_id: affected[i]._id},
+                {$unset: unset}
+            );
+            console.log("Removed", Object.keys(unset).join(", "), "from preset", affected[i]._id + "", "owned by", affected[i].owner_id);
+        }
+
+        console.log(affected.length ? "Cleaned " + affected.length + " preset(s)." : "Nothing to clean.");
+
+        if (affected.length) {
+            console.log("The credentials that were stored should be treated as exposed to everybody those presets were shared with. Rotate them: change the api_key of each owner listed above, and have them sign in again to invalidate the auth token.");
+        }
+
+        //other stray fields are reported rather than removed, since only the owner of a
+        //given deployment can say whether something was put there deliberately
+        var stray = {};
+        presets.forEach(function(preset) {
+            Object.keys(preset).forEach(function(field) {
+                if (!KNOWN_FIELDS.includes(field) && !CREDENTIAL_FIELDS.includes(field)) {
+                    stray[field] = (stray[field] || 0) + 1;
+                }
+            });
+        });
+        if (Object.keys(stray).length) {
+            console.log("Fields outside the preset's own set are also present, left untouched:", JSON.stringify(stray));
+        }
+    }
+    catch (error) {
+        console.log("Failed to clean date presets", error);
+    }
+    countlyDb.close();
+});

--- a/test/unit-tests/api.date-presets.view-only-write.js
+++ b/test/unit-tests/api.date-presets.view-only-write.js
@@ -1,0 +1,235 @@
+require("should");
+var common = require("../../api/utils/common.js");
+var presets = require("../../api/parts/mgmt/date_presets.js");
+
+// A date preset is found through a deliberately wide selector, because every member it
+// is shared with is allowed to reach the update handler: marking a favourite and
+// dragging the list both go through it and both send the whole row. So the selector
+// cannot be the authorization, and what these tests pin down is the decision made after
+// the document comes back.
+//
+// The case that matters is owner_id. The delete handler requires the caller to be the
+// stored owner, which is correct, so anything that lets a viewer write owner_id hands
+// them the delete as well.
+
+var PRESET_ID = "aaaaaaaaaaaaaaaaaaaaaaaa";
+var APP_ID = "bbbbbbbbbbbbbbbbbbbbbbbb";
+
+var owner = {_id: "owner1", email: "owner@example.test", group_id: []};
+var viewer = {_id: "viewer1", email: "viewer@example.test", group_id: []};
+var emailEditor = {_id: "editor1", email: "editor@example.test", group_id: []};
+var groupEditor = {_id: "editor2", email: "grouped@example.test", group_id: ["g1"]};
+var globalAdmin = {_id: "admin1", email: "admin@example.test", global_admin: true, group_id: []};
+
+var stored = {
+    _id: PRESET_ID,
+    name: "Owner's preset",
+    range: ["30days"],
+    owner_id: "owner1",
+    share_with: "selected-users",
+    shared_email_edit: ["editor@example.test"],
+    shared_email_view: ["viewer@example.test"],
+    shared_user_groups_edit: ["g1"],
+    shared_user_groups_view: [],
+    fav: [],
+    sort_order: 4
+};
+
+/**
+* Run a handler against a stubbed database and report what it tried to write.
+* @param {string} handler - the presetsApi method to call
+* @param {object} member - the acting member
+* @param {object} qstring - request parameters, merged over a valid baseline
+* @param {object} document - the stored preset the find should return
+* @returns {object} the captured $set, findOne options, status and message
+**/
+function run(handler, member, qstring, document) {
+    var captured = {set: null, options: null, status: null, message: null, reshuffled: false};
+
+    var realDb = common.db;
+    var realMessage = common.returnMessage;
+    var realOutput = common.returnOutput;
+
+    common.db = {
+        ObjectID: function(id) {
+            return id;
+        },
+        collection: function() {
+            return {
+                findOne: function(selector, options, callback) {
+                    if (typeof options === "function") {
+                        callback = options;
+                        options = null;
+                    }
+                    captured.options = options;
+                    callback(null, document ? JSON.parse(JSON.stringify(document)) : null);
+                },
+                update: function(selector, update, options, callback) {
+                    captured.set = update.$set;
+                    callback(null);
+                },
+                //called with and without an options argument in different places
+                updateMany: function(selector, update, options, callback) {
+                    captured.reshuffled = true;
+                    (typeof options === "function" ? options : callback)(null);
+                },
+                insert: function(doc, options, callback) {
+                    captured.set = doc;
+                    callback(null, {ops: [Object.assign({_id: PRESET_ID}, doc)]});
+                }
+            };
+        }
+    };
+    common.returnMessage = function(params, status, message) {
+        captured.status = status;
+        captured.message = message;
+    };
+    common.returnOutput = function(params, output) {
+        captured.status = 200;
+        captured.output = output;
+    };
+
+    try {
+        presets[handler]({
+            member: member,
+            qstring: Object.assign({app_id: APP_ID, preset_id: PRESET_ID}, qstring)
+        });
+    }
+    finally {
+        common.db = realDb;
+        common.returnMessage = realMessage;
+        common.returnOutput = realOutput;
+    }
+
+    return captured;
+}
+
+describe("date presets, view only members and writes", function() {
+    describe("who may edit", function() {
+        it("lets the owner change the preset", function() {
+            var result = run("update", owner, {name: "renamed", share_with: "selected-users"}, stored);
+            result.status.should.equal(200);
+            result.set.name.should.equal("renamed");
+        });
+
+        it("lets a member named in shared_email_edit change it", function() {
+            var result = run("update", emailEditor, {name: "renamed", share_with: "selected-users"}, stored);
+            result.set.name.should.equal("renamed");
+        });
+
+        it("lets a member of a group in shared_user_groups_edit change it", function() {
+            var result = run("update", groupEditor, {name: "renamed", share_with: "selected-users"}, stored);
+            result.set.name.should.equal("renamed");
+        });
+
+        it("lets a global admin change it", function() {
+            var result = run("update", globalAdmin, {name: "renamed", share_with: "selected-users"}, stored);
+            result.set.name.should.equal("renamed");
+        });
+
+        it("does not let a view only member change the content", function() {
+            var result = run("update", viewer, {name: "vandalised", share_with: "selected-users", fav: true}, stored);
+            (result.set.name === undefined).should.equal(true);
+        });
+
+        it("does not let a member of a view only group change the content", function() {
+            var viewGroup = Object.assign({}, stored, {shared_user_groups_edit: [], shared_user_groups_view: ["g1"]});
+            var result = run("update", groupEditor, {name: "vandalised", fav: true}, viewGroup);
+            (result.set.name === undefined).should.equal(true);
+        });
+
+        it("does not treat share_with all-users as an edit grant", function() {
+            var open = Object.assign({}, stored, {share_with: "all-users", shared_email_edit: [], shared_user_groups_edit: []});
+            var result = run("update", viewer, {name: "vandalised", fav: true}, open);
+            (result.set.name === undefined).should.equal(true);
+        });
+    });
+
+    describe("owner_id, which the delete handler trusts", function() {
+        it("is not writable by a view only member", function() {
+            var result = run("update", viewer, {name: "x", owner_id: "viewer1", fav: true}, stored);
+            (result.set.owner_id === undefined).should.equal(true);
+        });
+
+        it("is not writable by an editor either, since sharing stays the owner's", function() {
+            var result = run("update", emailEditor, {name: "x", owner_id: "editor1", share_with: "selected-users"}, stored);
+            (result.set.owner_id === undefined).should.equal(true);
+        });
+
+        it("is not writable by the owner, so it cannot be handed away by accident", function() {
+            var result = run("update", owner, {name: "x", owner_id: "viewer1", share_with: "selected-users"}, stored);
+            (result.set.owner_id === undefined).should.equal(true);
+        });
+
+        it("is refused outright when a view only member sends nothing else", function() {
+            var result = run("update", viewer, {owner_id: "viewer1"}, stored);
+            result.status.should.equal(403);
+            (result.set === null).should.equal(true);
+        });
+    });
+
+    describe("what a view only member keeps", function() {
+        it("may mark the preset as a favourite", function() {
+            var result = run("update", viewer, {name: "ignored", fav: true}, stored);
+            result.status.should.equal(200);
+            result.set.fav.should.eql(["viewer1"]);
+        });
+
+        it("may remove it from favourites again", function() {
+            var favourited = Object.assign({}, stored, {fav: ["viewer1"]});
+            var result = run("update", viewer, {fav: false}, favourited);
+            result.set.fav.should.eql([]);
+        });
+
+        it("may reorder the shared list, which the table lets anybody drag", function() {
+            var result = run("update", viewer, {sort_order: 1}, stored);
+            result.status.should.equal(200);
+            result.set.sort_order.should.equal(1);
+            result.reshuffled.should.equal(true);
+        });
+
+        it("does not stamp edited_at, since nothing was edited", function() {
+            var result = run("update", viewer, {name: "ignored", fav: true}, stored);
+            (result.set.edited_at === undefined).should.equal(true);
+        });
+
+        it("does not clear the sharing lists as a side effect", function() {
+            // an editor sending share_with other than selected-users empties these on
+            // purpose; a viewer's favourite toggle must not reach that path
+            var result = run("update", viewer, {share_with: "none", fav: true}, stored);
+            (result.set.shared_email_view === undefined).should.equal(true);
+        });
+    });
+
+    describe("credentials are not stored on the document", function() {
+        it("update does not persist an api_key sent for authentication", function() {
+            var result = run("update", owner, {name: "x", share_with: "selected-users", api_key: "OWNER_KEY"}, stored);
+            (result.set.api_key === undefined).should.equal(true);
+        });
+
+        it("update does not persist an auth_token sent for authentication", function() {
+            var result = run("update", owner, {name: "x", share_with: "selected-users", auth_token: "OWNER_TOKEN"}, stored);
+            (result.set.auth_token === undefined).should.equal(true);
+        });
+
+        it("create does not persist an api_key sent for authentication", function() {
+            var result = run("create", owner, {name: "new", share_with: "none", range: JSON.stringify(["2024-01-01", "2024-01-31"]), api_key: "OWNER_KEY"}, null);
+            (result.set.api_key === undefined).should.equal(true);
+            result.set.owner_id.should.equal("owner1");
+        });
+
+        it("create keeps the fields a preset is made of", function() {
+            var result = run("create", owner, {name: "new", share_with: "none", range: JSON.stringify(["2024-01-01", "2024-01-31"])}, null);
+            result.set.name.should.equal("new");
+        });
+    });
+
+    describe("reads", function() {
+        it("getById projects the preset's own fields rather than the document", function() {
+            var result = run("getById", viewer, {}, stored);
+            result.options.should.have.property("projection");
+            (result.options.projection.api_key === undefined).should.equal(true);
+            result.options.projection.owner_id.should.equal(1);
+        });
+    });
+});


### PR DESCRIPTION
## What was wrong

`/i/date_presets/update` used a single selector both to *find* the preset and to decide who may *change* it:

```js
filterCond = {$or: [
    {owner_id: memberId}, {share_with: "all-users"},
    {shared_email_view: memberEmail}, {shared_email_edit: memberEmail},
    {shared_user_groups_edit: {$in: groups}}, {shared_user_groups_view: {$in: groups}}
]};
```

The view predicates have to be there. Every member a preset is shared with reaches this handler on purpose: `toggleFav` and `reorderPresets` both dispatch through it. So the selector cannot be the authorization, and nothing else was.

The handler then copied every unrecognised request parameter into the update:

```js
if (typeof updatedPreset[i] === "undefined" && !["preset_id", "fav", "app_id"].includes(i)) {
```

Two consequences:

- **`owner_id` was writable.** The delete handler requires the caller to be the stored owner, which is right, so a view only sharee could set `owner_id` to themselves and then delete the preset. They could also rewrite its content and its sharing lists.
- **Credentials were persisted.** `api_key` and `auth_token` are both accepted as request parameters, so a preset created or updated through URL authentication kept the caller's credential in the document, and `getById` returned the document whole to everybody the preset was shared with. The dashboard sends its token as a header and posts a fixed field list, so this needs something scripted against the API.

This is the same catch-all loop described in #7894's problem statement, as *"an endpoint that keeps parameters it does not recognise and then returns what it stored"*. That was fixed at the export boundary; this fixes the gadget.

## What changed

**Edit rights come from the stored document.** `canEditPreset` returns true for the owner, a global admin, or a member named in `shared_email_edit` / `shared_user_groups_edit`. A view list grants nothing, and neither does `share_with: "all-users"`, which the UI labels as visibility.

**A member who cannot edit keeps `fav` and `sort_order`**, the two things the UI offers them, and the other fields are dropped rather than refused. Refusing would break both, because each sends the whole row. `sort_order` is a deliberate call: it is shared state, but the management table lets anybody drag (`preset-management.html:19` has no gate), there is no per-member ordering field, and it is cosmetic.

**Both catch-all loops are gone**, in create and update. `common.validateArgs` returns only declared fields, and the frontend's create and update services send only declared fields, so nothing legitimate used them. The loop dates from the original date presets commit, `e92613238e7`.

**`getById` projects `PRESET_FIELDS`**, so a document that already holds a credential cannot return it.

**`bin/scripts/clean_date_preset_credentials.js`** removes `api_key` and `auth_token` from existing documents and prints the owners whose keys should be rotated. Other unexpected fields are reported and left alone, since only the operator can say whether something was put there deliberately. Safe to run repeatedly.

## Deliberately unchanged

The delete handler. Its owner check was always correct; it was `owner_id` being writable that defeated it.

The frontend's `hasWritePermissions`. It tests whether the edit lists are non-empty rather than whether the member is in them, which reads wrong, but `getAll` already projects those lists away from non-editors (`date_presets.js:61-75`), so a viewer sees `false` and the gate holds. It leans on the projection for correctness rather than checking membership, which is worth tidying separately.

## Tests

`test/unit-tests/api.date-presets.view-only-write.js`, 21 cases through the real handlers with a stubbed database, asserting on what reaches `$set`.

Against this branch all 21 pass. Against the unpatched file 13 fail, including every `owner_id` case and both credential cases. The cases that pass either way are the no-regression ones: a viewer favouriting, unfavouriting and reordering.

Covered: owner, email editor, group editor and global admin can edit; view only member and view only group cannot; `all-users` is not an edit grant; `owner_id` is not writable by anyone, including the owner; a viewer sending only `owner_id` gets 403 and no write; a viewer keeps fav, unfav and reorder; a viewer's toggle does not stamp `edited_at` or clear the sharing lists; `api_key` and `auth_token` are not persisted by create or update; `getById` passes a projection.
