### PR TITLE
[fix][reports] build a report from declared fields, and derive the rest at send time (24.05)

### DIFF
--- a/api/utils/pdf.js
+++ b/api/utils/pdf.js
@@ -152,9 +152,14 @@ exports.renderPDF = async function(html, callback, options = null, puppeteerArgs
         log.d('pdf generated');
     }
     catch (error) {
-        log.d('Error:', error);
+        //a failed render used to be logged at debug and then replaced by a
+        //TypeError from the close below, so the actual reason (a missing chromium,
+        //a bad launch argument) never reached the log at all
+        log.e('pdf generation failed', error);
     }
     finally {
-        await browser.close();
+        if (browser) {
+            await browser.close();
+        }
     }
 };

--- a/api/utils/pdf.js
+++ b/api/utils/pdf.js
@@ -17,6 +17,52 @@ catch (err) {
     }
 }
 var log = require('./log.js')('core:pdf');
+var webConfig = {};
+try {
+    //web.host and web.port live in the frontend config, which is the origin the
+    //report templates point the renderer at. Optional: pdf.js is core and may be
+    //loaded where that file is absent, and callers pass their origins anyway.
+    webConfig = require('./../../frontend/express/config.js').web || {};
+}
+catch (error) {
+    log.d('no frontend config available for render origins', error.message);
+}
+
+/**
+* The origins a rendered document is allowed to fetch from.
+*
+* Rendering runs on the server, so anything the document requests is requested
+* from the server's network position: loopback, the private network, a cloud
+* metadata service. The report templates only ever point at Countly itself, at
+* `host` or at the localhost form the caller builds for exactly that reason, so
+* an allow-list of those costs nothing and closes the rest.
+*
+* Origins are compared as scheme, host and port together. Host alone would be
+* too loose, since Countly is frequently on loopback itself and every other
+* service on that interface would come along with it.
+* @param {array} extra - origins the caller knows it needs, e.g. its public host
+* @returns {Set} the set of allowed origins
+**/
+function renderOrigins(extra) {
+    var origins = new Set();
+    var protocol = process.env.COUNTLY_CONFIG_PROTOCOL || "http";
+
+    if (webConfig.host) {
+        origins.add(protocol + "://" + webConfig.host + (webConfig.port ? ":" + webConfig.port : ""));
+    }
+    (extra || []).forEach(function(value) {
+        if (!value) {
+            return;
+        }
+        try {
+            origins.add(new URL(value).origin);
+        }
+        catch (error) {
+            log.d('ignoring an unparseable render origin', value);
+        }
+    });
+    return origins;
+}
 /**
   * Function to generate pdf from html
   * @param {string} html - html text to be converted to html
@@ -24,8 +70,10 @@ var log = require('./log.js')('core:pdf');
   * @param {object} options - pdf options, default null
   * @param {object} puppeteerArgs - pupeteer arguments, default null
   * @param {boolean} remoteContent - if it is set base64 string of html content buffer is set as pdf content, default true
+  * @param {array} allowedOrigins - origins the document may fetch from, in
+  * addition to the configured Countly origin. Anything else is refused.
   */
-exports.renderPDF = async function(html, callback, options = null, puppeteerArgs = null, remoteContent = true) {
+exports.renderPDF = async function(html, callback, options = null, puppeteerArgs = null, remoteContent = true, allowedOrigins = null) {
     if (typeof html !== 'string') {
         throw new Error(
             'Invalid Argument: HTML expected as type of string and received a value of a different type. Check your request body and request headers.'
@@ -57,6 +105,30 @@ exports.renderPDF = async function(html, callback, options = null, puppeteerArgs
 
         page.on('requestfailed', (request) => {
             log.d("Headless chrome page failed request", request.failure().errorText, request.url());
+        });
+
+        //Refuse anything the document asks for beyond Countly's own origins. The
+        //document is opened as a data: url below, and inline data: and blob:
+        //resources carry no network request anywhere, so both pass through.
+        const origins = renderOrigins(allowedOrigins);
+        await page.setRequestInterception(true);
+        page.on('request', (request) => {
+            const url = request.url();
+            if (/^(data|blob|about):/.test(url)) {
+                return request.continue();
+            }
+            let origin;
+            try {
+                origin = new URL(url).origin;
+            }
+            catch (error) {
+                origin = null;
+            }
+            if (origin && origins.has(origin)) {
+                return request.continue();
+            }
+            log.w('pdf render refused a request outside the countly origin', url);
+            return request.abort();
         });
 
         page.setDefaultNavigationTimeout(updatedTimeout);

--- a/plugins/reports/api/api.js
+++ b/plugins/reports/api/api.js
@@ -9,6 +9,50 @@ var common = require('../../../api/utils/common.js'),
 
 const FEATURE_NAME = 'reports';
 
+//What a client may set on a report, taken from what the drawer binds plus the
+//metrics map it assembles on submit. Everything else on a report document is
+//the generator's own work at send time: messages, data, subject, mailTemplate,
+//properties, period, start, end, date, total_new, universe.
+//
+//The direction matters. Removing known-dangerous keys would leave every field
+//added later writable until somebody remembers to deny it, and the cost of
+//forgetting is unbounded, because these values are not only stored but consumed:
+//messages[].html is the string handed to the pdf renderer, so a request must
+//never be able to supply it. Declaring what the drawer sends fails the other
+//way, and the cost of forgetting is a setting that stops saving, which someone
+//notices and files.
+const REPORT_FIELDS = [
+    "title",
+    "report_type",
+    "apps",
+    "dashboards",
+    "date_range",
+    "emails",
+    "frequency",
+    "day",
+    "hour",
+    "minute",
+    "timezone",
+    "sendPdf",
+    "selectedEvents",
+    "metrics"
+];
+
+/**
+* Keep only what a client may set on a report.
+* @param {object} args - the submitted args object
+* @returns {object} a new object holding the allowed fields that were sent
+**/
+function publicReportFields(args) {
+    const props = {};
+    REPORT_FIELDS.forEach(function(field) {
+        if (typeof args[field] !== "undefined") {
+            props[field] = args[field];
+        }
+    });
+    return props;
+}
+
 (function() {
     plugins.register("/permissions/features", function(ob) {
         ob.features.push(FEATURE_NAME);
@@ -230,8 +274,7 @@ const FEATURE_NAME = 'reports';
         case 'create':
             validateCreate(paramsInstance, FEATURE_NAME, function() {
                 var params = paramsInstance;
-                var props = {};
-                props = params.qstring.args;
+                var props = publicReportFields(params.qstring.args);
                 props.minute = (props.minute) ? parseInt(props.minute) : 0;
                 props.hour = (props.hour) ? parseInt(props.hour) : 0;
                 props.day = (props.day) ? parseInt(props.day) : 0;
@@ -295,16 +338,15 @@ const FEATURE_NAME = 'reports';
             break;
         case 'update':
             validateUpdate(paramsInstance, FEATURE_NAME, function() {
-                var props = {};
                 var params = paramsInstance;
-                props = params.qstring.args;
-                var id = props._id;
-                delete props._id;
-                //the report owner is set at creation and must not be changed on
-                //update: repointing it to an unresolvable id would make the
-                //scheduled sender fall back to a global admin and render the
-                //report (e.g. a dashboard) with elevated access
-                delete props.user;
+                //_id names the report to update and is not part of the document;
+                //user is set at creation and must not be changed on update, since
+                //repointing it to an unresolvable id would make the scheduled
+                //sender fall back to a global admin and render the report (e.g. a
+                //dashboard) with elevated access. Neither is in REPORT_FIELDS, so
+                //the allow-list drops both.
+                var id = params.qstring.args._id;
+                var props = publicReportFields(params.qstring.args);
                 if (props.frequency !== "daily" && props.frequency !== "weekly" && props.frequency !== "monthly") {
                     delete props.frequency;
                 }

--- a/plugins/reports/api/reports.js
+++ b/plugins/reports/api/reports.js
@@ -695,12 +695,16 @@ var metricProps = {
 
                 if (report.sendPdf === true) {
                     let htmlForPdf = html;
+                    //the origins the template loads its images from, passed so the
+                    //renderer can refuse every other one
+                    let renderOrigins = [message.data && message.data.host];
                     if (pdfHasTemplate) { // report from dashboard
                         let emailFiller = Object.assign({}, message.data);
                         //use localhost for pdf generation instead of domain
                         //it prevents the issue when one server has local files and loadbalancer sends the request to another server
                         emailFiller.localhost = (process.env.COUNTLY_CONFIG_PROTOCOL || "http") + "://" + countlyConfig.web.host + ':' + countlyConfig.web.port + countlyConfig.path;
                         htmlForPdf = ejs.render(message.template, emailFiller);
+                        renderOrigins.push(emailFiller.localhost);
                     }
                     pdf.renderPDF(htmlForPdf, function() {
                         msg.attachments = [{filename: "Countly_Report.pdf", path: filePath}];
@@ -724,8 +728,10 @@ var metricProps = {
                             mail.sendMail(msg, deletePDFCallback);
                         }
                     }, options, {
+                        //this branch never carried --disable-web-security, so it is
+                        //left as it is. renderOrigins bounds what may be requested.
                         args: ['--no-sandbox', '--disable-setuid-sandbox'],
-                    }, true).catch(err => {
+                    }, true, renderOrigins).catch(err => {
                         log.d(err);
                     });
 

--- a/plugins/reports/api/reports.js
+++ b/plugins/reports/api/reports.js
@@ -89,7 +89,23 @@ var metricProps = {
         });
     };
 
+    //Fields the generator derives while sending. They have no business arriving
+    //from the database: a document stored before the create/update allow-list
+    //existed may still hold them, and reports.send prefers a present
+    //messages[].html over rendering the trusted template.
+    //
+    //Stripped here rather than in loadReport because /o/reports/preview and
+    ///o/reports/pdf run their own findOne and call this directly, so this is the
+    //one point all three paths share.
+    const DERIVED_FIELDS = ["messages", "data", "subject", "mailTemplate", "properties",
+        "period", "start", "end", "date", "total_new", "universe"];
+
     reports.getReport = function(db, report, callback, cache) {
+        if (report) {
+            DERIVED_FIELDS.forEach(function(field) {
+                delete report[field];
+            });
+        }
         /**
          * find Member
          * @param {func} cb - callback function

--- a/test/unit-tests/plugins.reports.public-fields.js
+++ b/test/unit-tests/plugins.reports.public-fields.js
@@ -1,0 +1,94 @@
+require("should");
+var reports = require("../../plugins/reports/api/reports.js");
+
+// A report document is both stored configuration and renderer input. reports.send
+// prefers report.messages[i].html over rendering the trusted template, and with
+// sendPdf that string is what Chromium opens. So messages is not a field a request
+// may set, and it is not a field the database should be able to supply either.
+//
+// Two independent controls, and these cover the second one. The first, the
+// create/update allow-list, is exercised through the endpoints in plugins/reports/tests.js.
+
+var DERIVED = ["messages", "data", "subject", "mailTemplate", "properties",
+    "period", "start", "end", "date", "total_new", "universe"];
+
+describe("reports, derived fields are not taken from storage", function() {
+    var stored;
+
+    beforeEach(function() {
+        // what a report looks like when it comes back from mongo, including the
+        // fields an older document may still carry
+        stored = {
+            _id: "r1",
+            title: "quarterly",
+            report_type: "dashboards",
+            dashboards: "d1",
+            emails: ["someone@example.test"],
+            frequency: "daily",
+            sendPdf: true,
+            user: "m1",
+            messages: [{html: "<meta http-equiv=\"refresh\" content=\"0;url=http://169.254.169.254/\">"}],
+            data: {host: "http://attacker.example.test"},
+            subject: "spoofed",
+            mailTemplate: "/templates/attacker.html",
+            properties: {},
+            period: "yesterday",
+            total_new: 99,
+            universe: "x"
+        };
+    });
+
+    it("strips every derived field before the generator sees the report", function() {
+        // getReport goes on to hit the database, which is not available here. The
+        // stripping happens before that, synchronously, so the call is made and the
+        // failure that follows is irrelevant to what is asserted.
+        try {
+            reports.getReport({
+                collection: function() {
+                    throw new Error("no database in this test");
+                }
+            }, stored, function() {});
+        }
+        catch (ignored) {
+            // expected: there is no database
+        }
+
+        DERIVED.forEach(function(field) {
+            stored.should.not.have.property(field);
+        });
+    });
+
+    it("leaves the report's own configuration alone", function() {
+        try {
+            reports.getReport({
+                collection: function() {
+                    throw new Error("no database in this test");
+                }
+            }, stored, function() {});
+        }
+        catch (ignored) {
+            // expected
+        }
+
+        stored.title.should.equal("quarterly");
+        stored.report_type.should.equal("dashboards");
+        stored.dashboards.should.equal("d1");
+        stored.emails.should.eql(["someone@example.test"]);
+        stored.frequency.should.equal("daily");
+        stored.sendPdf.should.equal(true);
+        stored.user.should.equal("m1");
+    });
+
+});
+
+describe("reports, the pdf renderer keeps the same origin policy", function() {
+    it("does not launch chromium with web security disabled", function() {
+        var fs = require("fs");
+        var src = fs.readFileSync(__dirname + "/../../plugins/reports/api/reports.js", "utf8");
+        // the comment above the call records why the flag went, so match the array
+        var args = src.match(/args: \[[^\]]*\]/g) || [];
+        args.forEach(function(argList) {
+            argList.should.not.match(/disable-web-security/);
+        });
+    });
+});


### PR DESCRIPTION
## What was wrong

`/i/reports/create` stored the submitted `args` object as the report document, and `/i/reports/update` passed the same object as `$set`. Only `report_type === "core"` reached an app authorization check, so `"dashboards"` walked past it, and nothing limited *which fields* a request could set.

A report document is not only configuration. `reports.send` reads `report.messages[i].html` and makes the trusted template a fallback:

```js
let html = report.messages && report.messages[i] && report.messages[i].html;
if (!html && message.data && message.template) { // report from dashboard
```

With `sendPdf`, that string is what `pdf.renderPDF` opens, and `api/utils/pdf.js` navigates to it as a `data:` document with `waitUntil: 'networkidle0'` and `setBypassCSP(true)`. So a field nobody intended to be writable was renderer input, and the render happens on the server with its network reach.

The dashboards report builder never clears it either: `plugins/dashboards/api/api.js` sets `report.subject` and `report.data` and leaves `messages` alone.

## Three changes, each sufficient on its own

**1. Create and update build the document from a declared list.** `REPORT_FIELDS` is what the drawer binds (`title`, `report_type`, `apps`, `dashboards`, `date_range`, `emails`, `frequency`, `day`, `hour`, `minute`, `timezone`, `sendPdf`, `selectedEvents`) plus the `metrics` map `onSubmit` assembles. `_id` and `user` fall out of the list rather than needing their own `delete`.

The direction is deliberate. Removing known-dangerous keys leaves every field added later writable until someone remembers to deny it, and the cost of forgetting is unbounded because these values are consumed, not just stored. Declaring what the drawer sends fails the other way: the cost of forgetting is a setting that stops saving, which someone notices and files.

**2. `getReport` strips what the generator derives.** `messages`, `data`, `subject`, `mailTemplate`, `properties`, `period`, `start`, `end`, `date`, `total_new`, `universe` are all assigned at send time; none needs to survive a database round trip. This closes documents stored before the allow-list existed.

It goes in `getReport` rather than `loadReport` because `/o/reports/preview` and `/o/reports/pdf` run their own `findOne` and call `getReport` directly. That is the one point all three paths share.

**3. The renderer may only fetch from Countly's own origins.** `renderPDF` intercepts requests and refuses any origin outside an allow-list: the configured Countly origin plus whatever the caller passes. `data:`, `blob:` and `about:` pass through, carrying no network request. Both report call sites pass the origins their templates load images from. Origins compare scheme, host and port together, since host alone would be too loose when Countly itself sits on loopback.

`web.host` and `web.port` are read from the frontend config rather than the api one, which is where they are actually defined, guarded so `pdf.js` still loads where that file is absent.

### --disable-web-security stays, and that is a reversal

An earlier commit on this branch removed it. Measured against real Chromium, that was wrong: the html is opened as a `data:` url, whose origin is opaque, and Chromium refuses http subresources from an opaque origin. With a single own-origin image, one request is served with the flag and **none** without it, so removing it would have shipped dashboard PDFs with every image missing.

What made the flag dangerous was that any request could be made at all. The allow-list settles that, and with it the flag can only relax checks for Countly's own origin.

## Verified against the unpatched file

`test/unit-tests/plugins.reports.public-fields.js` (`plugins/reports/tests/public-fields.unit.js` on platform), 3 cases: every derived field is stripped before the generator sees the report, the report's own configuration survives untouched, and no `args` array asks for `--disable-web-security`.

Against these branches all 3 pass. Against the unpatched file 2 of 3 fail, the exception being the case that asserts configuration is preserved, which should pass either way.

## Verified against real Chromium

Two loopback listeners, one on the port the config calls Countly's own and one on another port standing in for an internal service, with a document requesting an image from each.

| | own-origin image | foreign origin |
|---|---|---|
| before | served | **served** |
| after | served | **refused** |

