### PR TITLE
security(push): sanitize message-editor content before rendering into the editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Fixes:
 - [hooks] Internal event hooks are validated on save: an unknown event type is rejected, and an event that names a cohort, hook or alert must name one belonging to the hook's own apps
 
 Security Fixes:
+- [push] The message editor now sanitizes message content before rendering it into the editor, allowing only the user-property token element and rendering any other markup as text
 - [compliance-hub] The consents table now returns a fixed set of fields; a projection supplied on the request is no longer used to widen the response beyond the consent columns
 - [dashboards] Widgets are no longer copied when the copying user has no access to the apps they reference, and widget app ids are validated on widget create and update
 - [hooks] Internal event hooks are now scoped to the apps the hook belongs to: app creation is a global-admin-only event, and remote-config, cohort, alert and hook-chaining events are only delivered when the event's app is one the hook is scoped to

--- a/plugins/push/frontend/public/javascripts/countly.views.component.common.js
+++ b/plugins/push/frontend/public/javascripts/countly.views.component.common.js
@@ -1,6 +1,15 @@
 /* eslint-disable no-console */
 /*global CV,countlyVue,countlyPushNotification,countlyGlobal,countlyCommon,moment*/
 (function(countlyPushNotificationComponent) {
+    // The message editor is a live contenteditable. Its body is user-authored text; the
+    // only legitimate markup is the user-property token <span>. Allow just that element
+    // (with the attributes the token relies on) and let everything else be escaped to inert
+    // text, so a stored message cannot introduce active markup when the editor is populated.
+    var PUSH_MESSAGE_EDITOR_XSS_OPTIONS = {
+        whiteList: {
+            span: ["class", "id", "contenteditable", "data-user-property-label", "data-user-property-value", "data-user-property-fallback"]
+        }
+    };
     countlyPushNotificationComponent.LargeRadioButtonWithDescription = countlyVue.views.create({
         props: {
             value: {
@@ -706,7 +715,7 @@
             },
             reset: function(htmlContent, ids) {
                 this.disconnectMutationObserver();
-                this.$refs.element.innerHTML = htmlContent;
+                this.$refs.element.innerHTML = countlyCommon.encodeSomeHtml(htmlContent, PUSH_MESSAGE_EDITOR_XSS_OPTIONS);
                 this.addEventListeners(ids);
                 this.startMutationObserver();
             },


### PR DESCRIPTION
Backport of #7968 to `release.24.05`.

The push message editor set the composed message as `innerHTML` on a live `contenteditable` element. This routes it through `countlyCommon.encodeSomeHtml` with an allowlist restricted to the user-property token `<span>` and the attributes it depends on (`class`, `id`, `contenteditable`, `data-user-property-*`); any other markup is escaped to inert text.

Display is unchanged for normal messages, and the token `id` is preserved so the editor's per-token event wiring keeps working. Same change as master, applied on identical surrounding code.

Note: a quick manual check of composing/editing a notification with a personalization token is worthwhile before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
