### PR TITLE
[fix][hooks] sanitize every email effect, and stop throwing on a template-less one

### DIFF
--- a/plugins/hooks/api/api.js
+++ b/plugins/hooks/api/api.js
@@ -464,7 +464,9 @@ plugins.register("/i/hook/save", function(ob) {
             );
         }
         catch (err) {
-            log.e('Parse hook failed', hookConfig);
+            //the error itself was dropped here, so every failure in this block looked alike
+            //from the logs - which is how the sanitizeConfig throw above went unnoticed
+            log.e('Parse hook failed', hookConfig, err);
             common.returnMessage(params, 500, "Failed to create an hook");
         }
     }, paramsInstance);
@@ -649,13 +651,21 @@ function getVisibilityQuery(query, params) {
  * @returns {sanitizedHookConfig} - sanitized hook config
  */
 function sanitizeConfig(hookConfig) {
-    if (hookConfig && hookConfig.effects) {
-        let emailEffectIndex = hookConfig.effects.findIndex(item => item.type === "EmailEffect");
-        if (emailEffectIndex > -1) {
-            let emailEffect = hookConfig.effects[emailEffectIndex];
-            let sanitizedTemplate = common.sanitizeHTML(emailEffect.configuration.emailTemplate);
-            emailEffect.configuration.emailTemplate = sanitizedTemplate;
-        }
+    if (hookConfig && Array.isArray(hookConfig.effects)) {
+        //every email effect, not just the first one findIndex stops at: a hook may carry
+        //several, and the ones after the first were reaching the database unsanitized
+        hookConfig.effects.forEach(function(effect) {
+            if (!effect || effect.type !== "EmailEffect" || !effect.configuration) {
+                return;
+            }
+            //an email effect without a template is a supported configuration - the effect
+            //falls back to a formatted dump of the trigger payload - but sanitizeHTML reads
+            //.replace off whatever it is given, so passing undefined threw and the save
+            //answered 500, making that configuration impossible to store
+            if (typeof effect.configuration.emailTemplate === "string") {
+                effect.configuration.emailTemplate = common.sanitizeHTML(effect.configuration.emailTemplate);
+            }
+        });
     }
     return hookConfig;
 

--- a/plugins/hooks/tests/crud.js
+++ b/plugins/hooks/tests/crud.js
@@ -47,6 +47,79 @@ describe('Testing Hooks', function() {
                     });
             });
 
+            it('should save an email effect that carries no template', function(done) {
+                const APP_ID = testUtils.get("APP_ID");
+                //an email effect without a template is supported - the effect formats the
+                //trigger payload instead - but sanitizeConfig read .emailTemplate off the
+                //effect and handed it to sanitizeHTML unguarded, so the read threw, the
+                //catch around the save answered 500, and this could not be stored at all
+                const hookConfig = Object.assign({}, newHookConfig, {
+                    apps: [APP_ID],
+                    name: "test-email-effect-no-template",
+                    trigger: {
+                        type: "APIEndPointTrigger",
+                        configuration: {path: "email-no-template-" + Date.now(), method: "get"}
+                    },
+                    effects: [{type: "EmailEffect", configuration: {address: ["a@test.com"]}}]
+                });
+
+                request.post(getRequestURL('/i/hook/save'))
+                    .send({hook_config: JSON.stringify(hookConfig)})
+                    .end(function(err, res) {
+                        if (err) {
+                            return done(err);
+                        }
+                        res.status.should.equal(200,
+                            "a template-less email effect should save, got " + res.status + ": " + res.text);
+                        newHookIds.push(res.body);
+                        done();
+                    });
+            });
+
+            it('should sanitize the template of every email effect, not only the first', function(done) {
+                const APP_ID = testUtils.get("APP_ID");
+                //sanitizeConfig used to locate the email effect with findIndex, which stops
+                //at the first match, so a hook carrying two of them stored the second one's
+                //template exactly as it arrived
+                const hookConfig = Object.assign({}, newHookConfig, {
+                    apps: [APP_ID],
+                    name: "test-two-email-effects",
+                    trigger: {
+                        type: "APIEndPointTrigger",
+                        configuration: {path: "two-email-effects-" + Date.now(), method: "get"}
+                    },
+                    effects: [
+                        {type: "EmailEffect", configuration: {address: ["a@test.com"], emailTemplate: "first<script>alert(1)</script>"}},
+                        {type: "EmailEffect", configuration: {address: ["b@test.com"], emailTemplate: "second<script>alert(2)</script>"}}
+                    ]
+                });
+
+                request.post(getRequestURL('/i/hook/save'))
+                    .send({hook_config: JSON.stringify(hookConfig)})
+                    .expect(200)
+                    .end(function(err, res) {
+                        if (err) {
+                            return done(err);
+                        }
+                        newHookIds.push(res.body);
+                        getHookRecord(res.body, function(listErr, listRes) {
+                            if (listErr) {
+                                return done(listErr);
+                            }
+                            const hook = listRes.body.hooksList.find(function(item) {
+                                return item._id === res.body;
+                            });
+                            should.exist(hook, "the saved hook was not returned by /o/hook/list");
+                            hook.effects.length.should.equal(2);
+                            hook.effects.forEach(function(effect, index) {
+                                effect.configuration.emailTemplate.should.not.match(/<script/i,
+                                    "email effect " + index + " kept its script markup");
+                            });
+                            done();
+                        });
+                    });
+            });
+
 
             it('should fail to create hook with invalid required params', function(done) {
                 const APP_ID = testUtils.get("APP_ID");


### PR DESCRIPTION
Found while chasing a hooks test failure in the platform repo; the same code is here.

`sanitizeConfig` located the email effect with `findIndex` and read `.emailTemplate` off it unguarded. Two things followed.

**The second email effect was never sanitized.** `findIndex` stops at the first match, so a hook carrying two email effects sanitized the first template and stored the second exactly as it arrived. That template is rendered into the mail body, so the markup survived to delivery.

**A template-less email effect could not be saved at all.** Carrying no template is a supported configuration — `email.js` checks `if (emailTemplate && emailTemplate.length > 0)` and formats the trigger payload otherwise — but `sanitizeHTML` reads `.replace` off whatever it is given, so `undefined` threw. The `catch` around the save answered `500 "Failed to create an hook"` and discarded the error, so the request failed and the logs said nothing about why.

Sanitize every email effect that has a template, and log the error in that `catch` so the next failure there is not anonymous.

Two tests cover both directions: a template-less effect saves, and a hook with two email effects comes back from `/o/hook/list` with neither template holding script markup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)