### PR TITLE
fix(tracker): clear current-licence properties when the licence disappears

### DIFF
--- a/api/parts/mgmt/tracker.js
+++ b/api/parts/mgmt/tracker.js
@@ -182,29 +182,42 @@ tracker.reportLicenseState = function(license, extra) {
         return;
     }
     if (isEnabled && plugins.getConfig("tracking").server_user_details) {
-        // These are CURRENT-state properties, so they have to be cleared, not omitted: JSON drops
-        // undefined keys, which would leave the previous licence's id, name and rule standing on the
-        // tracked user next to license_status: "missing". `extra` is merged untouched — an unmeasured
-        // metric_current there stays omitted rather than becoming an empty string, so the numeric
-        // properties on the tracking server keep their type.
-        var blank = function(v) {
+        // These are CURRENT-state properties, and JSON drops undefined keys, so simply omitting the
+        // ones a license no longer supplies left the PREVIOUS license's id, name and rule standing on
+        // the tracked user next to license_status: "missing".
+        //
+        // Which is cleared and which is omitted follows the property's type, deliberately:
+        //
+        //   - text identity (id, client, rule, stage) is cleared with an empty string, so the tracked
+        //     user stops being segmentable by a license it no longer has;
+        //   - numbers (version, term dates, entitlement caps) are OMITTED instead. An empty string in
+        //     a numeric property changes its type on the tracking server and breaks filtering and
+        //     aggregation over the whole fleet, which is a worse outcome than a stale cap — and
+        //     license_status already says there is no license to read those caps against.
+        //
+        // `extra` is merged untouched for the same reason: an unmeasured metric_current stays omitted
+        // rather than becoming an empty string.
+        var text = function(v) {
             return (v === undefined || v === null) ? '' : v;
         };
         var ent = license.entitlement || {};
-        var custom = Object.assign({
-            license_id: blank(license._id || license.license_id),
-            license_version: (license._id || license.license_id) ? (license.license_version || 1) : '',
-            client_name: blank(license.name),
-            license_rule: blank(license.rule),
-            license_stage: blank(license.license_stage),
-            license_start: blank(license.start),
-            license_end: blank(license.end),
-            included_prod_apps: blank(ent.included_prod_apps),
-            max_prod_apps: blank(ent.max_prod_apps),
-            instance_allowance: blank(ent.instance_allowance),
-            support_dp_tier: blank(ent.support_dp_tier)
-        }, extra || {});
-        Countly.user_details({custom: custom});
+        var hasLicense = !!(license._id || license.license_id);
+        var custom = {
+            license_id: text(license._id || license.license_id),
+            client_name: text(license.name),
+            license_rule: text(license.rule),
+            license_stage: text(license.license_stage)
+        };
+        if (hasLicense) {
+            custom.license_version = license.license_version || 1;
+            custom.license_start = license.start;
+            custom.license_end = license.end;
+            custom.included_prod_apps = ent.included_prod_apps;
+            custom.max_prod_apps = ent.max_prod_apps;
+            custom.instance_allowance = ent.instance_allowance;
+            custom.support_dp_tier = ent.support_dp_tier;
+        }
+        Countly.user_details({custom: Object.assign(custom, extra || {})});
     }
 };
 

--- a/api/parts/mgmt/tracker.js
+++ b/api/parts/mgmt/tracker.js
@@ -182,21 +182,28 @@ tracker.reportLicenseState = function(license, extra) {
         return;
     }
     if (isEnabled && plugins.getConfig("tracking").server_user_details) {
+        // These are CURRENT-state properties, so they have to be cleared, not omitted: JSON drops
+        // undefined keys, which would leave the previous licence's id, name and rule standing on the
+        // tracked user next to license_status: "missing". `extra` is merged untouched — an unmeasured
+        // metric_current there stays omitted rather than becoming an empty string, so the numeric
+        // properties on the tracking server keep their type.
+        var blank = function(v) {
+            return (v === undefined || v === null) ? '' : v;
+        };
+        var ent = license.entitlement || {};
         var custom = Object.assign({
-            license_id: license._id || license.license_id,
-            license_version: license.license_version || 1,
-            client_name: license.name,
-            license_rule: license.rule,
-            license_stage: license.license_stage,
-            license_start: license.start,
-            license_end: license.end
+            license_id: blank(license._id || license.license_id),
+            license_version: (license._id || license.license_id) ? (license.license_version || 1) : '',
+            client_name: blank(license.name),
+            license_rule: blank(license.rule),
+            license_stage: blank(license.license_stage),
+            license_start: blank(license.start),
+            license_end: blank(license.end),
+            included_prod_apps: blank(ent.included_prod_apps),
+            max_prod_apps: blank(ent.max_prod_apps),
+            instance_allowance: blank(ent.instance_allowance),
+            support_dp_tier: blank(ent.support_dp_tier)
         }, extra || {});
-        if (license.entitlement) {
-            custom.included_prod_apps = license.entitlement.included_prod_apps;
-            custom.max_prod_apps = license.entitlement.max_prod_apps;
-            custom.instance_allowance = license.entitlement.instance_allowance;
-            custom.support_dp_tier = license.entitlement.support_dp_tier;
-        }
         Countly.user_details({custom: custom});
     }
 };

--- a/api/parts/mgmt/tracker.js
+++ b/api/parts/mgmt/tracker.js
@@ -182,42 +182,40 @@ tracker.reportLicenseState = function(license, extra) {
         return;
     }
     if (isEnabled && plugins.getConfig("tracking").server_user_details) {
-        // These are CURRENT-state properties, and JSON drops undefined keys, so simply omitting the
-        // ones a license no longer supplies left the PREVIOUS license's id, name and rule standing on
-        // the tracked user next to license_status: "missing".
+        // CURRENT-STATE PROPERTIES, SO THEY ARE CLEARED RATHER THAN OMITTED. JSON drops undefined
+        // keys, so omitting what a licence no longer supplies left the PREVIOUS license's id, client,
+        // rule, term and entitlement caps standing on the tracked user next to
+        // license_status: "missing" — an unlicensed server still sitting in v2 fleet segments with its
+        // former caps.
         //
-        // Which is cleared and which is omitted follows the property's type, deliberately:
+        // An empty string is not a string VALUE here: it is how Countly deletes a custom user
+        // property. The SDK's own Countly.userData.unset(key) is implemented as customData[key] = ""
+        // (see countly-sdk-nodejs lib/countly.js), and it reaches the server through this same
+        // user_details.custom payload — so the property is removed and numeric properties keep their
+        // type on the tracking server rather than being rewritten as text.
         //
-        //   - text identity (id, client, rule, stage) is cleared with an empty string, so the tracked
-        //     user stops being segmentable by a license it no longer has;
-        //   - numbers (version, term dates, entitlement caps) are OMITTED instead. An empty string in
-        //     a numeric property changes its type on the tracking server and breaks filtering and
-        //     aggregation over the whole fleet, which is a worse outcome than a stale cap — and
-        //     license_status already says there is no license to read those caps against.
-        //
-        // `extra` is merged untouched for the same reason: an unmeasured metric_current stays omitted
-        // rather than becoming an empty string.
-        var text = function(v) {
+        // `extra` is merged untouched, which is a different case on purpose: an unmeasured
+        // metric_current has no new value to report, and deleting the last measured one would lose
+        // data rather than correct it.
+        var clear = function(v) {
             return (v === undefined || v === null) ? '' : v;
         };
         var ent = license.entitlement || {};
         var hasLicense = !!(license._id || license.license_id);
-        var custom = {
-            license_id: text(license._id || license.license_id),
-            client_name: text(license.name),
-            license_rule: text(license.rule),
-            license_stage: text(license.license_stage)
-        };
-        if (hasLicense) {
-            custom.license_version = license.license_version || 1;
-            custom.license_start = license.start;
-            custom.license_end = license.end;
-            custom.included_prod_apps = ent.included_prod_apps;
-            custom.max_prod_apps = ent.max_prod_apps;
-            custom.instance_allowance = ent.instance_allowance;
-            custom.support_dp_tier = ent.support_dp_tier;
-        }
-        Countly.user_details({custom: Object.assign(custom, extra || {})});
+        var custom = Object.assign({
+            license_id: clear(license._id || license.license_id),
+            client_name: clear(license.name),
+            license_rule: clear(license.rule),
+            license_stage: clear(license.license_stage),
+            license_version: hasLicense ? (license.license_version || 1) : '',
+            license_start: clear(license.start),
+            license_end: clear(license.end),
+            included_prod_apps: clear(ent.included_prod_apps),
+            max_prod_apps: clear(ent.max_prod_apps),
+            instance_allowance: clear(ent.instance_allowance),
+            support_dp_tier: clear(ent.support_dp_tier)
+        }, extra || {});
+        Countly.user_details({custom: custom});
     }
 };
 


### PR DESCRIPTION
Follow-up to the licence telemetry hooks (#7943), found in review of the install-side work.

`tracker.reportLicenseState` builds its property set with `undefined` for whatever the licence does not carry, and `JSON.stringify` drops undefined keys. On an install whose licence was removed, the tracked user therefore keeps the previous `license_id`, `client_name` and `license_rule` standing next to `license_status: "missing"` — the fleet stays segmentable by a licence that is no longer there, and the two properties contradict each other. A v2 licence replaced by a v1 one left its `entitlement` caps behind the same way.

Current-state properties are now sent as empty strings so they actually clear.

`extra` is merged untouched on purpose: an unmeasured `metric_current` stays omitted rather than becoming `""`, which would change that property's type on the tracking server.

Also on release.24.05, where the same code was backported: Countly/countly-server#8005.

🤖 Generated with [Claude Code](https://claude.com/claude-code)