### PR TITLE
security(compliance-hub): HTML-encode the application name in the export-history action cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Enterprise Fixes:
 - [data-manager] Fixed editing an event whose key contains `&` creating undeletable duplicate rows in the events table
 
 Security Fixes:
+- [compliance-hub] The export/purge history table now HTML-encodes the application name before it is placed in the action cell, so an application name is shown as text rather than markup
 - [hooks] Internal event hooks are now scoped to the apps the hook belongs to: app creation is a global-admin-only event, and remote-config, cohort, alert and hook-chaining events are only delivered when the event's app is one the hook is scoped to
 - [compliance-hub] The consents table now returns a fixed set of fields; a projection supplied on the request is no longer used to widen the response beyond the consent columns
 - [dashboards] Widgets are no longer copied when the copying user has no access to the apps they reference, and widget app ids are validated on widget create and update

--- a/plugins/compliance-hub/frontend/public/javascripts/countly.models.js
+++ b/plugins/compliance-hub/frontend/public/javascripts/countly.models.js
@@ -194,7 +194,7 @@
                 var ret = "<p>" + ((jQuery.i18n.map["systemlogs.action." + row.a]) ? jQuery.i18n.map["systemlogs.action." + row.a] : row.a) + "</p>";
                 if (typeof row.i === "object") {
                     if (typeof row.i.app_id !== "undefined" && countlyGlobal.apps[row.i.app_id]) {
-                        ret += "<p title='" + row.i.app_id + "'>" + jQuery.i18n.map["systemlogs.for-app"] + ": " + countlyGlobal.apps[row.i.app_id].name + "</p>";
+                        ret += "<p title='" + row.i.app_id + "'>" + jQuery.i18n.map["systemlogs.for-app"] + ": " + countlyCommon.encodeHtml(countlyGlobal.apps[row.i.app_id].name) + "</p>";
                     }
                     if (typeof row.i.appuser_id !== "undefined") {
                         ret += "<p title='" + row.i.appuser_id + "'>" + jQuery.i18n.map["systemlogs.for-appuser"] + ": " + row.i.appuser_id + "</p>";


### PR DESCRIPTION
The export/purge history model (`plugins/compliance-hub/frontend/public/javascripts/countly.models.js`) builds each row's action cell as an HTML string, and `exportHistory.html` renders it with `v-html`. Every other value in that string comes from the API, which HTML-encodes its output, but the application name is read from `countlyGlobal`, whose values are raw at runtime. So an application name is placed into the `v-html` string unencoded.

Encode the application name with `countlyCommon.encodeHtml` so it renders as text, matching the encoding of the other fields in the same string.

Only the application name needed it — the remaining fields are already API-encoded and must not be double-encoded; the display is unchanged. This is a distinct sink from #7949 (that fix covered the inline serializer and the active-app jQuery sink); this is downstream HTML construction in the default Compliance Hub plugin.

Scope check: a codebase scan for a raw `countlyGlobal` value reaching an HTML sink found only two sites — the active-app name (fixed in #7949) and this one. The wider `v-html`/`unescapeHtml` source audit is tracked separately.

Reported through the security bug bounty program.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
