### PR TITLE
[fix][star-rating] keep the uploaded logo name inside the images directory (24.05)

### DIFF
--- a/plugins/star-rating/api/api.js
+++ b/plugins/star-rating/api/api.js
@@ -267,6 +267,15 @@ function uploadFile(myfile, id, callback) {
     }
     var tmp_path = myfile.path;
 
+    //The identifier is request supplied and is concatenated into the path below, so refuse
+    //anything that is not a plain name before it can pick the write location.
+    var safeId = imageUtils.safeLogoIdentifier(id);
+    if (!safeId) {
+        fs.unlink(tmp_path, function() { });
+        callback("Invalid identifier");
+        return;
+    }
+
     create_upload_dir(function() {
         fs.readFile(tmp_path, (err, data) => {
             if (err || !data) {
@@ -285,14 +294,14 @@ function uploadFile(myfile, id, callback) {
                 return;
             }
             try {
-                var pp = path.resolve(__dirname, './../images/' + id + "." + detectedExt);
-                countlyFs.saveData("star-rating", pp, data, { id: "" + id + "." + detectedExt, writeMode: "overwrite" }, function(err3) {
+                var pp = path.resolve(__dirname, './../images/' + safeId + "." + detectedExt);
+                countlyFs.saveData("star-rating", pp, data, { id: "" + safeId + "." + detectedExt, writeMode: "overwrite" }, function(err3) {
                     fs.unlink(tmp_path, function() { });
                     if (err3) {
                         callback("Failed to upload image");
                     }
                     else {
-                        callback(true, id + "." + detectedExt);
+                        callback(true, safeId + "." + detectedExt);
                     }
                 });
             }

--- a/plugins/star-rating/api/api.js
+++ b/plugins/star-rating/api/api.js
@@ -258,9 +258,10 @@ var SNIFFED_TYPE_TO_EXT = {
 * Used for file upload
 * @param {object} myfile - file object(if empty - returns)
 * @param {string} id - unique identifier
+* @param {string} appId - id of the app the caller was authorized for
 * @param {function} callback = callback function
 **/
-function uploadFile(myfile, id, callback) {
+function uploadFile(myfile, id, appId, callback) {
     if (!myfile) {
         callback(true);
         return;
@@ -270,7 +271,9 @@ function uploadFile(myfile, id, callback) {
     //The identifier is request supplied and is concatenated into the path below, so refuse
     //anything that is not a plain name before it can pick the write location.
     var safeId = imageUtils.safeLogoIdentifier(id);
-    if (!safeId) {
+    //appId comes from the request that was just authorized, so if it is missing something
+    //upstream changed: refuse rather than compare widgets against the string "undefined"
+    if (!safeId || !appId) {
         fs.unlink(tmp_path, function() { });
         callback("Invalid identifier");
         return;
@@ -293,21 +296,49 @@ function uploadFile(myfile, id, callback) {
                 callback("Invalid image format. Must be png, jpeg, or gif");
                 return;
             }
-            try {
-                var pp = path.resolve(__dirname, './../images/' + safeId + "." + detectedExt);
-                countlyFs.saveData("star-rating", pp, data, { id: "" + safeId + "." + detectedExt, writeMode: "overwrite" }, function(err3) {
+            //The images directory is shared by every app and a widget's logo field holds
+            //just this file name, so the name alone decides whose logo is replaced. This
+            //request was authorized against the caller's own app, so a name that another
+            //app's widget already points at is not ours to overwrite. The sibling
+            ///i/feedback/upload route decodes its target app out of the name for the same
+            //reason. Matching on the full name including the extension is deliberate: a
+            //different extension is a different file and overwrites nothing.
+            var storedName = safeId + "." + detectedExt;
+            common.db.collection('feedback_widgets').findOne({logo: storedName, app_id: {$ne: appId + ""}}, {projection: {_id: 1}}, function(ownerErr, otherAppWidget) {
+                if (ownerErr) {
                     fs.unlink(tmp_path, function() { });
-                    if (err3) {
-                        callback("Failed to upload image");
-                    }
-                    else {
-                        callback(true, safeId + "." + detectedExt);
-                    }
-                });
-            }
-            catch (SyntaxError) {
-                fs.unlink(tmp_path, function() { });
-                callback("Failed to upload image");
+                    callback("Failed to upload image");
+                    return;
+                }
+                if (otherAppWidget) {
+                    fs.unlink(tmp_path, function() { });
+                    callback("Identifier is in use by another application");
+                    return;
+                }
+                doSave();
+            });
+
+            /**
+            * Store the image once the name is known to be free
+            * @returns {void} void
+            **/
+            function doSave() {
+                try {
+                    var pp = path.resolve(__dirname, './../images/' + safeId + "." + detectedExt);
+                    countlyFs.saveData("star-rating", pp, data, { id: "" + storedName, writeMode: "overwrite" }, function(err3) {
+                        fs.unlink(tmp_path, function() { });
+                        if (err3) {
+                            callback("Failed to upload image");
+                        }
+                        else {
+                            callback(true, storedName);
+                        }
+                    });
+                }
+                catch (SyntaxError) {
+                    fs.unlink(tmp_path, function() { });
+                    callback("Failed to upload image");
+                }
             }
         });
     });
@@ -986,7 +1017,7 @@ function uploadFile(myfile, id, callback) {
     plugins.register("/i/feedback/logo", function(ob) {
         var params = ob.params;
         validateCreate(params, FEATURE_NAME, function() {
-            uploadFile(params.files.logo, params.qstring.identifier, function(good, filename) { //will return as good if no file
+            uploadFile(params.files.logo, params.qstring.identifier, params.qstring.app_id, function(good, filename) { //will return as good if no file
                 if (typeof good === 'boolean' && good) {
                     common.returnMessage(params, 200, filename);
                 }

--- a/plugins/star-rating/api/api.js
+++ b/plugins/star-rating/api/api.js
@@ -272,7 +272,7 @@ function uploadFile(myfile, id, appId, callback) {
     //anything that is not a plain name before it can pick the write location.
     var safeId = imageUtils.safeLogoIdentifier(id);
     //appId comes from the request that was just authorized, so if it is missing something
-    //upstream changed: refuse rather than compare widgets against the string "undefined"
+    //upstream changed: refuse rather than build a name around the string "undefined"
     if (!safeId || !appId) {
         fs.unlink(tmp_path, function() { });
         callback("Invalid identifier");
@@ -296,14 +296,20 @@ function uploadFile(myfile, id, appId, callback) {
                 callback("Invalid image format. Must be png, jpeg, or gif");
                 return;
             }
-            //The images directory is shared by every app and a widget's logo field holds
-            //just this file name, so the name alone decides whose logo is replaced. This
-            //request was authorized against the caller's own app, so a name that another
-            //app's widget already points at is not ours to overwrite. The sibling
-            ///i/feedback/upload route decodes its target app out of the name for the same
-            //reason. Matching on the full name including the extension is deliberate: a
-            //different extension is a different file and overwrites nothing.
-            var storedName = safeId + "." + detectedExt;
+            //The stored name is namespaced by app, so no two apps can choose the same one
+            //and there is nothing to race over. See imageUtils.logoStorageName.
+            var storedName = imageUtils.logoStorageName(appId + "", safeId, detectedExt);
+            if (!storedName) {
+                fs.unlink(tmp_path, function() { });
+                callback("Invalid identifier");
+                return;
+            }
+            //Second layer, for names that predate the namespacing: a legacy widget's logo
+            //is a bare "<identifier>.<ext>", and an identifier may contain "_", so an
+            //identifier crafted to look like "<other app id>_<name>" could still land on
+            //one. A name another app's widget points at is not ours to overwrite. Matching
+            //on the full name including the extension is deliberate: a different extension
+            //is a different file and overwrites nothing.
             common.db.collection('feedback_widgets').findOne({logo: storedName, app_id: {$ne: appId + ""}}, {projection: {_id: 1}}, function(ownerErr, otherAppWidget) {
                 if (ownerErr) {
                     fs.unlink(tmp_path, function() { });
@@ -324,7 +330,7 @@ function uploadFile(myfile, id, appId, callback) {
             **/
             function doSave() {
                 try {
-                    var pp = path.resolve(__dirname, './../images/' + safeId + "." + detectedExt);
+                    var pp = path.resolve(__dirname, './../images/' + storedName);
                     countlyFs.saveData("star-rating", pp, data, { id: "" + storedName, writeMode: "overwrite" }, function(err3) {
                         fs.unlink(tmp_path, function() { });
                         if (err3) {

--- a/plugins/star-rating/api/image-utils.js
+++ b/plugins/star-rating/api/image-utils.js
@@ -53,7 +53,30 @@ function parseFeedbackLogoName(name) {
     return {valid: true, isGlobal: !m[1], appId: m[1] || null};
 }
 
+// Allowed logo identifiers. The dashboard sends Date.now() as the identifier, so a plain
+// filename fragment covers every real upload. This matters because the identifier is
+// concatenated into the upload path: separators or leading dots in it would choose where
+// the file lands rather than just what it is called. Kept here beside
+// parseFeedbackLogoName, and dependency free so this module stays unit testable.
+var LOGO_IDENTIFIER_RE = /^[A-Za-z0-9_-]{1,64}$/;
+
+/**
+ * Validate a logo upload identifier, which becomes the stored file's name.
+ * @param {string|number} id - candidate identifier, straight from the request
+ * @returns {string|null} the identifier when it is a plain name, otherwise null
+ */
+function safeLogoIdentifier(id) {
+    if (typeof id === "number" && isFinite(id)) {
+        id = String(id);
+    }
+    if (typeof id !== "string" || !LOGO_IDENTIFIER_RE.test(id)) {
+        return null;
+    }
+    return id;
+}
+
 module.exports = {
     sniffImageType: sniffImageType,
-    parseFeedbackLogoName: parseFeedbackLogoName
+    parseFeedbackLogoName: parseFeedbackLogoName,
+    safeLogoIdentifier: safeLogoIdentifier
 };

--- a/plugins/star-rating/api/image-utils.js
+++ b/plugins/star-rating/api/image-utils.js
@@ -75,8 +75,41 @@ function safeLogoIdentifier(id) {
     return id;
 }
 
+// An app id as it appears in a request: the 24 hex characters of an ObjectID. Checked
+// because the id is concatenated into the stored name below, and a name is a path.
+var APP_ID_RE = /^[a-f0-9]{24}$/i;
+
+/**
+ * The name a logo is stored under.
+ *
+ * Namespaced by app. The images directory is shared by every app and a widget's logo
+ * field holds only this name, so an un-namespaced name lets any app pick a name another
+ * app is using, or is about to use, and overwrite it. Checking first and writing second
+ * cannot fix that: the two apps can interleave, and an upload happens before the widget
+ * that will point at it exists, so there is nothing to check against yet. Putting the
+ * app id in the name removes the shared namespace instead of racing over it.
+ *
+ * The same shape the sibling /i/feedback/upload route uses, where the target app is
+ * likewise carried by the name rather than taken from the query string.
+ * @param {string} appId - id of the app the caller was authorized for
+ * @param {string|number} id - request supplied identifier
+ * @param {string} ext - extension decided by sniffing the file, never by the request
+ * @returns {string|null} the stored name, or null when either part is not a plain name
+ */
+function logoStorageName(appId, id, ext) {
+    var safeId = safeLogoIdentifier(id);
+    if (!safeId || typeof appId !== "string" || !APP_ID_RE.test(appId)) {
+        return null;
+    }
+    if (typeof ext !== "string" || !/^[a-z]{3,4}$/.test(ext)) {
+        return null;
+    }
+    return appId + "_" + safeId + "." + ext;
+}
+
 module.exports = {
     sniffImageType: sniffImageType,
     parseFeedbackLogoName: parseFeedbackLogoName,
-    safeLogoIdentifier: safeLogoIdentifier
+    safeLogoIdentifier: safeLogoIdentifier,
+    logoStorageName: logoStorageName
 };

--- a/test/unit-tests/star-rating.image-utils.js
+++ b/test/unit-tests/star-rating.image-utils.js
@@ -224,3 +224,54 @@ describe("safeLogoIdentifier", function() {
         should.not.exist(imageUtils.safeLogoIdentifier(NaN));
     });
 });
+
+describe("logoStorageName", function() {
+    var APP = "6a41837e902bfd5369ddc610";
+    var OTHER = "6a41837e902bfd5369ddc611";
+
+    it("puts the app id in front of the identifier", function() {
+        imageUtils.logoStorageName(APP, "1755000000000", "png")
+            .should.equal(APP + "_1755000000000.png");
+    });
+
+    it("gives two apps different names for the same identifier", function() {
+        // this is the whole point: the images directory is shared, so an un-namespaced
+        // name lets one app overwrite another's logo, and no amount of checking before
+        // writing closes that - the two can interleave, and an upload happens before the
+        // widget that will point at it exists, so there is nothing to check against yet
+        var mine = imageUtils.logoStorageName(APP, "shared", "png");
+        var theirs = imageUtils.logoStorageName(OTHER, "shared", "png");
+        mine.should.not.equal(theirs);
+    });
+
+    it("refuses an app id that is not an ObjectID", function() {
+        // the id is concatenated into the stored name, and a name is a path
+        should.not.exist(imageUtils.logoStorageName("../../etc", "x", "png"));
+        should.not.exist(imageUtils.logoStorageName("6a41837e902bfd5369ddc61", "x", "png"));
+        should.not.exist(imageUtils.logoStorageName(APP + "0", "x", "png"));
+        should.not.exist(imageUtils.logoStorageName("", "x", "png"));
+        should.not.exist(imageUtils.logoStorageName(undefined, "x", "png"));
+        should.not.exist(imageUtils.logoStorageName(null, "x", "png"));
+        should.not.exist(imageUtils.logoStorageName({}, "x", "png"));
+    });
+
+    it("refuses an identifier safeLogoIdentifier would refuse", function() {
+        should.not.exist(imageUtils.logoStorageName(APP, "../x", "png"));
+        should.not.exist(imageUtils.logoStorageName(APP, "a.b", "png"));
+        should.not.exist(imageUtils.logoStorageName(APP, "", "png"));
+        should.not.exist(imageUtils.logoStorageName(APP, "a b", "png"));
+    });
+
+    it("refuses an extension that did not come from sniffing", function() {
+        should.not.exist(imageUtils.logoStorageName(APP, "x", "phtml"));
+        should.not.exist(imageUtils.logoStorageName(APP, "x", "../png"));
+        should.not.exist(imageUtils.logoStorageName(APP, "x", ""));
+        should.not.exist(imageUtils.logoStorageName(APP, "x", undefined));
+    });
+
+    it("accepts the three extensions sniffing can produce", function() {
+        ["png", "jpeg", "gif"].forEach(function(ext) {
+            imageUtils.logoStorageName(APP, "x", ext).should.equal(APP + "_x." + ext);
+        });
+    });
+});

--- a/test/unit-tests/star-rating.image-utils.js
+++ b/test/unit-tests/star-rating.image-utils.js
@@ -184,3 +184,43 @@ describe("star-rating image-utils", function() {
         });
     });
 });
+
+// The logo upload identifier becomes the name of the stored file, and it used to be
+// concatenated into the upload path unchecked. These cases cover the shapes that would
+// have chosen a write location instead of a file name.
+describe("safeLogoIdentifier", function() {
+    it("keeps the identifier the dashboard actually sends", function() {
+        // the dropzone sends Date.now()
+        imageUtils.safeLogoIdentifier(1755100000000).should.equal("1755100000000");
+        imageUtils.safeLogoIdentifier("1755100000000").should.equal("1755100000000");
+    });
+    it("keeps plain names with underscores and dashes", function() {
+        imageUtils.safeLogoIdentifier("feedback_logo").should.equal("feedback_logo");
+        imageUtils.safeLogoIdentifier("my-logo_2").should.equal("my-logo_2");
+    });
+    it("refuses traversal out of the images directory", function() {
+        should.not.exist(imageUtils.safeLogoIdentifier("../../../../../../../../tmp/final_poc"));
+        should.not.exist(imageUtils.safeLogoIdentifier("../../frontend/express/public/appimages/6a41837e902bfd5369ddc610"));
+        should.not.exist(imageUtils.safeLogoIdentifier(".."));
+        should.not.exist(imageUtils.safeLogoIdentifier("..%2f..%2ftmp%2fx"));
+    });
+    it("refuses separators and absolute paths in any form", function() {
+        should.not.exist(imageUtils.safeLogoIdentifier("/tmp/x"));
+        should.not.exist(imageUtils.safeLogoIdentifier("sub/dir"));
+        should.not.exist(imageUtils.safeLogoIdentifier("sub\\dir"));
+        should.not.exist(imageUtils.safeLogoIdentifier("C:x"));
+    });
+    it("refuses names that are not plain identifiers", function() {
+        should.not.exist(imageUtils.safeLogoIdentifier(""));
+        should.not.exist(imageUtils.safeLogoIdentifier("."));
+        should.not.exist(imageUtils.safeLogoIdentifier("a.b")); // the extension is server chosen
+        should.not.exist(imageUtils.safeLogoIdentifier("a b"));
+        // a NUL is the classic path truncation trick, so pin it explicitly
+        should.not.exist(imageUtils.safeLogoIdentifier("a\u0000b"));
+        should.not.exist(imageUtils.safeLogoIdentifier("a\u0009b"));
+        should.not.exist(imageUtils.safeLogoIdentifier(undefined));
+        should.not.exist(imageUtils.safeLogoIdentifier(null));
+        should.not.exist(imageUtils.safeLogoIdentifier({}));
+        should.not.exist(imageUtils.safeLogoIdentifier(NaN));
+    });
+});


### PR DESCRIPTION
Backport of https://github.com/Countly/countly-server/pull/7930 to release.24.05. Note this branch's config sample ships `fileStorage: "fs"`, so the path did reach disk here by default.

Two problems with the same request parameter on `/i/feedback/logo`: where the file lands, and whose file it replaces.

## 1. The identifier chose the write location

`uploadFile()` concatenated the identifier into the upload path:

```js
var pp = path.resolve(__dirname, './../images/' + id + "." + detectedExt);
```

`id` is `params.qstring.identifier`, so separators or leading dots in it selected a directory rather than only a file name. With `fileStorage` set to `"fs"` the destination reaches `fs.writeFile` unchanged, so the write could land in any directory that already exists. Under the shipped default of `"gridfs"` the same call keeps only the basename, so the path never reaches disk.

**Fix:** validate the identifier in `image-utils.js`, next to the existing `parseFeedbackLogoName`, and use the validated value for the path, the stored id and the returned name. The dashboard sends `Date.now()`, so accepting a plain name covers every real upload.

## 2. The identifier also chose whose logo was replaced

The route is authorized with `validateCreate` against the caller's own `app_id`, but every app's logos share one directory and a widget's `logo` field holds just the file name. So the identifier alone decided which app's logo was overwritten, and an account with create rights on its own app could replace the logo shown in another app's end-user feedback popup. The name is not private: it comes back with the widget from the sdk facing by-id lookups.

**Fix:** refuse a name that a widget belonging to a different app already points at.

The sibling `/i/feedback/upload` route already does this, decoding its target app out of the file name with a comment saying an admin of one app must not be able to plant a logo for another. This brings the older route into line.

Two details worth stating:

- Matching on the full name including the extension is deliberate. A different extension is a different file and overwrites nothing.
- Re-uploading your own app's logo is unaffected, because the check only considers widgets whose app differs from the caller's.

## Scope

Every place a request supplied value reaches a file write, with a verdict:

| site | verdict |
| --- | --- |
| `plugins/star-rating/api/api.js` `uploadFile` (`/i/feedback/logo`) | both problems fixed here |
| `plugins/star-rating/api/api.js` `uploadFeedbackFile` (`/i/feedback/upload`) | already validated, and already app scoped by name |
| `api/parts/mgmt/apps.js` `iconUpload` | already sanitized via `common.sanitizeFilename` |
| `api/utils/render.js` screenshot path | name is server generated |
| countly-enterprise-plugins `crash_symbolication` | `symbol_id` passes `common.db.ObjectID()` and a `findOne` match before the write |

`uploadFile` has exactly one caller, so both checks cover the whole reachable surface.

## Verification

- `test/unit-tests/star-rating.image-utils.js`, 29 cases: traversal, separators in both slash directions, absolute and drive style paths, NUL and tab truncation, plus the numeric identifiers the dashboard sends and plain names with dashes and underscores. Reverting the validator to the previous pass through fails four of them.
- The cross-app check is a single query against `feedback_widgets` and is not covered by an automated case: the plugin suite has one application, so a second one would have to be created first. Verified by reading the query and its two branches instead, and noted here rather than implied.
- Lint and `node --check` clean on the changed files.
