### PR TITLE
security(core): HTML-encode the application name in the graph note tooltip (24.05)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ Fixes:
 Enterprise Fixes:
 - [data-manager] Fixed editing an event whose key contains `&` creating undeletable duplicate rows in the events table
 
+Security Fixes:
+- [core] The graph note tooltip now HTML-encodes the application name before rendering, so an application name is shown as text rather than markup
+
 ## Version 24.05.51
 
 Fixes:

--- a/frontend/express/public/javascripts/countly/countly.common.js
+++ b/frontend/express/public/javascripts/countly/countly.common.js
@@ -1115,7 +1115,7 @@
                                         var noteTime = moment(notes[0].ts).format("D MMM, HH:mm");
                                         var noteId = notes[0].app_id;
                                         var app = countlyGlobal.apps[noteId] || {};
-                                        titleDom = "<div> <div class='note-header'><div class='note-title'>" + noteTime + "</div><div class='note-app' style='display:flex;line-height: 15px;'> <div class='icon' style='display:inline-block; border-radius:2px; width:15px; height:15px; margin-right: 5px; background: url(appimages/" + noteId + ".png) center center / cover no-repeat;'></div><span>" + app.name + "</span></div></div>" +
+                                        titleDom = "<div> <div class='note-header'><div class='note-title'>" + noteTime + "</div><div class='note-app' style='display:flex;line-height: 15px;'> <div class='icon' style='display:inline-block; border-radius:2px; width:15px; height:15px; margin-right: 5px; background: url(appimages/" + noteId + ".png) center center / cover no-repeat;'></div><span>" + countlyCommon.encodeHtml(app.name) + "</span></div></div>" +
                                         "<div class='note-content'>" + notes[0].note + "</div>" +
                                         "<div class='note-footer'> <span class='note-owner'>" + (notes[0].owner_name) + "</span> | <span class='note-type'>" + (jQuery.i18n.map["notes.note-" + notes[0].noteType] || notes[0].noteType) + "</span> </div>" +
                                             "</div>";


### PR DESCRIPTION
Backport of #7966 to `release.24.05`.

The graph-note tooltip builds an HTML string including the application name from `countlyGlobal` (raw at runtime) and renders it with `tipsy({html: true})`. Encode it with `countlyCommon.encodeHtml` so it renders as text; display unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
