### PR TITLE
security(core): stop scoped tokens from escalating via token create and login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Enterprise Fixes:
 - [data-manager] Fixed editing an event whose key contains `&` creating undeletable duplicate rows in the events table
 
 Security Fixes:
-- [core] Token creation is now allowed only from a full-permission credential: an api_key, or a token with no app and no endpoint restriction. A restricted token can no longer create a token, which previously let it mint an unrestricted or login-capable token and escalate beyond its own scope
+- [core] A token restricted to specific apps or endpoints can no longer escalate its scope. Token creation is allowed only from a full-permission credential (an api_key, or a token with no app and no endpoint restriction), and a scoped token can no longer be redeemed for a dashboard session at /login/token. Previously a token scoped to one app could mint an unrestricted or login-capable token and take over the owner's full account
 - [hooks] Internal event hooks are now scoped to the apps the hook belongs to: app creation is a global-admin-only event, and remote-config, cohort, alert and hook-chaining events are only delivered when the event's app is one the hook is scoped to
 - [compliance-hub] The consents table now returns a fixed set of fields; a projection supplied on the request is no longer used to widen the response beyond the consent columns
 - [dashboards] Widgets are no longer copied when the copying user has no access to the apps they reference, and widget app ids are validated on widget create and update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Enterprise Fixes:
 - [data-manager] Fixed editing an event whose key contains `&` creating undeletable duplicate rows in the events table
 
 Security Fixes:
+- [core] Token creation is now allowed only from a full-permission credential: an api_key, or a token with no app and no endpoint restriction. A restricted token can no longer create a token, which previously let it mint an unrestricted or login-capable token and escalate beyond its own scope
 - [hooks] Internal event hooks are now scoped to the apps the hook belongs to: app creation is a global-admin-only event, and remote-config, cohort, alert and hook-chaining events are only delivered when the event's app is one the hook is scoped to
 - [compliance-hub] The consents table now returns a fixed set of fields; a projection supplied on the request is no longer used to widen the response beyond the consent columns
 - [dashboards] Widgets are no longer copied when the copying user has no access to the apps they reference, and widget app ids are validated on widget create and update

--- a/api/utils/requestProcessor.js
+++ b/api/utils/requestProcessor.js
@@ -2564,58 +2564,91 @@ const processRequest = (params) => {
                 */
                 case 'create':
                     validateUser(params, () => {
-                        let ttl, multi, endpoint, purpose, apps;
-                        if (params.qstring.ttl) {
-                            ttl = parseInt(params.qstring.ttl);
-                        }
-                        else {
-                            ttl = 1800;
-                        }
-                        multi = true;
-                        if (params.qstring.multi === false || params.qstring.multi === 'false') {
-                            multi = false;
-                        }
-                        apps = params.qstring.apps || "";
-                        if (params.qstring.apps) {
-                            apps = params.qstring.apps.split(',');
-                        }
+                        // Token creation is a privileged management operation. A token's app/endpoint
+                        // restriction scopes which app data it may read or write through data endpoints;
+                        // it does not gate this endpoint, which carries no app_id, so it cannot be relied
+                        // on to constrain what is created here. A scoped token must therefore not be able
+                        // to mint a token: it could create an unrestricted child, or a LoggedInAuth token
+                        // redeemable at /login/token/:token for a full session, and so escalate beyond its
+                        // own scope. Allow creation only from a full-permission credential: an api_key (the
+                        // member itself) or a token with no app and no endpoint restriction, such as the
+                        // dashboard session token. Future: enforce the child's permissions as a subset of
+                        // the creating credential's CRUD permissions.
+                        const creatorToken = params.qstring.auth_token || (params.req && params.req.headers && params.req.headers["countly-token"]) || "";
+                        /**
+                        * Parse the request and save the new token. Reached only once the caller is
+                        * allowed to create tokens.
+                        * @returns {void}
+                        */
+                        const proceedWithCreate = function() {
+                            let ttl, multi, endpoint, purpose, apps;
+                            if (params.qstring.ttl) {
+                                ttl = parseInt(params.qstring.ttl);
+                            }
+                            else {
+                                ttl = 1800;
+                            }
+                            multi = true;
+                            if (params.qstring.multi === false || params.qstring.multi === 'false') {
+                                multi = false;
+                            }
+                            apps = params.qstring.apps || "";
+                            if (params.qstring.apps) {
+                                apps = params.qstring.apps.split(',');
+                            }
 
-                        if (params.qstring.endpointquery && params.qstring.endpointquery !== "") {
-                            try {
-                                endpoint = JSON.parse(params.qstring.endpointquery); //structure with also info for qstring params.
-                            }
-                            catch (ex) {
-                                if (params.qstring.endpoint) {
-                                    endpoint = params.qstring.endpoint.split(',');
+                            if (params.qstring.endpointquery && params.qstring.endpointquery !== "") {
+                                try {
+                                    endpoint = JSON.parse(params.qstring.endpointquery); //structure with also info for qstring params.
                                 }
-                                else {
-                                    endpoint = "";
+                                catch (ex) {
+                                    if (params.qstring.endpoint) {
+                                        endpoint = params.qstring.endpoint.split(',');
+                                    }
+                                    else {
+                                        endpoint = "";
+                                    }
                                 }
                             }
-                        }
-                        else if (params.qstring.endpoint) {
-                            endpoint = params.qstring.endpoint.split(',');
-                        }
+                            else if (params.qstring.endpoint) {
+                                endpoint = params.qstring.endpoint.split(',');
+                            }
 
-                        if (params.qstring.purpose) {
-                            purpose = params.qstring.purpose;
-                        }
-                        authorize.save({
-                            db: common.db,
-                            ttl: ttl,
-                            multi: multi,
-                            owner: params.member._id + "",
-                            app: apps,
-                            endpoint: endpoint,
-                            purpose: purpose,
-                            callback: (err, token) => {
-                                if (err) {
-                                    common.returnMessage(params, 404, err);
-                                }
-                                else {
-                                    common.returnMessage(params, 200, token);
-                                }
+                            if (params.qstring.purpose) {
+                                purpose = params.qstring.purpose;
                             }
+                            authorize.save({
+                                db: common.db,
+                                ttl: ttl,
+                                multi: multi,
+                                owner: params.member._id + "",
+                                app: apps,
+                                endpoint: endpoint,
+                                purpose: purpose,
+                                callback: (err, token) => {
+                                    if (err) {
+                                        common.returnMessage(params, 404, err);
+                                    }
+                                    else {
+                                        common.returnMessage(params, 200, token);
+                                    }
+                                }
+                            });
+                        };
+                        if (!creatorToken) {
+                            //api_key authenticated: the member itself, full permission
+                            proceedWithCreate();
+                            return;
+                        }
+                        common.db.collection("auth_tokens").findOne({_id: creatorToken + ""}, function(tokenErr, creatorTokenDoc) {
+                            const isScopeRestricted = function(scope) {
+                                return !(scope === undefined || scope === null || scope === "" || (Array.isArray(scope) && scope.length === 0));
+                            };
+                            if (tokenErr || !creatorTokenDoc || isScopeRestricted(creatorTokenDoc.app) || isScopeRestricted(creatorTokenDoc.endpoint)) {
+                                common.returnMessage(params, 403, "A restricted token cannot create tokens");
+                                return;
+                            }
+                            proceedWithCreate();
                         });
                     });
                     break;

--- a/frontend/express/libs/members.js
+++ b/frontend/express/libs/members.js
@@ -501,6 +501,21 @@ membersUtility.loginWithToken = function(req, callback) {
                 return callback(undefined);
             }
 
+            // A session grants the owner's full identity, so it may only be established
+            // from a full-permission token. A token restricted to specific apps or
+            // endpoints must never be redeemable for a session: that would escalate its
+            // scope to the owner's entire account. Legitimate session tokens are always
+            // created unrestricted (setLoggedInVariables, the renderer, and the ban-warning
+            // mail all save with no app and no endpoint), so this rejects only scoped
+            // tokens that should never have reached a login in the first place.
+            var isLoginScopeRestricted = function(scope) {
+                return !(scope === undefined || scope === null || scope === "" || (Array.isArray(scope) && scope.length === 0));
+            };
+            if (isLoginScopeRestricted(valid.app) || isLoginScopeRestricted(valid.endpoint)) {
+                plugins.callMethod("tokenLoginFailed", {req: req, data: {token: token, token_owner: valid.owner, reason: "restricted_token"}});
+                return callback(undefined);
+            }
+
             membersUtility.db.collection('members').findOne({"_id": membersUtility.db.ObjectID(valid.owner)}, function(err, member) {
                 if (err || !member) {
                     plugins.callMethod("tokenLoginFailed", {req: req, data: {token: token, token_owner: valid.owner}});

--- a/test/2.api/16.token.manager.js
+++ b/test/2.api/16.token.manager.js
@@ -379,4 +379,110 @@ describe('Testing token manager', function() {
                 });
         });
     });
+
+    describe('Preventing scope escalation via token create', function() {
+        var restrictedToken = "";
+        var fullPermissionToken = "";
+
+        it('setup: create an app-scoped restricted token via api_key', function(done) {
+            request
+                .get('/i/token/create?api_key=' + API_KEY_ADMIN + '&apps=' + APP_ID + '&purpose=integration&multi=true&ttl=3600')
+                .expect(200)
+                .end(function(err, res) {
+                    if (err) {
+                        return done(err);
+                    }
+                    var ob = JSON.parse(res.text);
+                    ob.should.have.property('result');
+                    restrictedToken = ob.result;
+                    (restrictedToken !== "").should.equal(true);
+                    done();
+                });
+        });
+
+        it('a restricted token cannot create an unrestricted child (no app_id supplied)', function(done) {
+            request
+                .get('/i/token/create?auth_token=' + restrictedToken + '&multi=true&ttl=300')
+                .expect(403)
+                .end(function(err, res) {
+                    if (err) {
+                        return done(err);
+                    }
+                    var ob = JSON.parse(res.text);
+                    ob.should.have.property('result', 'A restricted token cannot create tokens');
+                    done();
+                });
+        });
+
+        it('a restricted token cannot create a LoggedInAuth session child', function(done) {
+            request
+                .get('/i/token/create?auth_token=' + restrictedToken + '&purpose=LoggedInAuth&multi=true&ttl=300')
+                .expect(403)
+                .end(function(err, res) {
+                    if (err) {
+                        return done(err);
+                    }
+                    done();
+                });
+        });
+
+        it('a restricted token is refused even when it supplies its own permitted app_id', function(done) {
+            request
+                .get('/i/token/create?auth_token=' + restrictedToken + '&app_id=' + APP_ID + '&apps=' + APP_ID + '&multi=true&ttl=300')
+                .expect(403)
+                .end(function(err, res) {
+                    if (err) {
+                        return done(err);
+                    }
+                    done();
+                });
+        });
+
+        it('api_key can still create a token', function(done) {
+            request
+                .get('/i/token/create?api_key=' + API_KEY_ADMIN + '&multi=true&ttl=300')
+                .expect(200)
+                .end(function(err, res) {
+                    if (err) {
+                        return done(err);
+                    }
+                    var ob = JSON.parse(res.text);
+                    ob.should.have.property('result');
+                    testUtils.db.collection("auth_tokens").remove({_id: ob.result + ""}, function() {
+                        done();
+                    });
+                });
+        });
+
+        it('a full-permission (unrestricted) token can create a token, as the dashboard session does', function(done) {
+            request
+                .get('/i/token/create?api_key=' + API_KEY_ADMIN + '&multi=true&ttl=300')
+                .expect(200)
+                .end(function(err, res) {
+                    if (err) {
+                        return done(err);
+                    }
+                    fullPermissionToken = JSON.parse(res.text).result;
+                    request
+                        .get('/i/token/create?auth_token=' + fullPermissionToken + '&purpose=child&multi=true&ttl=300')
+                        .expect(200)
+                        .end(function(err2, res2) {
+                            if (err2) {
+                                return done(err2);
+                            }
+                            var child = JSON.parse(res2.text).result;
+                            (child !== "").should.equal(true);
+                            testUtils.db.collection("auth_tokens").remove({_id: {$in: [fullPermissionToken + "", child + ""]}}, function() {
+                                done();
+                            });
+                        });
+                });
+        });
+
+        it('cleanup: remove the restricted token', function(done) {
+            testUtils.db.collection("auth_tokens").remove({_id: restrictedToken + ""}, function() {
+                done();
+            });
+        });
+    });
 });


### PR DESCRIPTION
### Summary

A token deliberately scoped to one app could escalate to the owner's full account. Two independent gaps, closed from both ends.

**The chain (verified on master):**
1. A token's `app`/`endpoint` restriction is a *data-scoping* control — `verify_token` compares it to the request's `app_id`, and only when one is present. `/i/token/create` carries no `app_id` and isn't app-specific, so the restriction never gates it (supplying the permitted app passes; omitting `app_id` skips the check entirely).
2. `validateUser` resolves any bearer token to its owner and loads the **full member**, and the create handler then saved caller-supplied `apps`/`endpoint`/`purpose` with no relationship to the authenticating credential ([requestProcessor.js](api/utils/requestProcessor.js)). A restricted token could mint an **unrestricted** child (→ reads any of the owner's apps) or a **`LoggedInAuth`** child.
3. `/login/token/:token` gated only on `purpose` and then granted the owner's **full session** regardless of the token's scope ([members.js](frontend/express/libs/members.js)). So a `LoggedInAuth` child — or any scoped token carrying a login purpose — redeemed into a complete dashboard session as the owner. If the owner is a global admin, that's a global-admin session from a scoped integration token.

The `loginWithToken` comment even asserted arbitrary purposes are *"settable via /i/token/create by a global admin"* — but that endpoint uses `validateUser`, not `validateGlobalAdmin`, so any authenticated principal could set `purpose: "LoggedInAuth"`. The premise the allowlist rested on was false.

### Fix — enforce "a session comes only from a full-permission token" at both ends

- **Create side:** `/i/token/create` authenticated via a token is allowed only if that token has no app and no endpoint restriction. api_key callers (the member) and unrestricted tokens — which is what a dashboard session token is (`multi`, `app:""`, `endpoint:""`) — are unaffected, so the token manager and the mint-a-login-token-and-redirect flow keep working. A scoped token is refused with 403.
- **Redeem side:** `/login/token/:token` requires the token to be unrestricted, in addition to the purpose allowlist. Legitimate session tokens are always created unrestricted, so only scoped tokens are rejected.

Either gate alone closes the reported chain; both together enforce the invariant regardless of how a scoped login-capable token might arise (pre-existing token, a future regression, or another code path).

This is deliberately the conservative end of the planned "child permissions ⊆ the creating credential" model: refuse rather than intersect, because the app/endpoint model does not sensibly authorize management endpoints. When token/login permissions become explicit in the CRUD migration, these two checks become "you cannot grant a permission you do not hold, and login is one such permission."

### Tests

7 cases in `test/2.api/16.token.manager.js` (run by `test-api-core`): restricted-token refusals for an unrestricted child, a `LoggedInAuth` child, and even a child scoped to its own app; plus the api_key and full-permission-token allow cases.

Reported through the security bug bounty program (received 2026-08-18).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
