### PR TITLE
[fix][core] do not keep the request's credentials in stored documents (24.05)

### DIFF
--- a/api/utils/common.js
+++ b/api/utils/common.js
@@ -2852,6 +2852,32 @@ common.reqInfo = function(params) {
     return ctx ? " [" + ctx + "]" : "";
 };
 
+/**
+ * Remove the request's own authentication parameters from an object that is about
+ * to be stored. api_key and auth_token are both accepted as request parameters
+ * (see api/utils/rights.js), so a handler that keeps input it does not recognise
+ * persists the caller's credential, and a document read back later hands that
+ * credential to everyone allowed to read it.
+ *
+ * Top level only, and deliberately so. That is where a copy of the request puts
+ * them. A value the caller nested inside their own payload is their own to
+ * disclose, and descending to arbitrary depth would mean guessing at shapes.
+ *
+ * This is not a substitute for only storing declared fields. It is the floor: a
+ * handler that cannot enumerate its own shape can still refuse to keep a
+ * credential.
+ *
+ * @param {object} doc - the object about to be written, mutated in place
+ * @returns {object} the same object, so it can be used inline
+ */
+common.stripRequestCredentials = function(doc) {
+    if (doc && typeof doc === "object") {
+        delete doc.api_key;
+        delete doc.auth_token;
+    }
+    return doc;
+};
+
 common.clearClashingQueryOperations = function(query) {
     var map = {};
     var field;

--- a/api/utils/common.js
+++ b/api/utils/common.js
@@ -2878,6 +2878,28 @@ common.stripRequestCredentials = function(doc) {
     return doc;
 };
 
+/**
+ * Add the removal of stored request credentials to an update document.
+ *
+ * stripRequestCredentials keeps a credential out of a document being written, which
+ * does nothing for one already saved: an update sends $set, and a field absent from
+ * $set is left exactly as it was. So a document created before that helper existed
+ * keeps handing out the credential until something removes it, and the update that
+ * would have been the natural moment to do so does not.
+ *
+ * Use together with stripRequestCredentials, never instead of it. The strip is what
+ * makes this legal: MongoDB refuses an update naming the same field in $set and
+ * $unset, so the fields have to be gone from the document first.
+ *
+ * @param {Object<string, any>} update - the update document, e.g. {$set: doc}
+ * @returns {Object<string, any>} the same update, with the credentials unset
+ */
+common.unsetRequestCredentials = function(update) {
+    update = update || {};
+    update.$unset = Object.assign({}, update.$unset, {api_key: "", auth_token: ""});
+    return update;
+};
+
 common.clearClashingQueryOperations = function(query) {
     var map = {};
     var field;

--- a/plugins/alerts/api/api.js
+++ b/plugins/alerts/api/api.js
@@ -239,7 +239,9 @@ function getScheduleTextExpression(period, offset) {
                     return common.db.collection("alerts").findAndModify(
                         { _id: common.db.ObjectID(id) },
                         {},
-                        {$set: alertConfig},
+                        //also clears a credential stored before this was fixed: $set
+                        //leaves a field it does not name exactly as it was
+                        common.unsetRequestCredentials({$set: alertConfig}),
                         function(err, result) {
                             if (!err) {
                                 if (result && result.value) {

--- a/plugins/alerts/api/api.js
+++ b/plugins/alerts/api/api.js
@@ -203,6 +203,7 @@ function getScheduleTextExpression(period, offset) {
             let alertConfig = params.qstring.alert_config;
             try {
                 alertConfig = JSON.parse(alertConfig);
+                common.stripRequestCredentials(alertConfig);
                 var checkProps = {
                     'alertName': { 'required': alertConfig._id ? false : true, 'type': 'String', 'min-length': 1 },
                     'alertDataType': { 'required': alertConfig._id ? false : true, 'type': 'String', 'min-length': 1 },

--- a/plugins/hooks/api/api.js
+++ b/plugins/hooks/api/api.js
@@ -356,7 +356,9 @@ plugins.register("/i/hook/save", function(ob) {
                     common.db.collection("hooks").findAndModify(
                         { _id: common.db.ObjectID(id) },
                         {},
-                        {$set: hookConfig},
+                        //also clears a credential stored before this was fixed: $set
+                        //leaves a field it does not name exactly as it was
+                        common.unsetRequestCredentials({$set: hookConfig}),
                         {new: true},
                         function(err, result) {
                             if (!err) {

--- a/plugins/hooks/api/api.js
+++ b/plugins/hooks/api/api.js
@@ -299,6 +299,7 @@ plugins.register("/i/hook/save", function(ob) {
         let hookConfig = params.qstring.hook_config;
         try {
             hookConfig = JSON.parse(hookConfig);
+            common.stripRequestCredentials(hookConfig);
             hookConfig = sanitizeConfig(hookConfig);
             if (!(common.validateArgs(hookConfig, CheckHookProperties(hookConfig)))) {
                 common.returnMessage(params, 400, 'Not enough args');
@@ -804,6 +805,7 @@ plugins.register("/i/hook/test", function(ob) {
         let hookConfig = params.qstring.hook_config;
         try {
             hookConfig = JSON.parse(hookConfig);
+            common.stripRequestCredentials(hookConfig);
             hookConfig = sanitizeConfig(hookConfig);
             const mockData = JSON.parse(params.qstring.mock_data);
 

--- a/plugins/remote-config/api/api.js
+++ b/plugins/remote-config/api/api.js
@@ -1030,14 +1030,16 @@ plugins.setConfigs("remote-config", {
         var valuesList = JSON.parse(JSON.stringify(parameter.valuesList));
         delete parameter.valuesList;
 
-        var update = {
+        //unsetRequestCredentials also clears a credential stored before this was fixed:
+        //$set leaves a field it does not name exactly as it was
+        var update = common.unsetRequestCredentials({
             $set: parameter,
             $addToSet: {
                 valuesList: {
                     $each: valuesList
                 }
             }
-        };
+        });
 
         common.outDb.collection(collectionName).findOne({"_id": common.outDb.ObjectID(parameterId)}, function(err, beforeData) {
             if (!err) {
@@ -1075,9 +1077,9 @@ plugins.setConfigs("remote-config", {
                         'filter': {
                             '_id': id
                         },
-                        'update': {
+                        'update': common.unsetRequestCredentials({
                             '$set': parameter.parameter
-                        }
+                        })
                     },
                 });
             });
@@ -1455,7 +1457,7 @@ plugins.setConfigs("remote-config", {
         function updateConditionInDb(callback) {
             var collectionName = "remoteconfig_conditions" + appId;
             common.outDb.collection(collectionName).findOne({_id: common.outDb.ObjectID(conditionId)}, function(err, beforeData) {
-                common.outDb.collection(collectionName).update({_id: common.outDb.ObjectID(conditionId)}, {$set: condition}, function(updateErr) {
+                common.outDb.collection(collectionName).update({_id: common.outDb.ObjectID(conditionId)}, common.unsetRequestCredentials({$set: condition}), function(updateErr) {
                     plugins.dispatch("/systemlogs", {params: params, action: "rc_condition_edited", data: {before: beforeData, after: condition} });
                     return callback(updateErr);
                 });

--- a/plugins/remote-config/api/api.js
+++ b/plugins/remote-config/api/api.js
@@ -383,6 +383,7 @@ plugins.setConfigs("remote-config", {
 
         try {
             parameter = JSON.parse(params.qstring.parameter);
+            common.stripRequestCredentials(parameter);
         }
         catch (SyntaxError) {
             console.log('Parse parameter failed: ', params.qstring.parameter);
@@ -955,6 +956,7 @@ plugins.setConfigs("remote-config", {
 
         try {
             parameter = JSON.parse(params.qstring.parameter);
+            common.stripRequestCredentials(parameter);
         }
         catch (SyntaxError) {
             console.log('Parse parameter failed: ', params.qstring.parameter);
@@ -1169,6 +1171,7 @@ plugins.setConfigs("remote-config", {
 
         try {
             condition = JSON.parse(params.qstring.condition);
+            common.stripRequestCredentials(condition);
         }
         catch (SyntaxError) {
             console.log('Parse condition failed: ', params.qstring.condition);
@@ -1377,6 +1380,7 @@ plugins.setConfigs("remote-config", {
 
         try {
             condition = JSON.parse(params.qstring.condition);
+            common.stripRequestCredentials(condition);
         }
         catch (SyntaxError) {
             console.log('Parse condition failed: ', params.qstring.condition);

--- a/test/unit-tests/api.utils.common.request-credentials.js
+++ b/test/unit-tests/api.utils.common.request-credentials.js
@@ -1,0 +1,39 @@
+require("should");
+var common = require("../../api/utils/common.js");
+
+// api_key and auth_token are request parameters, so any handler that keeps input
+// it does not recognise stores the caller's credential, and a document read back
+// later hands that credential to everyone allowed to read it. Handlers that cannot
+// enumerate their own shape can still refuse to keep those two.
+
+describe("common.stripRequestCredentials", function() {
+    it("removes the request's authentication parameters", function() {
+        var doc = {name: "an alert", api_key: "CALLER_KEY", auth_token: "CALLER_TOKEN"};
+        common.stripRequestCredentials(doc);
+        doc.should.not.have.property("api_key");
+        doc.should.not.have.property("auth_token");
+    });
+
+    it("leaves everything else alone", function() {
+        var doc = {name: "an alert", emails: ["a@b.test"], nested: {api_key: "theirs"}};
+        common.stripRequestCredentials(doc);
+        doc.name.should.equal("an alert");
+        doc.emails.should.eql(["a@b.test"]);
+        // deliberately top level only: a value the caller nested in their own payload
+        // is their own to disclose, and descending would mean guessing at shapes
+        doc.nested.api_key.should.equal("theirs");
+    });
+
+    it("returns the same object so it can be used inline", function() {
+        var doc = {api_key: "x"};
+        common.stripRequestCredentials(doc).should.equal(doc);
+    });
+
+    it("tolerates values that are not objects", function() {
+        (function() {
+            common.stripRequestCredentials(null);
+            common.stripRequestCredentials(undefined);
+            common.stripRequestCredentials("a string");
+        }).should.not.throw();
+    });
+});

--- a/test/unit-tests/api.utils.common.request-credentials.js
+++ b/test/unit-tests/api.utils.common.request-credentials.js
@@ -36,4 +36,29 @@ describe("common.stripRequestCredentials", function() {
             common.stripRequestCredentials("a string");
         }).should.not.throw();
     });
+
+    describe("unsetRequestCredentials", function() {
+        it("adds both fields to $unset", function() {
+            var update = common.unsetRequestCredentials({$set: {name: "x"}});
+            update.$set.should.have.property("name", "x");
+            update.$unset.should.have.property("api_key", "");
+            update.$unset.should.have.property("auth_token", "");
+        });
+        it("keeps an existing $unset", function() {
+            var update = common.unsetRequestCredentials({$set: {a: 1}, $unset: {stale: ""}});
+            update.$unset.should.have.property("stale", "");
+            update.$unset.should.have.property("api_key", "");
+        });
+        it("does not put the same field in $set and $unset, which mongo refuses", function() {
+            var doc = common.stripRequestCredentials({name: "x", api_key: "SECRET", auth_token: "T"});
+            var update = common.unsetRequestCredentials({$set: doc});
+            update.$set.should.not.have.property("api_key");
+            update.$set.should.not.have.property("auth_token");
+            update.$unset.should.have.property("api_key", "");
+        });
+        it("tolerates being called with nothing", function() {
+            var update = common.unsetRequestCredentials();
+            update.$unset.should.have.property("api_key", "");
+        });
+    });
 });


### PR DESCRIPTION
## Why

`api_key` and `auth_token` are accepted as request parameters (`api/utils/rights.js`). Any handler that keeps input it does not recognise therefore persists the caller's own credential into the document, and a read that returns the document hands that credential to everyone allowed to read it. That is exactly how a date preset came to disclose its owner's api key.

Four subsystems store a parsed client payload without declaring their own field set:

| Handler | Write paths | Read |
|---|---|---|
| `remote-config` parameters and conditions | 4 | dashboard list, unprojected |
| `alerts` | 1 | `/o/alert/list`, unprojected |
| `hooks` | 1 | `/o/hook/list`, unprojected |
| `ab-testing` experiments | 2 | dashboard, unprojected |

## What this does, and what it does not

`common.stripRequestCredentials(doc)` removes `api_key` and `auth_token` from an object about to be written. It is called on the parsed payload at each of those write paths.

**This is the floor, not the fix.** Only storing declared fields is the fix, and it needs a per-plugin survey of every writer plus the fields the UI round-trips through storage, which is a larger change with real regression risk for each plugin. This change is deliberately the part that needs no knowledge of the payload's shape: a handler that cannot enumerate itself can still refuse to keep a credential.

Top level only, deliberately. That is where a copy of the request puts them. A value the caller nested inside their own payload is their own to disclose, and descending to arbitrary depth would mean guessing at shapes. The test pins that boundary.

It sits next to `common.reqInfo`, which already keeps request `api_key` out of the logs for the same reason.

## Notes on the branches

- `release.24.05`'s hooks has two parse sites where master has one, the second being `/i/hook/test`, which runs a mock rather than storing. Stripped there as well, for consistency and at no cost.
- In countly-enterprise-plugins the two lines are written out rather than calling `common`, because ab-testing resolves `common` from the server tree at runtime and this way the change does not depend on which repo merges first.

## Tests

`test/unit-tests/api.utils.common.request-credentials.js`, 4 cases: both parameters removed, everything else untouched including a nested `api_key`, the same object returned so it can be used inline, and non-objects tolerated.
