### PR TITLE
security(core): escape "<" in the res.expose script island (24.05)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Fixes:
 Enterprise Fixes:
 - [data-manager] Fixed editing an event whose key contains `&` creating undeletable duplicate rows in the events table
 
+Security Fixes:
+- [core] The dashboard escapes `<` when serializing the exposed `countlyGlobal` object into the inline page script, so an application name (or any exposed value) containing a `</script>` end tag in any spelling can no longer break out of the script block and run in another user's session; the active-app name is now rendered with `.text()` instead of `.html()`
+
 ## Version 24.05.51
 
 Fixes:

--- a/frontend/express/libs/express-expose.js
+++ b/frontend/express/libs/express-expose.js
@@ -186,9 +186,13 @@ function string(obj) {
     else {
         obj = JSON.stringify(obj);
         if (obj) {
-            // Only escape things that could break out of script context
-            obj = obj.replace(/<\/script>/ig, '</scr"+"ipt>');
-            obj = obj.replace(/<!--/g, '<\\!--');
+            // Escape "<" so nothing serialized here can open or close a tag in the inline
+            // <script> block this value is written into. A "</script>" end tag terminates the
+            // script in any of its whitespace/slash spellings (</script >, </script/>, ...),
+            // which an exact-match replace of "</script>" misses; escaping every "<" closes all
+            // of those plus "<!--" and "<script". The escape parses back to "<", so runtime
+            // values read from the exposed object are unchanged.
+            obj = obj.replace(/</g, '\\u003c');
             obj = obj.replace(/\u2028/g, '\\u2028'); // Line separator
             obj = obj.replace(/\u2029/g, '\\u2029'); // Paragraph separator
         }
@@ -222,7 +226,8 @@ function escape_js_string(str) {
         .replace(/\0/g, '\\0') // Null character
         .replace(/[\u0000-\u001F\u007F-\u009F]/g, function(ch) {
             return '\\u' + ('0000' + ch.charCodeAt(0).toString(16)).slice(-4);
-        });
+        })
+        .replace(/</g, '\\u003c'); // "<" so a key cannot break out of the <script> block
 }
 
 exports = module.exports = function(app) {

--- a/frontend/express/public/javascripts/countly/countly.template.js
+++ b/frontend/express/public/javascripts/countly/countly.template.js
@@ -2403,7 +2403,7 @@ var AppRouter = Backbone.Router.extend({
 
                 countlyCommon.setActiveApp(activeApp._id);
                 self.activeAppName = activeApp.name;
-                $('#active-app-name').html(activeApp.name);
+                $('#active-app-name').text(activeApp.name);
                 $('#active-app-name').attr('title', activeApp.name);
                 $("#active-app-icon").css("background-image", "url('" + countlyGlobal.cdn + "appimages/" + countlyCommon.ACTIVE_APP_ID + ".png')");
             }


### PR DESCRIPTION
Backport of #7949 to `release.24.05`.

`frontend/express/libs/express-expose.js` serializes the exposed `countlyGlobal` object into an inline `<script>` block. It neutralized only the exact `</script>` sequence, but the HTML tokenizer also ends a script at `</script >`, `</script/>` and other whitespace/slash spellings, so an **application name** containing one broke out. Because a global admin's dashboard lists every app, an **app admin of one app** could store such a name and have it execute in any global admin's session — an app-admin-to-global-admin escalation. Medium under [SECURITY.md](https://github.com/Countly/countly-server/blob/master/SECURITY.md).

Fix (identical to #7949): escape every `<` as `<` in both serialization paths — string values and object keys (`escape_js_string`). `<` parses back to `<`, so values read from the exposed object are unchanged. Also render the active-app name with `.text()` instead of `.html()` in `countly.template.js` (the only `.html()` sink fed by an app name).

Verified on this branch: no raw `<` survives for any breakout spelling in values or keys, and an eval round-trip reproduces the input object byte-for-byte and matches the previous serializer output (no dashboard-visible change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
