### PR TITLE
[security][core] escape values at dashboard html sinks the api escaper does not cover

### DIFF
--- a/plugins/compliance-hub/frontend/public/javascripts/countly.models.js
+++ b/plugins/compliance-hub/frontend/public/javascripts/countly.models.js
@@ -194,7 +194,13 @@
                 var ret = "<p>" + ((jQuery.i18n.map["systemlogs.action." + row.a]) ? jQuery.i18n.map["systemlogs.action." + row.a] : row.a) + "</p>";
                 if (typeof row.i === "object") {
                     if (typeof row.i.app_id !== "undefined" && countlyGlobal.apps[row.i.app_id]) {
-                        ret += "<p title='" + row.i.app_id + "'>" + jQuery.i18n.map["systemlogs.for-app"] + ": " + countlyGlobal.apps[row.i.app_id].name + "</p>";
+                        //this string is rendered with v-html, so every interpolated value must already be
+                        //HTML-safe. Everything taken from "row" arrives through common.returnOutput, which
+                        //escape_html_entities has already escaped, so it must NOT be escaped again here or
+                        //the entities would show up literally. The app name is the exception: it comes from
+                        //countlyGlobal, which is serialized into the dashboard's script island by
+                        //express-expose and is never HTML-escaped, so it reaches us raw and is escaped here.
+                        ret += "<p title='" + row.i.app_id + "'>" + jQuery.i18n.map["systemlogs.for-app"] + ": " + countlyCommon.encodeHtml(countlyGlobal.apps[row.i.app_id].name) + "</p>";
                     }
                     if (typeof row.i.appuser_id !== "undefined") {
                         ret += "<p title='" + row.i.appuser_id + "'>" + jQuery.i18n.map["systemlogs.for-appuser"] + ": " + row.i.appuser_id + "</p>";

--- a/plugins/populator/frontend/public/templates/environment_detail.html
+++ b/plugins/populator/frontend/public/templates/environment_detail.html
@@ -33,7 +33,8 @@
         <cly-section>
             <cly-confirm-dialog @cancel="closeConfirmDialog" @confirm="submitConfirmDialog" :visible.sync="dialog.showDialog" dialogType="success" :saveButtonLabel="dialog.saveButtonLabel" :cancelButtonLabel="dialog.cancelButtonLabel" :title="dialog.title" :show-close="false">
                 <template slot-scope="scope">
-                    <div v-html="dialog.text"></div>
+                    <!-- dialog.text is a localized sentence with an environment name substituted in, never markup -->
+                    <div>{{dialog.text}}</div>
                 </template>
             </cly-confirm-dialog>
             <cly-datatable-n ref="populatorEnvTable" id="populator-environment-table" :data-source="remoteTableDataSource" :force-loading="isLoading" searchPlaceholder="Search in User Name" :hasExport="false">

--- a/plugins/populator/frontend/public/templates/populator.html
+++ b/plugins/populator/frontend/public/templates/populator.html
@@ -178,7 +178,8 @@
     </cly-tabs>
     <cly-confirm-dialog class="populator-wrapper__start-dialog" :show-close="false" @cancel="closeConfirmDialog" @confirm="submitConfirmDialog" :before-close="closeConfirmDialog" ref="deleteConfirmDialog" :visible.sync="dialog.showDialog" dialogType="success" :saveButtonLabel="dialog.saveButtonLabel" :cancelButtonLabel="dialog.cancelButtonLabel" :saveButtonVisibility="dialog.saveButtonVisibility" :title="dialog.title" >
         <template slot-scope="scope">
-            <div v-html="dialog.text"></div>
+            <!-- dialog.text is a localized sentence with a template or environment name substituted in, never markup -->
+            <div>{{dialog.text}}</div>
         </template>
     </cly-confirm-dialog>
     <cly-populator-template-drawer ref="populatorTemplateDrawer" @refresh-table="refresh" @closeHandler="refreshTable" :titleDescription="titleDescription" :controls="drawers.populatorTemplate"></cly-populator-template-drawer>

--- a/test/unit-tests/plugins.compliance-hub.actions-escaping.js
+++ b/test/unit-tests/plugins.compliance-hub.actions-escaping.js
@@ -1,0 +1,132 @@
+var should = require("should");
+var fs = require("fs");
+var path = require("path");
+var vm = require("vm");
+
+// The export/purge history datatable builds an HTML string in onReady and the template renders it
+// with v-html (plugins/compliance-hub/frontend/public/templates/exportHistory.html). Everything
+// interpolated into that string therefore has to be HTML-safe already.
+//
+// Two opposite mistakes are possible and this file guards both directions:
+//
+//  1. NOT escaping the app name. It is read from countlyGlobal, which express-expose serializes
+//     into the dashboard's inline script island. That serializer escapes for the JavaScript string
+//     context only and is deliberately value-preserving, so the value arrives raw. An app admin can
+//     set their own app's name, and a global admin's dashboard lists every app, so an unescaped name
+//     is a stored cross-user XSS.
+//  2. Escaping the values that came from the API. Those already went through
+//     common.escape_html_entities in common.returnOutput, so escaping them again would render the
+//     entities literally in the UI.
+var SRC = path.resolve(__dirname, "../../plugins/compliance-hub/frontend/public/javascripts/countly.models.js");
+
+/**
+ * Load countly.models.js in a sandbox and hand back the onReady callbacks it registers,
+ * keyed by data-table name.
+ * @param {object} apps - the countlyGlobal.apps map the module should see
+ * @returns {object} map of resource name to its onReady function
+ */
+function loadResources(apps) {
+    var resources = {};
+    var noop = function() {};
+    // matches countlyCommon.encodeHtml, which is `div.innerText = x; return div.innerHTML`:
+    // the text-node serializer escapes &, < and > and leaves quotes alone.
+    var encodeHtml = function(html) {
+        return (html + "").replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+    };
+    var sandbox = {
+        window: {},
+        countlyCommon: {
+            encodeHtml: encodeHtml,
+            formatTimeAgoText: function() {
+                return { text: "just now" };
+            },
+            getDescendantProp: noop,
+            API_PARTS: { data: { r: "/o" } },
+            ACTIVE_APP_ID: "5f1a2b3c4d5e6f0011223344",
+            periodObj: {},
+            getPeriodForAjax: function() {
+                return "30days";
+            }
+        },
+        CountlyHelpers: { createMetricModel: noop },
+        jQuery: { i18n: { map: { "systemlogs.for-app": "For app", "systemlogs.for-appuser": "For app user", "systemlogs.action.export": "Data exported" } } },
+        CV: {
+            i18n: function(k) {
+                return k;
+            }
+        },
+        countlyGlobal: { apps: apps },
+        countlyTaskManager: {},
+        countlyVue: {
+            vuex: {
+                ServerDataTable: function(name, cfg) {
+                    resources[name] = cfg.onReady;
+                    return { name: name };
+                },
+                Module: function() {
+                    return {};
+                },
+                MutationsFor: noop,
+                ActionsFor: noop
+            }
+        }
+    };
+    sandbox.global = sandbox;
+    vm.createContext(sandbox);
+    vm.runInContext(fs.readFileSync(SRC, "utf8"), sandbox, { filename: SRC });
+    return resources;
+}
+
+describe("compliance-hub export history actions escaping", function() {
+    var APP_ID = "5f1a2b3c4d5e6f0011223344";
+
+    /**
+     * Run the export-history onReady over a single row.
+     * @param {string} appName - the app name countlyGlobal should carry
+     * @param {object} i - the row's "i" payload
+     * @returns {string} the built actions HTML
+     */
+    function actionsFor(appName, i) {
+        var apps = {};
+        apps[APP_ID] = { name: appName };
+        var onReady = loadResources(apps).exportHistoryDataResource;
+        should.exist(onReady);
+        var rows = onReady({}, [{ a: "export", ts: 0, i: i || { app_id: APP_ID } }]);
+        return rows[0].actions;
+    }
+
+    it("escapes an app name that carries a tag", function(done) {
+        var actions = actionsFor('<img src=x onerror="alert(1)">');
+        actions.indexOf("<img").should.equal(-1);
+        actions.should.containEql("&lt;img src=x onerror=&quot;alert(1)&quot;&gt;".replace(/&quot;/g, '"'));
+        done();
+    });
+
+    it("escapes an app name that closes the surrounding tag", function(done) {
+        var actions = actionsFor("</p><script>alert(1)</script>");
+        actions.indexOf("<script").should.equal(-1);
+        actions.indexOf("</script>").should.equal(-1);
+        done();
+    });
+
+    it("leaves no raw angle bracket from the app name", function(done) {
+        var actions = actionsFor("<svg onload=alert(1)>");
+        // the only markup left must be the <p> wrappers this builder emits itself
+        actions.replace(/<\/?p[^>]*>/g, "").indexOf("<").should.equal(-1);
+        done();
+    });
+
+    it("keeps an ordinary app name readable", function(done) {
+        var actions = actionsFor("My Application");
+        actions.should.containEql("For app: My Application");
+        done();
+    });
+
+    it("does not double-escape values the API already escaped", function(done) {
+        // returnOutput turns ' into &#39;; escaping again would surface "&amp;#39;" in the UI
+        var actions = actionsFor("My Application", { app_id: APP_ID, appuser_id: "user&#39;s-id" });
+        actions.should.containEql("user&#39;s-id");
+        actions.indexOf("&amp;#39;").should.equal(-1);
+        done();
+    });
+});


### PR DESCRIPTION
Found while looking at how the dashboard's HTML sinks are fed, alongside #7949.

Countly's model is that API output is HTML-escaped server side by `common.escape_html_entities`, so a value that came from an API response is already safe by the time a template renders it. This PR covers the two situations where that guarantee does not hold, and were the only ones the sweep found still open.

## 1. A value the API escaper does not cover

The compliance-hub export/purge history datatable builds an HTML string in `onReady` and the template renders it. Most of what goes into that string comes from the row, i.e. through `common.returnOutput`, and is already escaped: those are deliberately left alone, because escaping them a second time would surface the entities literally in the UI.

One value in that string comes from `countlyGlobal` instead. That object is serialized into the dashboard by `express-expose`, and that serializer escapes for the JavaScript string context, not the HTML one. It is value-preserving by design (see #7949), so the API's HTML escaping was never applied to this value at any point. It is now escaped where it is interpolated.

## 2. Dialog bodies that never needed HTML

The populator template and environment delete confirmations rendered their body with `v-html`, where the bound value is a localized sentence with a name substituted into a `{0}` placeholder. Both names are HTML-decoded on the way in, so the escaping the API applied no longer held at render time.

Rather than filter what reaches those, they now use text interpolation, which removes the sink. I checked every assignment to this dialog object and every populator locale file that supplies these strings, in all 26 languages present: none contain tags, so nothing renders differently.

**The plugins plugin's dependency confirmation is deliberately left on `v-html`.** Its strings genuinely carry markup — `plugins.confirm` has a `<br/><br/>` in all 24 translated locale files, even though the default locale no longer does — so converting it would render those literally for every non-English user. The values interpolated into that one are plugin titles from package metadata rather than anything a dashboard account can write, so there is nothing to neutralize. Worth knowing for anyone auditing the same pattern: identical-looking sinks here have opposite correct answers, and the default `.properties` file is not a reliable guide to what the translations contain.

## Scope

The sweep covered `v-html` bindings, jQuery `.html(<var>)`, `innerHTML`, `insertAdjacentHTML`, and every `unescapeHtml` call site, in this repo and in the enterprise plugins, cross-referencing each sink against whether its source is API-escaped or not.

| Site | Verdict |
|---|---|
| compliance-hub `countly.models.js` actions column | fixed here |
| populator template + environment delete confirmations | fixed here |
| plugins enable/disable dependency confirmation | intentional markup, source not writable from the dashboard, left as is |
| `vue/components/vis.js` chart tooltips | already covered by #7882 / #7883, left alone |
| dashboards note widget, EP content localization table, EP surveys, EP users note | already hardened previously |
| `<textarea v-html>` in hooks effects | RCDATA, parsed as text |
| `formatTimeAgo` / i18n-only bindings | no external input |
| two-factor-auth QR markup | generated SVG geometry, and caller's own secret |
| remaining `v-html` bindings | API-escaped with no decode step in between, inert |
| app-name accessors in `countly.template.js` and `appIdsToNames` consumers | already text sinks |

Counts, so the sweep's completeness is checkable: 62 `v-html` bindings here and 60 in the enterprise plugins, 57 `.html()` hits of which 12 are application code, 45 `innerHTML`-family hits of which about 20 are application code, and 137 `unescapeHtml` call sites classified by destination.

Worth recording for future readers: a detached-element `.html()` is still a live sink, since image loading is not gated on document insertion. The ones above are inert because of their inputs, not because they are detached.

## Verification

New file `test/unit-tests/plugins.compliance-hub.actions-escaping.js` loads the real module in a sandbox and exercises the actual `onReady` builder, so it tests the shipped code path rather than a copy. It pins both directions, because the failure mode here is symmetric: a value carrying markup must be neutralized, and an already-escaped API value must not be double-escaped.

- new tests against unpatched code: **3 failing, 2 passing**. Against patched: **5 passing**. The three failures are exactly the three security assertions.
- full unit suite: **185 passing before, 190 after** (+5, the new tests), with the same 2 pre-existing failures either way (`Countly Request`, network dependent). Baseline established by re-running with the new file excluded, not assumed.
- eslint clean.
- The dialog changes are template-only and carry no test: the guarantee is structural, since text interpolation cannot render markup, and the "nothing renders differently" claim rests on the locale audit described above.

## Propagation

Handled in their own PRs rather than by widening this one:

- `release.24.05`: #7965
- countly-platform `main`: Countly/countly-platform#1121

Platform is a straight port, since those frontend files are unchanged from this repo. `release.24.05` is **not**: there the environment delete string is `Are you sure you want to delete <b>{0}</b> environment?`, so that dialog keeps `v-html` and escapes the name at the assignment instead of converting the template. Same class of fix, different mechanism, chosen by what each branch's locale files actually contain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
