### PR TITLE
security(core): escape "<" in the res.expose script island (stored XSS via app name)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Enterprise Fixes:
 - [data-manager] Fixed editing an event whose key contains `&` creating undeletable duplicate rows in the events table
 
 Security Fixes:
+- [core] The dashboard escapes `<` when serializing the exposed `countlyGlobal` object into the inline page script, so an application name (or any exposed value) containing a `</script>` end tag in any spelling can no longer break out of the script block and run in another user's session; the active-app name is now rendered with `.text()` instead of `.html()`
 - [hooks] Internal event hooks are now scoped to the apps the hook belongs to: app creation is a global-admin-only event, and remote-config, cohort, alert and hook-chaining events are only delivered when the event's app is one the hook is scoped to
 - [compliance-hub] The consents table now returns a fixed set of fields; a projection supplied on the request is no longer used to widen the response beyond the consent columns
 - [dashboards] Widgets are no longer copied when the copying user has no access to the apps they reference, and widget app ids are validated on widget create and update

--- a/frontend/express/libs/express-expose.js
+++ b/frontend/express/libs/express-expose.js
@@ -186,9 +186,13 @@ function string(obj) {
     else {
         obj = JSON.stringify(obj);
         if (obj) {
-            // Only escape things that could break out of script context
-            obj = obj.replace(/<\/script>/ig, '</scr"+"ipt>');
-            obj = obj.replace(/<!--/g, '<\\!--');
+            // Escape "<" so nothing serialized here can open or close a tag in the inline
+            // <script> block this value is written into. A "</script>" end tag terminates the
+            // script in any of its whitespace/slash spellings (</script >, </script/>, ...),
+            // which an exact-match replace of "</script>" misses; escaping every "<" closes all
+            // of those plus "<!--" and "<script". "<" parses back to "<", so runtime
+            // values read from the exposed object are unchanged.
+            obj = obj.replace(/</g, '\\u003c');
             obj = obj.replace(/\u2028/g, '\\u2028'); // Line separator
             obj = obj.replace(/\u2029/g, '\\u2029'); // Paragraph separator
         }
@@ -222,7 +226,8 @@ function escape_js_string(str) {
         .replace(/\0/g, '\\0') // Null character
         .replace(/[\u0000-\u001F\u007F-\u009F]/g, function(ch) {
             return '\\u' + ('0000' + ch.charCodeAt(0).toString(16)).slice(-4);
-        });
+        })
+        .replace(/</g, '\\u003c'); // "<" so a key cannot break out of the <script> block
 }
 
 exports = module.exports = function(app) {

--- a/frontend/express/public/javascripts/countly/countly.template.js
+++ b/frontend/express/public/javascripts/countly/countly.template.js
@@ -2403,7 +2403,7 @@ var AppRouter = Backbone.Router.extend({
 
                 countlyCommon.setActiveApp(activeApp._id);
                 self.activeAppName = activeApp.name;
-                $('#active-app-name').html(activeApp.name);
+                $('#active-app-name').text(activeApp.name);
                 $('#active-app-name').attr('title', activeApp.name);
                 $("#active-app-icon").css("background-image", "url('" + countlyGlobal.cdn + "appimages/" + countlyCommon.ACTIVE_APP_ID + ".png')");
             }


### PR DESCRIPTION
### Summary

The dashboard serializes the exposed `countlyGlobal` object into an inline script block in `dashboard.html`:

```html
<script><%- javascript %></script>
```

`frontend/express/libs/express-expose.js` produced that JavaScript and tried to prevent a breakout by replacing the exact sequence `</script>`. But the HTML tokenizer also ends a `<script>` element at `</script >`, `</script/>` and other whitespace/slash spellings, which the exact-match replace missed. An **application name** containing such a spelling therefore broke out of the script block.

Because a global admin's dashboard lists **every** app, an **app admin of a single app** could set their own app's name to a `</script >`-based payload; when any global admin loaded the dashboard, the payload executed in the global admin's own session. From there it can read the session token / api_key and drive global-admin-only endpoints, i.e. escalate a single app-admin account to full instance control.

Requires an authenticated app-admin account, so this is Medium under [SECURITY.md](https://github.com/Countly/countly-server/blob/master/SECURITY.md).

### Root cause

- The primitive branch escaped only the literal `</script>` (and `<!--`), not the other end-tag spellings the parser accepts.
- `escape_js_string` (used for object **keys**) escaped quotes, backticks and control chars but never `<`, so a hostile key could break out even with the exact spelling.

### Fix

Escape every `<` as `<` in **both** serialization paths — string values and object keys. `<` parses back to `<`, so every value read out of the exposed object is unchanged; this is the value-preserving JS-string escaping direction of the previous fix (`aa33b31`, which removed the old value-*changing* `escape_html`), not a return to HTML-entity escaping.

Separately, the active-app name is now rendered with `.text()` instead of `.html()` in `countly.template.js` (line 2406) — an independent DOM sink for the same value, and the only `.html()` sink fed by an app name anywhere in the frontend or plugins (the others render trusted templates, clear content, decode numeric metrics, or i18n strings).

### Why this does not break the dashboard

The escaping that broke dashboards historically was `escape_html` (`<`→`&lt;`), which changed the runtime values. `<` does not: it is exactly `<` after the JS parser reads it. Verified by an eval round-trip:

- **Security:** no raw `<` survives for `</script>`, `</script >`, `</script/>`, `</script\t>`, `</script\n>`, `<img …>`, `<!--`, `<script>` — in values **and** keys.
- **Safety:** evaluating the serialized output reproduces the input object byte-for-byte, and matches the previous serializer's output exactly — no dashboard-visible change.

### Notes

- Structurally moving the island to a non-executed `<script type="application/json">` data block would retire this class entirely, but is intentionally out of scope here (larger change to a UI being phased out).
- Reported through the security bug bounty program (received 2026-08-17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
