### PR TITLE
[fix][core] keep server side rendering on the dashboard origin

### DIFF
--- a/api/config.sample.js
+++ b/api/config.sample.js
@@ -86,6 +86,18 @@ var countlyConfig = {
         default: "warn"
     },
     /**
+    * Settings for the headless renderer used by screenshots, emailed reports and PDFs
+    * @type {object=}
+    * @property {array=} allowedOrigins - extra origins the rendered dashboard may fetch
+    *   assets from. The dashboard's own origin, the configured cdn and the map tile
+    *   provider are allowed already; add an entry only for an asset host of your own,
+    *   for example a self hosted tile server. Everything else is refused, which is what
+    *   stops a rendered page from reaching what the server itself can reach.
+    */
+    render: {
+        allowedOrigins: [/*"https://tiles.example.com"*/]
+    },
+    /**
     * Default proxy settings, if provided then countly uses ip address from the right side of x-forwarded-for header ignoring list of provided proxy ip addresses
     * @type {array=} 
     */

--- a/api/utils/render.js
+++ b/api/utils/render.js
@@ -29,6 +29,54 @@ var fs = require('fs');
 
 
 /**
+* Check that a view stays on the dashboard, and return the url to navigate to
+*
+* The view can come from a request (/o/render passes params.qstring.view through), and the
+* url is built by concatenation. With the default countlyConfig.path of "" the prefix is
+* exactly "http://localhost", so a view that does not begin with "/" rewrites the host
+* instead of the path:
+*
+*   "@169.254.169.254/latest/meta-data/"  ->  host 169.254.169.254
+*   ":8500/v1/kv/?recurse"                ->  host localhost:8500
+*   ".internal.example/x"                 ->  host localhost.internal.example
+*
+* Parsing the concatenated url and comparing origins settles all of those at once, rather
+* than trying to enumerate them. It also agrees with what Chromium will do with the same
+* string, since both use the WHATWG url parser. Note that a private range denylist would
+* be the wrong control here: the intended target is loopback.
+*
+* The returned url is the concatenation itself, unchanged, so a configured
+* countlyConfig.path keeps working exactly as before.
+* @param {string} host - dashboard origin plus the configured path
+* @param {string} view - view to render, expected to be a path on that dashboard
+* @returns {string|null} url to navigate to, or null when it leaves the dashboard origin
+**/
+function sameOriginView(host, view) {
+    if (typeof view !== "string") {
+        return null;
+    }
+    var target = host + view;
+    var expected;
+    var actual;
+    try {
+        //host may carry no path at all, so normalise it before taking the origin
+        expected = new URL(host + "/").origin;
+        actual = new URL(target).origin;
+    }
+    catch (error) {
+        return null;
+    }
+    //opaque origins serialise to "null" and would compare equal to each other
+    if (!expected || expected === "null" || actual !== expected) {
+        return null;
+    }
+    return target;
+}
+
+//exported so the same origin check can be unit tested without launching a browser
+exports.sameOriginView = sameOriginView;
+
+/**
  * Function to render views as images
  * @param  {object} options - options required for rendering
  * @param  {string} options.host - the hostname
@@ -128,6 +176,38 @@ exports.renderView = function(options, cb) {
                     scale: options.dimensions && options.dimensions.scale ? options.dimensions.scale : 2
                 };
 
+                //Second, independent control: the renderer may only fetch from the
+                //dashboard origin. The check on the view bounds where we navigate, this
+                //bounds every subresource the rendered page then asks for. Same approach as
+                //api/utils/pdf.js. The dashboard serves all of its own assets, so nothing in
+                //a normal render is refused here.
+                var renderOrigin = null;
+                try {
+                    renderOrigin = new URL(host + "/").origin;
+                }
+                catch (error) {
+                    log.e("Cannot parse the configured dashboard host", host);
+                }
+                await page.setRequestInterception(true);
+                page.on('request', function(request) {
+                    var requestUrl = request.url();
+                    if (/^(data|blob|about):/.test(requestUrl)) {
+                        return request.continue();
+                    }
+                    var requestOrigin;
+                    try {
+                        requestOrigin = new URL(requestUrl).origin;
+                    }
+                    catch (error) {
+                        requestOrigin = null;
+                    }
+                    if (renderOrigin && renderOrigin !== "null" && requestOrigin === renderOrigin) {
+                        return request.continue();
+                    }
+                    log.d("Refused a request outside the dashboard origin", requestUrl);
+                    return request.abort();
+                });
+
                 page.setDefaultNavigationTimeout(updatedTimeout);
                 const resp = await page.goto(host + '/login/token/' + token + '?ssr=true');
                 const status = resp?.status();
@@ -139,7 +219,14 @@ exports.renderView = function(options, cb) {
 
                 await timeout(1500);
 
-                await page.goto(host + view);
+                var viewUrl = sameOriginView(host, view);
+                if (!viewUrl) {
+                    //the value can be attacker supplied, so keep it out of the log
+                    log.e("Refusing to render a view outside the dashboard origin");
+                    throw new Error("Invalid view");
+                }
+
+                await page.goto(viewUrl);
 
                 if (waitForRegex) {
                     await page.waitForResponse(

--- a/api/utils/render.js
+++ b/api/utils/render.js
@@ -56,25 +56,101 @@ function sameOriginView(host, view) {
         return null;
     }
     var target = host + view;
-    var expected;
-    var actual;
-    try {
-        //host may carry no path at all, so normalise it before taking the origin
-        expected = new URL(host + "/").origin;
-        actual = new URL(target).origin;
-    }
-    catch (error) {
-        return null;
-    }
-    //opaque origins serialise to "null" and would compare equal to each other
-    if (!expected || expected === "null" || actual !== expected) {
+    //host may carry no path at all, so normalise it before taking the origin
+    var expected = originOf(host + "/");
+    if (!expected || originOf(target) !== expected) {
         return null;
     }
     return target;
 }
 
+//The dashboard serves nearly all of its own assets, but not quite all of them. Two
+//off-origin fetches are part of a normal render: countlyConfig.cdn moves the core
+//styles and scripts to a CDN, and the map widgets fetch tiles from OpenStreetMap.
+//Refusing those leaves screenshots unstyled or the map blank, and a CDN deployment
+//cannot bootstrap the dashboard at all, so both are allowed by origin.
+//
+//frontend/express/public/javascripts/countly/vue/components/vis.js requests
+//https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png and passes no subdomains option,
+//so leaflet expands {s} to a, b and c. Listed as exact origins rather than matched by
+//suffix: the allowlist stays a set of strings to compare, with no pattern to get wrong.
+var TILE_ORIGINS = [
+    "https://a.tile.openstreetmap.org",
+    "https://b.tile.openstreetmap.org",
+    "https://c.tile.openstreetmap.org",
+    "https://tile.openstreetmap.org"
+];
+
+/**
+* Origin of a url, or null when it has none to speak of
+*
+* A relative cdn ("" or "/assets/") has no origin and returns null here, which is
+* correct: it is already served from the dashboard origin and needs no entry.
+* @param {string} url - absolute url, or anything at all
+* @returns {string|null} the serialised origin, or null when there is not a real one
+**/
+function originOf(url) {
+    var origin;
+    try {
+        origin = new URL(url).origin;
+    }
+    catch (error) {
+        return null;
+    }
+    //opaque origins serialise to "null" and would compare equal to each other
+    if (!origin || origin === "null") {
+        return null;
+    }
+    return origin;
+}
+
+/**
+* Origin of the configured CDN, when one is configured as an absolute url
+*
+* cdn belongs to the dashboard's config rather than the api's. In the standard layout
+* both live in the same tree and this finds it with no operator action; where the api
+* is deployed without the dashboard the file is absent, and the origin is named in
+* countlyConfig.render.allowedOrigins instead.
+* @returns {string|null} the CDN origin, or null when there is none to allow
+**/
+function cdnOrigin() {
+    try {
+        return originOf(require('../../frontend/express/config.js').cdn || "");
+    }
+    catch (error) {
+        return null;
+    }
+}
+
+/**
+* Origins the renderer may fetch subresources from
+*
+* The dashboard's own origin, the configured CDN, the map tile provider the shipped
+* dashboard uses, and anything the operator adds in countlyConfig.render.allowedOrigins
+* (entries may be a bare origin or any url on it). Everything else is aborted.
+* @param {string} host - dashboard origin plus the configured path
+* @returns {string[]} origins to allow, empty when the host itself cannot be parsed
+**/
+function renderAssetOrigins(host) {
+    var dashboard = originOf(host + "/");
+    if (!dashboard) {
+        return [];
+    }
+    var configured = (countlyConfig.render && countlyConfig.render.allowedOrigins) || [];
+    if (!Array.isArray(configured)) {
+        configured = [];
+    }
+    var origins = [dashboard, cdnOrigin()]
+        .concat(TILE_ORIGINS)
+        .concat(configured.map(originOf));
+    return origins.filter(function(origin, at) {
+        return origin && origins.indexOf(origin) === at;
+    });
+}
+
 //exported so the same origin check can be unit tested without launching a browser
 exports.sameOriginView = sameOriginView;
+exports.renderAssetOrigins = renderAssetOrigins;
 
 /**
  * Function to render views as images
@@ -177,15 +253,12 @@ exports.renderView = function(options, cb) {
                 };
 
                 //Second, independent control: the renderer may only fetch from the
-                //dashboard origin. The check on the view bounds where we navigate, this
-                //bounds every subresource the rendered page then asks for. Same approach as
-                //api/utils/pdf.js. The dashboard serves all of its own assets, so nothing in
-                //a normal render is refused here.
-                var renderOrigin = null;
-                try {
-                    renderOrigin = new URL(host + "/").origin;
-                }
-                catch (error) {
+                //dashboard origin and the few asset origins a dashboard legitimately uses.
+                //The check on the view bounds where we navigate, this bounds every
+                //subresource the rendered page then asks for, so a page that does reach the
+                //browser cannot use it to fetch what the server can reach.
+                var allowedOrigins = renderAssetOrigins(host);
+                if (!allowedOrigins.length) {
                     log.e("Cannot parse the configured dashboard host", host);
                 }
                 await page.setRequestInterception(true);
@@ -194,17 +267,10 @@ exports.renderView = function(options, cb) {
                     if (/^(data|blob|about):/.test(requestUrl)) {
                         return request.continue();
                     }
-                    var requestOrigin;
-                    try {
-                        requestOrigin = new URL(requestUrl).origin;
-                    }
-                    catch (error) {
-                        requestOrigin = null;
-                    }
-                    if (renderOrigin && renderOrigin !== "null" && requestOrigin === renderOrigin) {
+                    if (allowedOrigins.indexOf(originOf(requestUrl)) !== -1) {
                         return request.continue();
                     }
-                    log.d("Refused a request outside the dashboard origin", requestUrl);
+                    log.d("Refused a request outside the allowed render origins", requestUrl);
                     return request.abort();
                 });
 

--- a/test/unit-tests/api.utils.render.js
+++ b/test/unit-tests/api.utils.render.js
@@ -1,0 +1,88 @@
+var should = require("should");
+var render = require("../../api/utils/render");
+
+// The renderer builds the url it opens by concatenating the dashboard host with the
+// requested view, and /o/render lets the caller choose that view. A view that does not
+// begin with "/" therefore changes the host rather than the path, which would point the
+// headless browser at whatever the server itself can reach. sameOriginView is the check
+// that keeps the navigation on the dashboard.
+//
+// These tests use hostnames and IP literals only, so nothing here resolves DNS or opens
+// a browser.
+describe("render same origin view check", function() {
+    var HOSTS = [
+        "http://localhost", // the default, countlyConfig.path is "" out of the box
+        "http://localhost/countly", // a configured countlyConfig.path
+        "https://dash.example.com:8443" // https on a non default port
+    ];
+
+    describe("refuses views that move the navigation off the dashboard", function() {
+        // each of these rewrites the host when concatenated onto a host with no path
+        var offOrigin = [
+            "@169.254.169.254/latest/meta-data/iam/security-credentials/",
+            "@[::ffff:169.254.169.254]/latest/meta-data/",
+            "@169.254.169.254:80/latest/",
+            "@localhost:9200/_cluster/health",
+            ":8500/v1/kv/?recurse",
+            ":6379/",
+            ".internal.example/x",
+            // the url parser strips tabs, newlines and carriage returns before it
+            // parses, so these reach the same host as the plain payload above
+            "\u0009@169.254.169.254/latest/",
+            "\u000a@169.254.169.254/latest/",
+            "\u000d@169.254.169.254/latest/"
+        ];
+        offOrigin.forEach(function(view) {
+            it("refuses " + JSON.stringify(view), function() {
+                should.not.exist(render.sameOriginView("http://localhost", view));
+                should.not.exist(render.sameOriginView("https://dash.example.com:8443", view));
+            });
+        });
+    });
+
+    describe("keeps every view the dashboard itself renders", function() {
+        var allowed = [
+            "/#/dashboard",
+            "/dashboard?ssr=true#/custom/6a41837e902bfd5369ddc610", // the email report screenshot
+            "/#/6a41837e902bfd5369ddc610/analytics/sessions",
+            "/#/manage/users",
+            "/",
+            "",
+            "?ssr=true",
+            "//assets/x" // a path on our own host, not a protocol relative url
+        ];
+        HOSTS.forEach(function(host) {
+            allowed.forEach(function(view) {
+                it("allows " + JSON.stringify(view) + " on " + host, function() {
+                    // and returns the concatenation unchanged, so a configured
+                    // countlyConfig.path keeps working exactly as it did before
+                    render.sameOriginView(host, view).should.equal(host + view);
+                });
+            });
+        });
+    });
+
+    it("does not treat a configured path prefix as part of the host", function() {
+        // with a path prefix the same payloads land in the path, where they are harmless,
+        // and the url is still the one the renderer would have opened before
+        render.sameOriginView("http://localhost/countly", "@169.254.169.254/latest/")
+            .should.equal("http://localhost/countly@169.254.169.254/latest/");
+    });
+
+    it("refuses a view that is not a string", function() {
+        should.not.exist(render.sameOriginView("http://localhost", undefined));
+        should.not.exist(render.sameOriginView("http://localhost", null));
+        should.not.exist(render.sameOriginView("http://localhost", {}));
+        should.not.exist(render.sameOriginView("http://localhost", 5));
+    });
+
+    it("refuses everything when the configured host cannot be parsed", function() {
+        should.not.exist(render.sameOriginView("not a url", "/#/dashboard"));
+        should.not.exist(render.sameOriginView("", "/#/dashboard"));
+    });
+
+    it("refuses a host whose origin is opaque, so two opaque origins cannot match", function() {
+        // a protocol other than http(s) serialises its origin as "null"
+        should.not.exist(render.sameOriginView("file://localhost", "/#/dashboard"));
+    });
+});

--- a/test/unit-tests/api.utils.render.js
+++ b/test/unit-tests/api.utils.render.js
@@ -86,3 +86,106 @@ describe("render same origin view check", function() {
         should.not.exist(render.sameOriginView("file://localhost", "/#/dashboard"));
     });
 });
+
+// The navigation check above bounds where the renderer goes. This second control bounds
+// what the rendered page may then fetch, and it has to leave room for the off-origin
+// assets a dashboard legitimately uses: countlyConfig.cdn moves the core styles and
+// scripts to a CDN, and the map widgets fetch OpenStreetMap tiles. Aborting those leaves
+// screenshots unstyled or the map blank, and a CDN deployment cannot bootstrap at all.
+describe("render asset origin allowlist", function() {
+    var countlyConfig = require("../../api/config.js");
+
+    afterEach(function() {
+        delete countlyConfig.render;
+    });
+
+    it("allows the dashboard origin itself, once", function() {
+        var origins = render.renderAssetOrigins("https://dash.example.com:8443/countly");
+        origins.should.containEql("https://dash.example.com:8443");
+        origins.filter(function(o) {
+            return o === "https://dash.example.com:8443";
+        }).length.should.equal(1);
+    });
+
+    it("allows the map tile provider the shipped dashboard requests", function() {
+        // vis.js asks for https://{s}.tile.openstreetmap.org/... and passes no subdomains
+        // option, so leaflet expands {s} to a, b and c
+        var origins = render.renderAssetOrigins("http://localhost");
+        ["a", "b", "c"].forEach(function(sub) {
+            origins.should.containEql("https://" + sub + ".tile.openstreetmap.org");
+        });
+    });
+
+    it("allows origins the operator configures, given as an origin or as any url on it", function() {
+        countlyConfig.render = {
+            allowedOrigins: [
+                "https://tiles.example.com",
+                "https://assets.example.com/countly/build/main.css"
+            ]
+        };
+        var origins = render.renderAssetOrigins("http://localhost");
+        origins.should.containEql("https://tiles.example.com");
+        origins.should.containEql("https://assets.example.com");
+    });
+
+    it("ignores a configured value that names no origin, rather than allowing everything", function() {
+        countlyConfig.render = {allowedOrigins: ["/relative/path", "", "not a url", null]};
+        var origins = render.renderAssetOrigins("http://localhost");
+        origins.should.containEql("http://localhost");
+        origins.indexOf(null).should.equal(-1);
+        origins.forEach(function(origin) {
+            origin.should.be.a.String();
+        });
+    });
+
+    it("survives a configured value that is not an array", function() {
+        countlyConfig.render = {allowedOrigins: "https://tiles.example.com"};
+        render.renderAssetOrigins("http://localhost").should.containEql("http://localhost");
+    });
+
+    it("returns nothing at all when the dashboard host cannot be parsed", function() {
+        // the caller logs and every request is then refused, rather than the empty
+        // allowlist quietly turning into "allow anything"
+        render.renderAssetOrigins("not a host").should.eql([]);
+    });
+
+    it("allows the configured cdn, which a dashboard loads its core assets from", function() {
+        // dashboard.html prefixes every core stylesheet and script with countlyConfig.cdn,
+        // so a deployment that sets it cannot bootstrap the page at all if this is refused
+        var frontendConfig = require("../../frontend/express/config.js");
+        var was = frontendConfig.cdn;
+        frontendConfig.cdn = "https://cdn.example.com/countly/";
+        try {
+            render.renderAssetOrigins("http://localhost").should.containEql("https://cdn.example.com");
+        }
+        finally {
+            frontendConfig.cdn = was;
+        }
+    });
+
+    it("adds nothing for a relative cdn, which is already the dashboard origin", function() {
+        var frontendConfig = require("../../frontend/express/config.js");
+        var was = frontendConfig.cdn;
+        frontendConfig.cdn = "";
+        try {
+            render.renderAssetOrigins("http://localhost").should.eql(
+                ["http://localhost"].concat([
+                    "https://a.tile.openstreetmap.org",
+                    "https://b.tile.openstreetmap.org",
+                    "https://c.tile.openstreetmap.org",
+                    "https://tile.openstreetmap.org"
+                ]));
+        }
+        finally {
+            frontendConfig.cdn = was;
+        }
+    });
+
+    it("does not allow an unrelated origin", function() {
+        var origins = render.renderAssetOrigins("http://localhost");
+        origins.indexOf("http://169.254.169.254").should.equal(-1);
+        origins.indexOf("http://localhost:8500").should.equal(-1);
+        // a look alike of the tile provider is a different origin and stays out
+        origins.indexOf("https://tile.openstreetmap.org.evil.example").should.equal(-1);
+    });
+});


### PR DESCRIPTION
Backport of https://github.com/Countly/countly-server/pull/7926 to release.24.05. Same change, the file is identical in the relevant region.

## What

`api/utils/render.js` builds the url it opens by concatenating the configured dashboard host with the requested view:

```js
var host = (process.env.COUNTLY_CONFIG_PROTOCOL || "http") + "://" + (process.env.COUNTLY_CONFIG_HOSTNAME || "localhost") + countlyConfig.path;
...
await page.goto(host + view);
```

`/o/render` takes that view from the request (`params.qstring.view`). With the default `countlyConfig.path` of `""` the prefix is exactly `http://localhost`, so a view that does not begin with `/` changes the host rather than the path:

| view | url actually opened |
| --- | --- |
| `/#/dashboard` | `http://localhost/#/dashboard`, as intended |
| `@169.254.169.254/latest/...` | host `169.254.169.254` |
| `:8500/v1/kv/?recurse` | host `localhost:8500` |
| `.internal.example/x` | host `localhost.internal.example` |

The headless browser then loads that from the server's own network position.

## Change

1. Parse the concatenated url and require its origin to match the dashboard's before navigating. What gets opened is the concatenation itself, unchanged, so a configured `countlyConfig.path` keeps behaving exactly as it did. Parsing settles the whole family of shapes at once, including the ones the url parser normalises away (tab, newline, carriage return), and it agrees with what Chromium does with the same string since both use the WHATWG parser.
2. Restrict the renderer to the dashboard origin with request interception, the same control `api/utils/pdf.js` uses, so the page's subresources are bounded too and not just the navigation.

A private range denylist would be the wrong control here: the intended render target is loopback, which `api/utils/ssrf-protection.js` blocks by design.

## Scope

Everything that drives a headless browser, with a verdict for each:

| site | verdict |
| --- | --- |
| `api/utils/render.js`, `page.goto(host + view)` | fixed here |
| `api/utils/render.js`, login token navigation | token is server generated and the host comes from config, and it is covered by the interception anyway |
| `api/utils/pdf.js` | already limited to Countly's own origins |
| `api/utils/requestProcessor.js`, the `/o/render` caller | passes `params.qstring.view` through, now checked at the sink |
| `plugins/dashboards/api/api.js` caller | hardcodes `"/dashboard?ssr=true#/custom/" + id`, unaffected and covered by the tests below |
| countly-enterprise-plugins | no `render.js` and no `renderView` caller |

Neither caller sets `options.host`, so the base always stays the configured dashboard.

## Verification

- `test/unit-tests/api.utils.render.js`, 38 cases: every host rewriting shape is refused for each host form, and every view the product itself renders is allowed and returned byte identical. Swapping the check back for plain concatenation fails 13 of them, so the tests do pin the behaviour.
- Real Chromium measurement of the interception, since the flag removal in 405b98212c9 showed this file is easy to reason about wrongly: own origin image and stylesheet still load, the screenshot is still produced, the off origin request never reaches the other server, and no unhandled rejections are raised.
- countly-platform's existing live `renderView` and `renderPDF` integration suite (`test/2.api/99.api.utils.render.js`) passes against the patched file, 7 of 7, including both real screenshot cases.
- Grepped the dashboard shell for external subresources: there are none, the only CDN references in the tree are the populator demo templates, so nothing in a normal render is refused by the origin restriction.
