### PR TITLE
security(compliance-hub): HTML-encode the application name in the export-history action cell (24.05)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Fixes:
 Enterprise Fixes:
 - [data-manager] Fixed editing an event whose key contains `&` creating undeletable duplicate rows in the events table
 
+Security Fixes:
+- [compliance-hub] The export/purge history table now HTML-encodes the application name before it is placed in the action cell, so an application name is shown as text rather than markup
+
 ## Version 24.05.51
 
 Fixes:

--- a/plugins/compliance-hub/frontend/public/javascripts/countly.models.js
+++ b/plugins/compliance-hub/frontend/public/javascripts/countly.models.js
@@ -194,7 +194,7 @@
                 var ret = "<p>" + ((jQuery.i18n.map["systemlogs.action." + row.a]) ? jQuery.i18n.map["systemlogs.action." + row.a] : row.a) + "</p>";
                 if (typeof row.i === "object") {
                     if (typeof row.i.app_id !== "undefined" && countlyGlobal.apps[row.i.app_id]) {
-                        ret += "<p title='" + row.i.app_id + "'>" + jQuery.i18n.map["systemlogs.for-app"] + ": " + countlyGlobal.apps[row.i.app_id].name + "</p>";
+                        ret += "<p title='" + row.i.app_id + "'>" + jQuery.i18n.map["systemlogs.for-app"] + ": " + countlyCommon.encodeHtml(countlyGlobal.apps[row.i.app_id].name) + "</p>";
                     }
                     if (typeof row.i.appuser_id !== "undefined") {
                         ret += "<p title='" + row.i.appuser_id + "'>" + jQuery.i18n.map["systemlogs.for-appuser"] + ": " + row.i.appuser_id + "</p>";


### PR DESCRIPTION
Backport of #7961 to `release.24.05`.

The export/purge history model builds each row's action cell as an HTML string rendered with `v-html`. The other values are API-encoded, but the application name is read from `countlyGlobal`, whose values are raw at runtime, so it reached the `v-html` string unencoded. Encode it with `countlyCommon.encodeHtml` so it renders as text; only the application name needed it and the display is unchanged.

Identical to #7961. eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
