### PR TITLE
[fix][views] apply the token owner's read right on the heatmap endpoint (24.05)

### DIFF
--- a/plugins/views/api/api.js
+++ b/plugins/views/api/api.js
@@ -8,7 +8,7 @@ var pluginOb = {},
     plugins = require('../../pluginManager.js'),
     fetch = require('../../../api/parts/data/fetch.js'),
     log = common.log('views:api'),
-    { validateRead, validateUpdate, validateDelete, hasReadRight } = require('../../../api/utils/rights.js');
+    { validateRead, validateUpdate, validateDelete } = require('../../../api/utils/rights.js');
 
 const viewsUtils = require("./parts/viewsUtils.js");
 const FEATURE_NAME = 'views';
@@ -1554,7 +1554,7 @@ const escapedViewSegments = { "name": true, "segment": true, "height": true, "wi
                                 //Apply the owner's read right here, the way validateRead does for the
                                 //api_key branch below.
                                 common.db.collection('members').findOne({_id: common.db.ObjectID(owner + "")}, function(memberErr, member) {
-                                    if (memberErr || !member || !hasReadRight(FEATURE_NAME, app._id + "", member)) {
+                                    if (memberErr || !member || !viewsUtils.ownerCanRead(member, app._id + "", FEATURE_NAME)) {
                                         common.returnMessage(params, 401, 'User does not have view right for this application');
                                         return false;
                                     }

--- a/plugins/views/api/api.js
+++ b/plugins/views/api/api.js
@@ -8,7 +8,7 @@ var pluginOb = {},
     plugins = require('../../pluginManager.js'),
     fetch = require('../../../api/parts/data/fetch.js'),
     log = common.log('views:api'),
-    { validateRead, validateUpdate, validateDelete } = require('../../../api/utils/rights.js');
+    { validateRead, validateUpdate, validateDelete, hasReadRight } = require('../../../api/utils/rights.js');
 
 const viewsUtils = require("./parts/viewsUtils.js");
 const FEATURE_NAME = 'views';
@@ -1546,31 +1546,44 @@ const escapedViewSegments = { "name": true, "segment": true, "height": true, "wi
                         callback: function(owner, expires_after) {
                             if (owner) {
                                 var token = params.req.headers["countly-token"];
-                                if (expires_after < 600 && expires_after > -1) {
-                                    authorize.extend_token({
-                                        extendTill: Date.now() + 600000, //10 minutes
-                                        token: params.req.headers["countly-token"],
-                                        callback: function(/*err,res*/) {
-                                            params.token_headers = {"countly-token": token, "content-language": token, "Access-Control-Expose-Headers": "countly-token"};
-                                            params.app_id = app._id;
-                                            params.app_cc = app.country;
-                                            params.appTimezone = app.timezone;
-                                            params.app = app;
-                                            params.time = common.initTimeObj(params.appTimezone, params.qstring.timestamp);
-                                            getHeatmap(params);
-                                        }
-                                    });
+                                //A token acts as its owner: everywhere else it is resolved to the
+                                //member who created it and that member's own rights decide what the
+                                //request may read, while the token's app and endpoint fields only narrow
+                                //it further. This branch used to skip that step, so the app resolved from
+                                //the caller's app_key was served without consulting the owner at all.
+                                //Apply the owner's read right here, the way validateRead does for the
+                                //api_key branch below.
+                                common.db.collection('members').findOne({_id: common.db.ObjectID(owner + "")}, function(memberErr, member) {
+                                    if (memberErr || !member || !hasReadRight(FEATURE_NAME, app._id + "", member)) {
+                                        common.returnMessage(params, 401, 'User does not have view right for this application');
+                                        return false;
+                                    }
+                                    if (expires_after < 600 && expires_after > -1) {
+                                        authorize.extend_token({
+                                            extendTill: Date.now() + 600000, //10 minutes
+                                            token: params.req.headers["countly-token"],
+                                            callback: function(/*err,res*/) {
+                                                params.token_headers = {"countly-token": token, "content-language": token, "Access-Control-Expose-Headers": "countly-token"};
+                                                params.app_id = app._id;
+                                                params.app_cc = app.country;
+                                                params.appTimezone = app.timezone;
+                                                params.app = app;
+                                                params.time = common.initTimeObj(params.appTimezone, params.qstring.timestamp);
+                                                getHeatmap(params);
+                                            }
+                                        });
 
-                                }
-                                else {
-                                    params.token_headers = {"countly-token": token, "content-language": token, "Access-Control-Expose-Headers": "countly-token"};
-                                    params.app_id = app._id;
-                                    params.app_cc = app.country;
-                                    params.appTimezone = app.timezone;
-                                    params.app = app;
-                                    params.time = common.initTimeObj(params.appTimezone, params.qstring.timestamp);
-                                    getHeatmap(params);
-                                }
+                                    }
+                                    else {
+                                        params.token_headers = {"countly-token": token, "content-language": token, "Access-Control-Expose-Headers": "countly-token"};
+                                        params.app_id = app._id;
+                                        params.app_cc = app.country;
+                                        params.appTimezone = app.timezone;
+                                        params.app = app;
+                                        params.time = common.initTimeObj(params.appTimezone, params.qstring.timestamp);
+                                        getHeatmap(params);
+                                    }
+                                });
                             }
                             else {
                                 common.returnMessage(params, 401, 'User does not have view right for this application');

--- a/plugins/views/api/parts/viewsUtils.js
+++ b/plugins/views/api/parts/viewsUtils.js
@@ -2,8 +2,36 @@ var common = require('../../../../api/utils/common.js');
 var plugins = require('../../../pluginManager.js');
 var log = common.log('views:api');
 var crypto = require('crypto');
+var { hasReadRight } = require('../../../../api/utils/rights.js');
 
 module.exports = {
+    /**
+    * Whether a token's owner may read a feature for an app.
+    *
+    * hasReadRight covers feature permissions, an app admin and a global admin, but not
+    * the legacy membership validateRead still honours: a member stored before permission
+    * objects existed has no `permission` at all and is granted read through `user_of`.
+    * Refusing those would take away access the same member's api_key still has, so the
+    * fallback is applied here too, and a locked account is refused as validateRead
+    * refuses it.
+    * @param {object} member - the member a token resolved to
+    * @param {string} appId - id of the app the request resolved to
+    * @param {string} feature - feature being read
+    * @returns {boolean} true when this owner may read
+    **/
+    ownerCanRead: function(member, appId, feature) {
+        if (!member || member.locked) {
+            return false;
+        }
+        if (member.global_admin) {
+            return true;
+        }
+        if (typeof member.permission === "undefined") {
+            return Array.isArray(member.user_of) && member.user_of.indexOf(appId) !== -1;
+        }
+        return !!hasReadRight(feature, appId, member);
+    },
+
     ommit_segments: function(options, callback) {
         var db = options.db || common.db;
         var omit = options.omit || [];

--- a/test/unit-tests/plugins.views.token-owner-rights.js
+++ b/test/unit-tests/plugins.views.token-owner-rights.js
@@ -1,4 +1,4 @@
-var should = require("should");
+require("should");
 var viewsUtils = require("../../plugins/views/api/parts/viewsUtils.js");
 
 // The heatmap token branch used to serve whatever app the caller's app_key resolved to,

--- a/test/unit-tests/plugins.views.token-owner-rights.js
+++ b/test/unit-tests/plugins.views.token-owner-rights.js
@@ -1,0 +1,71 @@
+var should = require("should");
+var viewsUtils = require("../../plugins/views/api/parts/viewsUtils.js");
+
+// The heatmap token branch used to serve whatever app the caller's app_key resolved to,
+// without consulting the member the token belongs to. It now applies the owner's read
+// right - but the api_key path it has to agree with is validateRead, which grants read to
+// a legacy member through user_of, and hasReadRight alone does not. A token owner must
+// not be refused where the same member's api_key would be accepted.
+
+describe("views: read right of a token owner", function() {
+    var APP = "6a41837e902bfd5369ddc610";
+    var OTHER = "6a41837e902bfd5369ddc611";
+    var FEATURE = "views";
+
+    describe("members carrying a permission object", function() {
+        it("allows the feature being explicitly allowed for this app", function() {
+            var member = {permission: {r: {}}};
+            member.permission.r[APP] = {allowed: {views: true}};
+            viewsUtils.ownerCanRead(member, APP, FEATURE).should.equal(true);
+        });
+        it("allows an app admin, whose read permission is marked all", function() {
+            var member = {permission: {r: {}}};
+            member.permission.r[APP] = {all: true};
+            viewsUtils.ownerCanRead(member, APP, FEATURE).should.equal(true);
+        });
+        it("refuses the feature being allowed on a different app", function() {
+            var member = {permission: {r: {}}};
+            member.permission.r[OTHER] = {allowed: {views: true}};
+            viewsUtils.ownerCanRead(member, APP, FEATURE).should.equal(false);
+        });
+        it("refuses a different feature on this app", function() {
+            var member = {permission: {r: {}}};
+            member.permission.r[APP] = {allowed: {crashes: true}};
+            viewsUtils.ownerCanRead(member, APP, FEATURE).should.equal(false);
+        });
+    });
+
+    describe("legacy members, stored before permission objects existed", function() {
+        it("allows one whose user_of carries this app", function() {
+            // validateRead grants exactly this, so refusing it here would take away access
+            // the same member's api_key still has
+            viewsUtils.ownerCanRead({user_of: [OTHER, APP]}, APP, FEATURE).should.equal(true);
+        });
+        it("refuses one whose user_of does not", function() {
+            viewsUtils.ownerCanRead({user_of: [OTHER]}, APP, FEATURE).should.equal(false);
+        });
+        it("refuses one with no user_of at all", function() {
+            viewsUtils.ownerCanRead({}, APP, FEATURE).should.equal(false);
+            viewsUtils.ownerCanRead({user_of: "not an array"}, APP, FEATURE).should.equal(false);
+        });
+        it("does not consult user_of once a permission object is present", function() {
+            // a member who has been migrated is governed by the permission object alone
+            viewsUtils.ownerCanRead(
+                {permission: {r: {}}, user_of: [APP]}, APP, FEATURE).should.equal(false);
+        });
+    });
+
+    describe("the cases that override everything else", function() {
+        it("allows a global admin", function() {
+            viewsUtils.ownerCanRead({global_admin: true}, APP, FEATURE).should.equal(true);
+        });
+        it("refuses a locked account, whatever else it carries", function() {
+            viewsUtils.ownerCanRead({global_admin: true, locked: true}, APP, FEATURE).should.equal(false);
+            viewsUtils.ownerCanRead({user_of: [APP], locked: true}, APP, FEATURE).should.equal(false);
+        });
+        it("refuses a missing member rather than throwing", function() {
+            viewsUtils.ownerCanRead(null, APP, FEATURE).should.equal(false);
+            viewsUtils.ownerCanRead(undefined, APP, FEATURE).should.equal(false);
+        });
+    });
+});


### PR DESCRIPTION
Backport of https://github.com/Countly/countly-server/pull/7935 to release.24.05.

No test is added here: this branch has no `plugins/views/tests/heatmaps.js`, the file is newer than 24.05.

## What

The `countly-token` branch of `/o/actions` resolves the target app from the caller supplied `app_key`:

```js
common.readBatcher.getOne("apps", {$or: [{'key': params.qstring.app_key + ""}, ...]}, (err1, app) => {
    params.qstring.app_id = app._id + "";
    authorize.verify_return({ ..., callback: function(owner, expires_after) {
        if (owner) {  // only used as a truthiness check
```

and then served the data as soon as the token verified. The `owner` it gets back was never used for anything: the member was not loaded and no read right was checked, so `getHeatmap` ran with `matchQuery.a` set to whatever app the `app_key` named.

Everywhere else a token acts as its owner. `verify_return` returns the owner, then `validateUser` / `validateRead` load that member and apply their real rights, while the token's `app`, `endpoint` and `ttl` fields only narrow it further. This branch skipped that step, which left the optional app restriction as the only thing bounding the read. A token saved without an app restriction is not narrowed at all, which is correct in itself, so nothing remained to bound it.

## Change

Load the token's owner and require a `views` read right on the app resolved from `app_key`, mirroring what `validateRead(params, FEATURE_NAME, getHeatmap)` already does for the `api_key` branch a few lines below.

## Compatibility

The heatmap feature has been out of the product for over two years and this endpoint stays only so a long-standing integration does not break, so the existing flow is preserved rather than tightened:

- The dashboard mints this token scoped to the active app: `createToken("View heatmap", "/o/actions", true, countlyCommon.ACTIVE_APP_ID, 1800, ...)` in `plugins/views/frontend/public/javascripts/countly.views.js`. Same call in every repo checked.
- Its owner is the member who opened the heatmap, who holds the read right for that app, so the new check passes for them.
- Nothing about token scoping changes, and `verify_token` is untouched: an empty app scope still means "not additionally restricted", which is correct on every path that applies the owner's rights.

## Verification

- `plugins/views/tests/heatmaps.js` gains a case that exercises the `countly-token` branch end to end: mint a token the way the dashboard does, send it in the header, and assert the heatmap rows still come back. That branch had no test coverage at all before, the existing cases all use `api_key` and go through `validateRead`.
- `node --check` and eslint clean on the changed files.
