### PR TITLE
security(core): HTML-encode the application name in the graph note tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Enterprise Fixes:
 - [data-manager] Fixed editing an event whose key contains `&` creating undeletable duplicate rows in the events table
 
 Security Fixes:
+- [core] The graph note tooltip now HTML-encodes the application name before rendering, so an application name is shown as text rather than markup
 - [hooks] Internal event hooks are now scoped to the apps the hook belongs to: app creation is a global-admin-only event, and remote-config, cohort, alert and hook-chaining events are only delivered when the event's app is one the hook is scoped to
 - [compliance-hub] The consents table now returns a fixed set of fields; a projection supplied on the request is no longer used to widen the response beyond the consent columns
 - [dashboards] Widgets are no longer copied when the copying user has no access to the apps they reference, and widget app ids are validated on widget create and update

--- a/frontend/express/public/javascripts/countly/countly.common.js
+++ b/frontend/express/public/javascripts/countly/countly.common.js
@@ -1115,7 +1115,7 @@
                                         var noteTime = moment(notes[0].ts).format("D MMM, HH:mm");
                                         var noteId = notes[0].app_id;
                                         var app = countlyGlobal.apps[noteId] || {};
-                                        titleDom = "<div> <div class='note-header'><div class='note-title'>" + noteTime + "</div><div class='note-app' style='display:flex;line-height: 15px;'> <div class='icon' style='display:inline-block; border-radius:2px; width:15px; height:15px; margin-right: 5px; background: url(appimages/" + noteId + ".png) center center / cover no-repeat;'></div><span>" + app.name + "</span></div></div>" +
+                                        titleDom = "<div> <div class='note-header'><div class='note-title'>" + noteTime + "</div><div class='note-app' style='display:flex;line-height: 15px;'> <div class='icon' style='display:inline-block; border-radius:2px; width:15px; height:15px; margin-right: 5px; background: url(appimages/" + noteId + ".png) center center / cover no-repeat;'></div><span>" + countlyCommon.encodeHtml(app.name) + "</span></div></div>" +
                                         "<div class='note-content'>" + notes[0].note + "</div>" +
                                         "<div class='note-footer'> <span class='note-owner'>" + (notes[0].owner_name) + "</span> | <span class='note-type'>" + (jQuery.i18n.map["notes.note-" + notes[0].noteType] || notes[0].noteType) + "</span> </div>" +
                                             "</div>";


### PR DESCRIPTION
The graph-note hover tooltip builds its content as an HTML string that includes the application name from `countlyGlobal` (raw at runtime) and renders it with `tipsy({html: true})`. Encode the application name with `countlyCommon.encodeHtml` so it renders as text. The other values in the tooltip are API-encoded or i18n; display is unchanged.

Same shape as the active-app name and compliance-hub encodes already in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
