### PR TITLE
[security][core] request parameters are scalars, and consumers parse

### DIFF
--- a/api/api.js
+++ b/api/api.js
@@ -559,14 +559,16 @@ function handleRequest(req, res) {
             if (multiFormData) {
                 let formDataUrl = [];
                 for (const i in fields) {
-                    params.qstring[i] = fields[i];
-                    formDataUrl.push(`${i}=${fields[i]}`);
+                    //back to the scalar the request carried; formidable's json body
+                    //parser is the only thing that makes these structures
+                    params.qstring[i] = common.asRequestScalar(fields[i]);
+                    formDataUrl.push(`${i}=${params.qstring[i]}`);
                 }
                 params.formDataUrl = formDataUrl.join('&');
             }
             else {
                 for (const i in fields) {
-                    params.qstring[i] = fields[i];
+                    params.qstring[i] = common.asRequestScalar(fields[i]);
                 }
             }
             if (!params.apiPath) {

--- a/api/utils/common.js
+++ b/api/utils/common.js
@@ -669,6 +669,42 @@ common.getISOWeeksInYear = function(year) {
 };
 
 
+/**
+ * Parse a declared Object or Array argument that arrived as its JSON text.
+ *
+ * Request parameters are scalars by the time a handler sees them, so a caller
+ * that means to send a structure sends its JSON. This lets a declared type
+ * accept either form, so an endpoint does not have to parse it itself.
+ *
+ * Applied wherever a structure is declared, not only at the literal "Object" and
+ * "Array" types: a nested schema declares one too.
+ *
+ * Widening only: an argument that was already the declared type is untouched,
+ * and text that is not that type still fails the check below.
+ * @param {any} value - the argument as supplied
+ * @param {string} type - the declared type, "Object" or "Array"
+ * @returns {any} the parsed value, or the original when it does not apply
+ */
+function parseDeclaredStructure(value, type) {
+    if (typeof value !== "string" || !value.length) {
+        return value;
+    }
+    var parsed;
+    try {
+        parsed = JSON.parse(value);
+    }
+    catch (ex) {
+        return value;
+    }
+    if (type === "Array" && Array.isArray(parsed)) {
+        return parsed;
+    }
+    if (type === "Object" && parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed;
+    }
+    return value;
+}
+
 common.validateArgs = function(args, argProperties, returnErrors) {
     if (arguments.length === 2) {
         returnErrors = false;
@@ -906,6 +942,7 @@ common.validateArgs = function(args, argProperties, returnErrors) {
                     }
                 }
                 else if (argProperties[arg].type === 'Array') {
+                    args[arg] = parseDeclaredStructure(args[arg], 'Array');
                     if (!Array.isArray(args[arg])) {
                         if (returnErrors) {
                             returnObj.errors.push("Invalid type for " + arg);
@@ -951,6 +988,7 @@ common.validateArgs = function(args, argProperties, returnErrors) {
                     }
                 }
                 else if (argProperties[arg].type === 'Object') {
+                    args[arg] = parseDeclaredStructure(args[arg], 'Object');
                     if (toString.call(args[arg]) !== '[object ' + argProperties[arg].type + ']' && !(!argProperties[arg].required && args[arg] === null)) {
                         if (returnErrors) {
                             returnObj.errors.push("Invalid type for " + arg);
@@ -1087,6 +1125,8 @@ common.validateArgs = function(args, argProperties, returnErrors) {
                     }
                 }
                 else if (typeof argProperties[arg].type === 'object' && !argProperties[arg].array) {
+                    //a nested schema declares an object just as surely as type: "Object"
+                    args[arg] = parseDeclaredStructure(args[arg], 'Object');
                     if (typeof args[arg] !== 'object' && !(!argProperties[arg].required && args[arg] === null)) {
                         if (returnErrors) {
                             returnObj.errors.push("Invalid type for " + arg);
@@ -1115,6 +1155,8 @@ common.validateArgs = function(args, argProperties, returnErrors) {
                     }
                 }
                 else if ((typeof argProperties[arg].type === 'object' && argProperties[arg].array) || argProperties[arg].type.indexOf('[]') === argProperties[arg].type.length - 2) {
+                    //and a nested schema marked array declares an array
+                    args[arg] = parseDeclaredStructure(args[arg], 'Array');
                     if (!Array.isArray(args[arg])) {
                         if (returnErrors) {
                             returnObj.errors.push("Invalid type for " + arg);
@@ -2623,6 +2665,40 @@ common.parseUserQuery = function(raw) {
         return { error: common.unsafeQueryError(bad) };
     }
     return { query: query };
+};
+
+/**
+ * Keep a request parameter out of the shape Mongo reads as a query expression.
+ *
+ * An object in a value position is read as an operator document rather than as
+ * the value it stands in for, so `{"view": {"$ne": null}}` turns an equality
+ * match on one document into a match on many: rows the endpoint never meant to
+ * return, and no bound left on how much it has to scan.
+ *
+ * Arrays go the same way. Whether a structure is pre-parsed at all depends on the
+ * request's content type, so an endpoint that wants one cannot rely on receiving
+ * it already parsed and has to accept the json text regardless - a form encoded
+ * caller sends exactly that today. Scalarizing both keeps one rule rather than
+ * one rule and an exception.
+ *
+ * Applied to what comes in off the request. Internal callers build a qstring
+ * themselves and pass structures on purpose.
+ *
+ * @param {any} value - one value from a parsed request
+ * @returns {any} the value unchanged when it is a scalar, else its JSON text
+ */
+common.asRequestScalar = function(value) {
+    if (value === null || typeof value !== "object") {
+        return value;
+    }
+    try {
+        return JSON.stringify(value);
+    }
+    catch (ex) {
+        //a parsed body cannot be circular, but never hand a handler an object
+        //just because stringifying failed
+        return "";
+    }
 };
 
 /**

--- a/test/unit-tests/api.utils.common.request-scalars.js
+++ b/test/unit-tests/api.utils.common.request-scalars.js
@@ -1,0 +1,95 @@
+var should = require("should");
+var common = require("../../api/utils/common.js");
+
+// HTTP delivers text. A parameter that carries structure is sent as JSON and parsed by
+// the endpoint that wants it, which is why those parsers begin with
+// `typeof x === "string"`. Form encoding cannot produce a nested value either -
+// `view[$ne]=x` yields the literal key "view[$ne]". The only thing that turns a request
+// value into an object is the json body parser, on the way in.
+//
+// asRequestScalar puts it back at the copy into params.qstring, so an endpoint that
+// wants a value gets a string - inert in a Mongo match - and one that wants a structure
+// parses it, which validateArgs now does for any type it already declares.
+
+describe("request parameters are the scalars HTTP carried", function() {
+    describe("asRequestScalar", function() {
+        it("leaves a scalar exactly as it is", function() {
+            common.asRequestScalar("abc").should.equal("abc");
+            common.asRequestScalar("").should.equal("");
+            common.asRequestScalar(10).should.equal(10);
+            common.asRequestScalar(true).should.equal(true);
+            should(common.asRequestScalar(null)).equal(null);
+            should(common.asRequestScalar(undefined)).equal(undefined);
+        });
+
+        it("turns an operator document back into its json text", function() {
+            // in a value position Mongo reads this as a query expression, so an equality
+            // match on one document becomes a match on many
+            common.asRequestScalar({$ne: null}).should.equal('{"$ne":null}');
+            common.asRequestScalar({a: {$regex: ".*"}}).should.equal('{"a":{"$regex":".*"}}');
+        });
+
+        it("turns an array into its json text too", function() {
+            // one rule rather than one rule and an exception: whether a structure is
+            // pre-parsed at all depends on the content type
+            common.asRequestScalar(["1", "2"]).should.equal('["1","2"]');
+        });
+
+        it("never hands a handler a structure, whatever it is given", function() {
+            [{}, [], {$ne: 1}, {a: [{b: {$in: [1]}}]}].forEach(function(value) {
+                (typeof common.asRequestScalar(value)).should.equal("string",
+                    JSON.stringify(value) + " was left as a structure");
+            });
+        });
+    });
+
+    describe("what the endpoints then see", function() {
+        it("gives a scalar parameter something inert in a match", function() {
+            var view = common.asRequestScalar({$ne: null});
+            (typeof view).should.equal("string");
+            view.should.not.have.property("$ne");
+        });
+
+        it("lets a declared Object or Array argument arrive as its json text", function() {
+            var props = {behavior: {required: false, type: "Object"}, users: {required: false, type: "Array"}};
+            var out = common.validateArgs({
+                behavior: common.asRequestScalar({a: 1}),
+                users: common.asRequestScalar([{x: 1}])
+            }, props, true);
+            out.result.should.equal(true, JSON.stringify(out.errors));
+            out.obj.behavior.should.eql({a: 1});
+            out.obj.users.should.eql([{x: 1}]);
+        });
+
+        it("carries a nested schema, not only the literal Object and Array types", function() {
+            // push describes its message parts with nested schemes, so the widening has
+            // to reach that branch too
+            var nested = {
+                page: {type: "String", required: false},
+                stages: {type: "Array", required: false}
+            };
+            var schema = {state: {required: false, type: nested}};
+            var state = {page: "/dashboard", stages: ["a"]};
+            var typed = common.validateArgs({state: state}, schema, true);
+            typed.result.should.equal(true, JSON.stringify(typed.errors));
+            var asText = common.validateArgs({state: common.asRequestScalar(state)}, schema, true);
+            asText.result.should.equal(true, JSON.stringify(asText.errors));
+            asText.obj.state.should.eql(state);
+        });
+
+        it("still refuses text that is not the declared type", function() {
+            common.validateArgs({behavior: "not json"},
+                {behavior: {required: false, type: "Object"}}, true).result.should.equal(false);
+        });
+
+        it("does not change the checksum payload for anything an SDK sends", function() {
+            // api.js builds params.formDataUrl from these values and it feeds
+            // checksumSaltVerification, so the interpolated text has to be identical for
+            // every scalar - which is all a multipart SDK request carries
+            ["abc", "", "0", 0, 10, -1, 1.5, true, false, null, undefined].forEach(function(value) {
+                ("" + common.asRequestScalar(value)).should.equal("" + value,
+                    "checksum payload changed for " + JSON.stringify(value));
+            });
+        });
+    });
+});

--- a/types/common.d.ts
+++ b/types/common.d.ts
@@ -508,6 +508,14 @@ export interface Common {
     fixEventKey: (eventKey: string) => string | false;
 
     /**
+     * Keep a request parameter out of the shape Mongo reads as a query expression:
+     * a scalar is returned unchanged, an object or array as its JSON text. Applied
+     * where request fields are copied into params.qstring, so a structure cannot
+     * reach a Mongo value position and be read there as an operator document.
+     */
+    asRequestScalar: (value: any) => any;
+
+    /**
      * Block {@link module:api/utils/common.returnMessage} and {@link module:api/utils/common.returnOutput} from ouputting anything
      * @param {Params} params - params object
      */


### PR DESCRIPTION
Backport of Countly/countly-platform#1249.

## What was wrong

`params.qstring` values are not guaranteed to be scalars. formidable parses an `application/json` body into nested objects and `api/api.js` copies them straight into `qstring`, so `{"view": {"$ne": null}}` leaves `params.qstring.view` an object rather than the string the endpoint expects.

In a Mongo **value** position an object is read as a query expression, so an equality match on one document becomes a match on many: rows the endpoint never meant to return, and no bound left on how much it has to scan.

## One rule

**Request parameters are scalars. Whoever wants a structure parses it.**

`common.asRequestScalar` returns a scalar unchanged and a structure as its JSON text, applied at both formidable `fields` loops in `api/api.js`.

Arrays are included deliberately. Whether a structure is pre-parsed at all depends on the request's content type, so an endpoint that wants one cannot rely on receiving it parsed — a form encoded caller sends the text today. Accepting text is therefore something consumers need regardless, and including arrays gives one rule rather than a rule plus an exception.

`validateArgs` then accepts the JSON text of any type it **already declares**, so no endpoint has to parse it itself — the literal `Object` and `Array` types, a nested schema, and the `Type[]` form. Widening only: an already-typed value is untouched, and text that is not that type still fails.

## What this backport does not need

The platform change also touches its TypeScript ingestor, its zod-based push validation, and `crash_symbolication`. Neither the ingestor nor zod exists here, and push's data classes validate through `common.validateArgs` schemes — so the widening covers them. Verified against the real push filter scheme (`String[]` / `ObjectID[]` / `JSON`):

```
typed form : true []
json text  : true []
```

`crash_symbolication` lives in countly-enterprise-plugins and is handled in the companion PR there.

The body-copy branch in `requestProcessor` is deliberately untouched: off the wire `req.body` is the raw text `api.js` accumulated, so that branch is the internal-caller path and those callers pass structures on purpose.

## Verification

- `test/unit-tests/api.utils.common.request-scalars.js`, 9 cases — including that the checksum payload is byte-identical for every scalar, which is all a multipart SDK request carries.
- eslint clean on all changed files.
- A sweep of every `params.qstring` read in `api/` and every plugin `api/` for values used as structures without a parse: all are either already parsed centrally (`events`, `metrics`, `args`), parsed in their own file, declared in a schema, or set server-side after ingress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)