### PR TITLE
security(core): bound token grants by the owner's app membership

### DIFF
--- a/api/utils/authorizer.js
+++ b/api/utils/authorizer.js
@@ -375,8 +375,12 @@ var verify_token = function(options, return_owner, return_data) {
                 // change retimes every LoggedInAuth token of a member in one update - must not be
                 // able to move the token past it either, so it is enforced here, at every use.
                 var pastBound = res.max_ends > 0 && res.max_ends < Math.round(Date.now() / 1000);
-                if (valid_endpoint && valid_app && !pastBound) {
-                    if (res.ttl === 0) {
+                if (valid_endpoint && valid_app) {
+                    if (pastBound) {
+                        // expired by its bound: neither branch below may mark it valid, and the
+                        // consume step at the end removes it like any other expired token
+                    }
+                    else if (res.ttl === 0) {
                         valid = true;
                         expires_after = -1;
                         if (return_owner) {

--- a/api/utils/authorizer.js
+++ b/api/utils/authorizer.js
@@ -68,10 +68,19 @@ authorizer.save = function(options) {
                 * @returns {object} document to insert into auth_tokens
                 */
                 var buildTokenDoc = function() {
+                    var ends = options.ttl + Math.round(Date.now() / 1000);
+                    // A caller bounding this token by another credential's lifetime passes that
+                    // credential's absolute end. The cap is applied here, at insertion, rather than
+                    // by the caller turning it into a relative ttl: the member lookup above is
+                    // asynchronous, so a ttl computed before it would land ends later than the
+                    // bound by however long the lookup took.
+                    if (options.maxEnds > 0 && options.ttl > 0 && ends > options.maxEnds) {
+                        ends = options.maxEnds;
+                    }
                     var doc = {
                         _id: options.token,
                         ttl: options.ttl,
-                        ends: options.ttl + Math.round(Date.now() / 1000),
+                        ends: ends,
                         multi: options.multi,
                         owner: options.owner,
                         app: options.app,

--- a/api/utils/authorizer.js
+++ b/api/utils/authorizer.js
@@ -256,12 +256,16 @@ authorizer.extend_token = function(options) {
     // after its parent expired. Read the document first; a token with no bound extends as
     // before.
     options.db.collection("auth_tokens").findOne({_id: options.token}, {projection: {max_ends: 1}}, function(readErr, doc) {
-        if (!readErr && doc && doc.max_ends > 0) {
-            if (updateArr.ttl === 0 || updateArr.ends > doc.max_ends) {
-                // ttl 0 would mean never expires; the bound turns that into "until the bound"
-                updateArr.ends = doc.max_ends;
-                updateArr.ttl = Math.max(1, doc.max_ends - Math.round(Date.now() / 1000));
+        if (readErr) {
+            // fail closed: without the bound there is no safe extension to write
+            if (typeof options.callback === "function") {
+                options.callback(readErr, null);
             }
+            return;
+        }
+        if (doc && doc.max_ends > 0 && updateArr.ends > doc.max_ends) {
+            updateArr.ends = doc.max_ends;
+            updateArr.ttl = Math.max(1, doc.max_ends - Math.round(Date.now() / 1000));
         }
         options.db.collection("auth_tokens").update({_id: options.token}, {$set: updateArr}, function(err) {
             if (typeof options.callback === "function") {
@@ -366,7 +370,12 @@ var verify_token = function(options, return_owner, return_data) {
                     }
                 }
 
-                if (valid_endpoint && valid_app) {
+                // The bound a scoped parent put on this token is absolute. It is applied wherever
+                // ends is written, but a writer that does not know about it - a session-timeout
+                // change retimes every LoggedInAuth token of a member in one update - must not be
+                // able to move the token past it either, so it is enforced here, at every use.
+                var pastBound = res.max_ends > 0 && res.max_ends < Math.round(Date.now() / 1000);
+                if (valid_endpoint && valid_app && !pastBound) {
                     if (res.ttl === 0) {
                         valid = true;
                         expires_after = -1;
@@ -389,7 +398,7 @@ var verify_token = function(options, return_owner, return_data) {
                     }
 
                     //consume token if expired or not multi
-                    if (!res.multi || (res.ttl > 0 && res.ends < Math.round(Date.now() / 1000))) {
+                    if (!res.multi || (res.ttl > 0 && res.ends < Math.round(Date.now() / 1000)) || pastBound) {
                         options.db.collection("auth_tokens").remove({_id: options.token});
                     }
                 }

--- a/api/utils/authorizer.js
+++ b/api/utils/authorizer.js
@@ -92,6 +92,11 @@ authorizer.save = function(options) {
                     if (options.token_permission) {
                         doc.token_permission = options.token_permission;
                     }
+                    if (options.maxEnds > 0) {
+                        // kept on the document so that extend_token can honour it: the bound is
+                        // a property of this token for its whole life, not of the insert alone
+                        doc.max_ends = options.maxEnds;
+                    }
                     return doc;
                 };
                 if (options.tryReuse === true) {
@@ -245,10 +250,24 @@ authorizer.extend_token = function(options) {
         }
         return;
     }
-    options.db.collection("auth_tokens").update({_id: options.token}, {$set: updateArr}, function(err) {
-        if (typeof options.callback === "function") {
-            options.callback(err, true);
+    // A token bounded by another credential's lifetime carries max_ends. An extension - the
+    // heatmap route extends a token by ten minutes whenever it is close to expiry - must not
+    // carry it past that bound, or repeated requests keep a scoped child alive indefinitely
+    // after its parent expired. Read the document first; a token with no bound extends as
+    // before.
+    options.db.collection("auth_tokens").findOne({_id: options.token}, {projection: {max_ends: 1}}, function(readErr, doc) {
+        if (!readErr && doc && doc.max_ends > 0) {
+            if (updateArr.ttl === 0 || updateArr.ends > doc.max_ends) {
+                // ttl 0 would mean never expires; the bound turns that into "until the bound"
+                updateArr.ends = doc.max_ends;
+                updateArr.ttl = Math.max(1, doc.max_ends - Math.round(Date.now() / 1000));
+            }
         }
+        options.db.collection("auth_tokens").update({_id: options.token}, {$set: updateArr}, function(err) {
+            if (typeof options.callback === "function") {
+                options.callback(err, true);
+            }
+        });
     });
 };
 /**

--- a/api/utils/requestProcessor.js
+++ b/api/utils/requestProcessor.js
@@ -2759,7 +2759,11 @@ const processRequest = (params) => {
                         // would then be permanent. An api_key, and an unscoped credential such as
                         // the dashboard session token, are the owner's own authority and carry no
                         // cap: they are not narrower than the member they belong to.
+                        let maxEnds;
                         if (creatorToken && creatorToken.token_permission && creatorToken.ttl > 0) {
+                            //the absolute bound; authorizer.save applies it at insertion, so the async
+                            //member lookup in between cannot push the child past the parent
+                            maxEnds = creatorToken.ends;
                             const remainingLife = (creatorToken.ends || 0) - Math.round(Date.now() / 1000);
                             if (remainingLife < 1) {
                                 common.returnMessage(params, 403, "The creating token has no remaining lifetime to grant");
@@ -2814,6 +2818,7 @@ const processRequest = (params) => {
                             purpose: purpose,
                             token_permission: tokenPermission,
                             can_login: canLogin,
+                            maxEnds: maxEnds,
                             callback: (err, token) => {
                                 if (err) {
                                     common.returnMessage(params, 404, err);

--- a/api/utils/requestProcessor.js
+++ b/api/utils/requestProcessor.js
@@ -2751,6 +2751,25 @@ const processRequest = (params) => {
                         else {
                             ttl = 1800;
                         }
+
+                        // A scoped token may pass its permissions on, but not more life than it
+                        // has left. A ttl of 0 means "never expires", so a sixty second credential
+                        // minting one of those outlives itself indefinitely - the permissions were
+                        // bounded and the lifetime was not, and capturing the parent for a moment
+                        // would then be permanent. An api_key, and an unscoped credential such as
+                        // the dashboard session token, are the owner's own authority and carry no
+                        // cap: they are not narrower than the member they belong to.
+                        if (creatorToken && creatorToken.token_permission && creatorToken.ttl > 0) {
+                            const remainingLife = (creatorToken.ends || 0) - Math.round(Date.now() / 1000);
+                            if (remainingLife < 1) {
+                                common.returnMessage(params, 403, "The creating token has no remaining lifetime to grant");
+                                return;
+                            }
+                            //also catches a ttl that did not parse, which would otherwise be stored as NaN
+                            if (!(ttl > 0) || ttl > remainingLife) {
+                                ttl = remainingLife;
+                            }
+                        }
                         multi = true;
                         if (params.qstring.multi === false || params.qstring.multi === 'false') {
                             multi = false;

--- a/api/utils/rights.js
+++ b/api/utils/rights.js
@@ -1520,9 +1520,20 @@ exports.isPermissionSubset = function(childPermission, ceiling) {
         return false;
     }
     var t, appId, i;
+    //membership is authority of its own: validateUserForRead and validateUserForWrite authorize
+    //on it alone, without asking about any feature, and getUserApps drives app listings and
+    //data scoping. So an app the child names under _ - as admin or as user - has to be an app
+    //the ceiling is itself a member of. Holding features on an app, even all of them, is not the
+    //same as being a member of it: a member can carry all:true for an app that is absent from
+    //its own _.u/_.a, and hasAdminAccess would then call the child an admin of an app the owner
+    //is not even a member of.
+    var ceilingMemberApps = principalMemberApps(ceiling);
     //an app the child administers implies every feature of every type, present and future
     var childAdminApps = (childPermission._ && Array.isArray(childPermission._.a)) ? childPermission._.a : [];
     for (i = 0; i < childAdminApps.length; i++) {
+        if (!ceiling.global_admin && ceilingMemberApps.indexOf(childAdminApps[i]) === -1) {
+            return false;
+        }
         for (t = 0; t < PERMISSION_TYPES.length; t++) {
             if (!principalAllowsAll(ceiling, PERMISSION_TYPES[t], childAdminApps[i])) {
                 return false;
@@ -1537,12 +1548,7 @@ exports.isPermissionSubset = function(childPermission, ceiling) {
             return false;
         }
     }
-    //membership is authority of its own: validateUserForRead and validateUserForWrite authorize
-    //on it alone, without asking about any feature. So an app the child names as a user app has
-    //to be an app the ceiling is itself a member of - holding one feature on an app is not the
-    //same as being a member of it, and treating it as such would let a token read an app its
-    //own owner is refused on.
-    var ceilingMemberApps = principalMemberApps(ceiling);
+    //and the same for the apps the child names as user apps
     var childUserApps = [];
     if (childPermission._ && Array.isArray(childPermission._.u)) {
         for (i = 0; i < childPermission._.u.length; i++) {
@@ -1675,11 +1681,15 @@ exports.intersectPermission = function(member, tokenPermission) {
                 grantsAnything = true;
             }
         }
-        var isAdmin = tokenAdminApps.indexOf(appId) !== -1 && exports.hasAdminAccess(member, appId);
+        //membership of either kind is granted only where the owner is itself a member. hasAdminAccess
+        //alone is not enough for the admin branch: it also says yes to four all:true entries on an
+        //app absent from the owner's _.u/_.a, and an admin app is membership too
+        var ownerIsMember = member.global_admin || memberMemberApps.indexOf(appId) !== -1;
+        var isAdmin = tokenAdminApps.indexOf(appId) !== -1 && exports.hasAdminAccess(member, appId) && ownerIsMember;
         if (isAdmin) {
             result._.a.push(appId);
         }
-        else if ((grantsAnything || tokenUserApps.indexOf(appId) !== -1) && (member.global_admin || memberMemberApps.indexOf(appId) !== -1)) {
+        else if ((grantsAnything || tokenUserApps.indexOf(appId) !== -1) && ownerIsMember) {
             //an app the token grants anything on - or names as a user app - stays visible, but
             //only while the owner is a member of it too
             userApps.push(appId);

--- a/api/utils/rights.js
+++ b/api/utils/rights.js
@@ -1362,11 +1362,15 @@ function principalAllowsAll(principal, type, appId) {
 }
 
 /**
-* Every app id a principal refers to, whether through the _ grouping or a c/r/u/d entry.
+* Apps a principal is a member of - the ones it administers, and the ones it is a user of.
+*
+* Distinct from the apps it can reach a feature on: some validators (validateUserForRead and
+* validateUserForWrite) authorize on membership alone, so membership is authority in its own
+* right and has to be bounded separately from the c/r/u/d grants.
 * @param {object} principal - object with permission (and optionally the legacy arrays)
-* @returns {string[]} list of app ids
+* @returns {string[]} list of app ids the principal is a member of
 */
-function principalApps(principal) {
+function principalMemberApps(principal) {
     var apps = [];
     /**
     * Add an app id once.
@@ -1397,13 +1401,28 @@ function principalApps(principal) {
             }
         }
     }
-    for (var t = 0; t < PERMISSION_TYPES.length; t++) {
-        var forType = permission[PERMISSION_TYPES[t]];
-        for (var appId in forType || {}) {
-            push(appId);
-        }
-    }
     return apps;
+}
+
+/**
+* Every app id a principal actually reaches: the ones it is a member of, plus the ones it holds
+* a c/r/u/d grant on.
+*
+* An entry under c/r/u/d that grants nothing does not count. The permission editor writes an
+* entry for every app the editing user could see, so a member routinely carries empty entries
+* for apps it has no access to at all; treating those as apps the member reaches would let a
+* token be scoped to one of them and come out wider than its own owner.
+* @param {object} principal - object with permission (and optionally the legacy arrays)
+* @returns {string[]} list of app ids
+*/
+function principalApps(principal) {
+    if (!principal) {
+        return [];
+    }
+    if (typeof principal.permission === "undefined") {
+        return principalMemberApps(principal);
+    }
+    return grantingApps(principal.permission);
 }
 
 /**
@@ -1510,12 +1529,28 @@ exports.isPermissionSubset = function(childPermission, ceiling) {
             }
         }
     }
-    //an app the child can see at all must be an app the ceiling can see, since some validators
-    //authorize on app membership alone
+    //an app the child can reach at all must be an app the ceiling can reach
     var ceilingApps = principalApps(ceiling);
     var childApps = grantingApps(childPermission);
     for (i = 0; i < childApps.length; i++) {
         if (!ceiling.global_admin && ceilingApps.indexOf(childApps[i]) === -1) {
+            return false;
+        }
+    }
+    //membership is authority of its own: validateUserForRead and validateUserForWrite authorize
+    //on it alone, without asking about any feature. So an app the child names as a user app has
+    //to be an app the ceiling is itself a member of - holding one feature on an app is not the
+    //same as being a member of it, and treating it as such would let a token read an app its
+    //own owner is refused on.
+    var ceilingMemberApps = principalMemberApps(ceiling);
+    var childUserApps = [];
+    if (childPermission._ && Array.isArray(childPermission._.u)) {
+        for (i = 0; i < childPermission._.u.length; i++) {
+            childUserApps = childUserApps.concat(childPermission._.u[i] || []);
+        }
+    }
+    for (i = 0; i < childUserApps.length; i++) {
+        if (!ceiling.global_admin && ceilingMemberApps.indexOf(childUserApps[i]) === -1) {
             return false;
         }
     }
@@ -1599,6 +1634,10 @@ exports.intersectPermission = function(member, tokenPermission) {
     var tokenPrincipal = {permission: tokenPermission};
     var userApps = [];
     var memberApps = principalApps(member);
+    //membership is granted by the owner's own membership, never by a feature it happens to hold:
+    //validateUserForRead and validateUserForWrite authorize on membership alone, so a token that
+    //picked it up from a feature grant would read apps its owner is refused on
+    var memberMemberApps = principalMemberApps(member);
     var tokenAdminApps = (tokenPermission._ && Array.isArray(tokenPermission._.a)) ? tokenPermission._.a : [];
     var tokenUserApps = [];
     if (tokenPermission._ && Array.isArray(tokenPermission._.u)) {
@@ -1640,9 +1679,9 @@ exports.intersectPermission = function(member, tokenPermission) {
         if (isAdmin) {
             result._.a.push(appId);
         }
-        else if (grantsAnything || tokenUserApps.indexOf(appId) !== -1) {
-            //app membership alone is what some validators check, so an app the token grants
-            //anything on - or names as a user app - stays visible
+        else if ((grantsAnything || tokenUserApps.indexOf(appId) !== -1) && (member.global_admin || memberMemberApps.indexOf(appId) !== -1)) {
+            //an app the token grants anything on - or names as a user app - stays visible, but
+            //only while the owner is a member of it too
             userApps.push(appId);
         }
     });

--- a/frontend/express/public/core/token-manager/javascripts/countly.views.js
+++ b/frontend/express/public/core/token-manager/javascripts/countly.views.js
@@ -45,10 +45,13 @@
                 else {
                     self.filteredFeatures = self.features;
                 }
+                //the column headers describe the rows on screen, and those just changed
+                self.syncAllFlags();
             },
             clearSearch: function() {
                 this.searchQuery = '';
                 this.filteredFeatures = this.features;
+                this.syncAllFlags();
             },
             //granting anything on a feature implies being able to read it, mirroring how a user's
             //own permissions are edited in user management
@@ -79,16 +82,30 @@
                 }
                 this.syncAllFlags();
             },
-            //"all" must mean every feature, including ones added later, so it is only set when the
-            //whole list is selected - the server refuses an "all" grant the creator does not hold
             syncAllFlags: function() {
                 var self = this;
-                PERMISSION_TYPES.forEach(function(type) {
-                    var every = self.features.length > 0 && self.features.every(function(feature) {
+                /**
+                * Whether every feature in a list is allowed for one access type.
+                * @param {string} type - access type (c, r, u, d)
+                * @param {string[]} features - features to check
+                * @returns {boolean} true when the list is non-empty and fully allowed
+                */
+                var allOf = function(type, features) {
+                    return features.length > 0 && features.every(function(feature) {
                         return self.permissionSet[type].allowed[feature] === true;
                     });
-                    self.permissionSet[type].all = every;
-                    self.allByType[type] = every;
+                };
+                PERMISSION_TYPES.forEach(function(type) {
+                    //"all" must mean every feature, including ones added later, so it is only set
+                    //when the whole list is selected - the server refuses an "all" grant the
+                    //creator does not hold
+                    self.permissionSet[type].all = allOf(type, self.features);
+                    //the column header toggles the rows on screen, so it reports on those. Reading
+                    //it off the full list instead would leave it ticked after a filtered toggle -
+                    //the value would go false, true, false within one tick, so Vue would see no
+                    //change to patch and the box the browser just ticked would stay ticked while
+                    //the model said otherwise.
+                    self.allByType[type] = allOf(type, self.filteredFeatures);
                 });
             },
             buildPermission: function(apps) {

--- a/frontend/express/public/core/token-manager/javascripts/countly.views.js
+++ b/frontend/express/public/core/token-manager/javascripts/countly.views.js
@@ -109,7 +109,17 @@
                 });
             },
             buildPermission: function(apps) {
-                var permission = {_: {a: [], u: [apps]}, c: {}, r: {}, u: {}, d: {}};
+                //the dashboard lists every app the creator holds a read grant on, and that includes
+                //apps the creator is not a member of - a read grant on one feature puts an app in
+                //the app switcher without putting it in the member's _.u. Membership is a grant of
+                //its own that the server refuses to widen, so the token names as user apps only
+                //the selected apps the creator is itself a member of. The others still carry their
+                //feature grants, which is exactly what the creator has on them.
+                var memberApps = countlyAuth.getUserApps();
+                var userApps = apps.filter(function(appId) {
+                    return memberApps.indexOf(appId) !== -1;
+                });
+                var permission = {_: {a: [], u: [userApps]}, c: {}, r: {}, u: {}, d: {}};
                 return countlyAuth.combinePermissionObject([apps], [this.permissionSet], permission);
             },
             onClose: function() {

--- a/frontend/express/public/core/token-manager/javascripts/countly.views.js
+++ b/frontend/express/public/core/token-manager/javascripts/countly.views.js
@@ -108,6 +108,23 @@
                     self.allByType[type] = allOf(type, self.filteredFeatures);
                 });
             },
+            //apps the creator is a member of. countlyAuth.getUserApps reads permission._.u
+            //unconditionally, and a member stored before permission objects existed has no
+            //permission at all - only admin_of/user_of, which the dashboard still honours
+            creatorMemberApps: function() {
+                var member = countlyGlobal.member || {};
+                if (member.global_admin) {
+                    return Object.keys(countlyGlobal.apps || {});
+                }
+                if (member.permission && member.permission._) {
+                    var apps = [];
+                    (member.permission._.u || []).forEach(function(group) {
+                        apps = apps.concat(group || []);
+                    });
+                    return apps.concat(member.permission._.a || []);
+                }
+                return (member.admin_of || []).concat(member.user_of || []);
+            },
             buildPermission: function(apps) {
                 //the dashboard lists every app the creator holds a read grant on, and that includes
                 //apps the creator is not a member of - a read grant on one feature puts an app in
@@ -115,7 +132,7 @@
                 //its own that the server refuses to widen, so the token names as user apps only
                 //the selected apps the creator is itself a member of. The others still carry their
                 //feature grants, which is exactly what the creator has on them.
-                var memberApps = countlyAuth.getUserApps();
+                var memberApps = this.creatorMemberApps();
                 var userApps = apps.filter(function(appId) {
                     return memberApps.indexOf(appId) !== -1;
                 });

--- a/frontend/express/public/core/token-manager/templates/token-manager-drawer.html
+++ b/frontend/express/public/core/token-manager/templates/token-manager-drawer.html
@@ -32,10 +32,7 @@
                 </el-checkbox>
                 <p class="text-small color-cool-gray-50 bu-mt-1">{{i18n('token_manager.permission.can-login-text')}}</p>
             </cly-form-field>
-            <cly-form-field v-if="tokenUsage === '1'" class="bu-p-0">
-                <div class="bu-is-flex bu-mt-4">
-                    <p class="text-small color-cool-gray-100">{{i18n('token_manager.select-apps')}}<i class="el-icon-question bu-ml-2"></i></p>
-                </div>
+            <cly-form-field v-if="tokenUsage === '1'" class="bu-p-0 bu-mt-4" :label="i18n('token_manager.select-apps')" :name="i18n('token_manager.select-apps')" rules="required">
                 <cly-app-select
                     style="width: 100%;"
                     v-model="formScope.editedObject.selectApps"

--- a/plugins/plugins/api/api.js
+++ b/plugins/plugins/api/api.js
@@ -256,7 +256,7 @@ var plugin = {},
                     }
                     if (params.member.settings && params.member.settings.frontend && typeof data.frontend.session_timeout !== "undefined") {} //eslint-disable-line no-empty
                     else { //if not set member value
-                        common.db.collection("auth_tokens").update({"owner": ob.params.member._id + "", "purpose": "LoggedInAuth"}, {$set: updateArr}, function(err) {
+                        common.db.collection("auth_tokens").update({"owner": ob.params.member._id + "", "purpose": "LoggedInAuth", "max_ends": {$exists: false}}, {$set: updateArr}, function(err) {
                             if (err) {
                                 console.log(err);
                             }
@@ -333,7 +333,7 @@ var plugin = {},
                         updateArr.ttl = data.frontend.session_timeout * 60;
                     }
 
-                    common.db.collection("auth_tokens").update({"owner": ob.params.member._id + "", "purpose": "LoggedInAuth"}, {$set: updateArr}, function(err) {
+                    common.db.collection("auth_tokens").update({"owner": ob.params.member._id + "", "purpose": "LoggedInAuth", "max_ends": {$exists: false}}, {$set: updateArr}, function(err) {
                         if (err) {
                             console.log(err);
                         }

--- a/test/2.api/16.token.manager.js
+++ b/test/2.api/16.token.manager.js
@@ -1378,6 +1378,40 @@ describe('Testing token manager', function() {
                 });
         });
 
+        it('nor one that administers it, however many features the member holds there', function(done) {
+            //give the member every feature on the other app - but no membership of it - and ask for
+            //admin. hasAdminAccess is satisfied by the four all grants; membership is not
+            var full = {_: {a: [], u: [[APP_ID]]}, c: {}, r: {}, u: {}, d: {}};
+            ["c", "r", "u", "d"].forEach(function(type) {
+                full[type][APP_ID] = {all: false, allowed: {core: true}};
+                full[type][OTHER_APP_ID] = {all: true, allowed: {}};
+            });
+            request
+                .get('/i/users/update?api_key=' + API_KEY_ADMIN + "&args=" + JSON.stringify({user_id: memberId, permission: full}))
+                .expect(200)
+                .end(function(err) {
+                    if (err) {
+                        return done(err);
+                    }
+                    request
+                        .get('/i/token/create?api_key=' + memberKey + '&multi=true&ttl=3600&permission=' + encodeURIComponent(JSON.stringify({_: {a: [OTHER_APP_ID], u: [[]]}, c: {}, r: {}, u: {}, d: {}})))
+                        .expect(403)
+                        .end(function(err2) {
+                            if (err2) {
+                                return done(err2);
+                            }
+                            //restore the plain shape the remaining cases rely on
+                            var plain = {_: {a: [], u: [[APP_ID]]}, c: {}, r: {}, u: {}, d: {}};
+                            plain.r[APP_ID] = {all: false, allowed: {core: true}};
+                            plain.r[OTHER_APP_ID] = {all: false, allowed: {}};
+                            request
+                                .get('/i/users/update?api_key=' + API_KEY_ADMIN + "&args=" + JSON.stringify({user_id: memberId, permission: plain}))
+                                .expect(200)
+                                .end(done);
+                        });
+                });
+        });
+
         it('a token for the app the member does reach is still granted', function(done) {
             var permission = {_: {a: [], u: [[APP_ID]]}, c: {}, r: {}, u: {}, d: {}};
             permission.r[APP_ID] = {all: false, allowed: {core: true}};

--- a/test/2.api/16.token.manager.js
+++ b/test/2.api/16.token.manager.js
@@ -1348,12 +1348,22 @@ describe('Testing token manager', function() {
                 });
         });
 
-        it('the member itself is refused on that app', function(done) {
+        it('the member itself is not a member of that app', function(done) {
+            //membership is what getUserApps reports, and /o/apps/mine is built from it on every
+            //branch. (An app-data endpoint is not used here: which validator gates one differs
+            //between release lines, and this case is about membership, not a feature.)
             request
-                .get('/o/app_users/loyalty?app_id=' + OTHER_APP_ID + '&api_key=' + memberKey)
-                .expect(401)
-                .end(function(err) {
-                    done(err);
+                .get('/o/apps/mine?api_key=' + memberKey)
+                .expect(200)
+                .end(function(err, res) {
+                    if (err) {
+                        return done(err);
+                    }
+                    var mine = JSON.parse(res.text);
+                    (mine.user_of || {}).should.not.have.property(OTHER_APP_ID);
+                    (mine.admin_of || {}).should.not.have.property(OTHER_APP_ID);
+                    (mine.user_of || {}).should.have.property(APP_ID);
+                    done();
                 });
         });
 
@@ -1428,12 +1438,18 @@ describe('Testing token manager', function() {
                 });
         });
 
-        it('and reads on the app it names, as its owner does', function(done) {
+        it('and is a member of the app it names, as its owner is', function(done) {
             request
-                .get('/o/app_users/loyalty?app_id=' + APP_ID + '&auth_token=' + scopedToken)
+                .get('/o/apps/mine?auth_token=' + scopedToken)
                 .expect(200)
-                .end(function(err) {
-                    done(err);
+                .end(function(err, res) {
+                    if (err) {
+                        return done(err);
+                    }
+                    var mine = JSON.parse(res.text);
+                    (mine.user_of || {}).should.have.property(APP_ID);
+                    (mine.user_of || {}).should.not.have.property(OTHER_APP_ID);
+                    done();
                 });
         });
 

--- a/test/2.api/16.token.manager.js
+++ b/test/2.api/16.token.manager.js
@@ -494,6 +494,58 @@ describe('Testing token manager', function() {
                 });
         });
 
+        //the parent holds ttl 3600, so anything longer than that - "never expires" most of all -
+        //would outlive the credential that granted it
+        var createChildAndReadTtl = function(ttl, cb) {
+            request
+                .get('/i/token/create?auth_token=' + limitedToken + '&multi=true&ttl=' + ttl + '&permission=' + readCorePermission(APP_ID))
+                .expect(200)
+                .end(function(err, res) {
+                    if (err) {
+                        return cb(err);
+                    }
+                    var child = JSON.parse(res.text).result;
+                    testUtils.db.collection("auth_tokens").findOne({_id: child}, function(dbErr, doc) {
+                        if (dbErr || !doc) {
+                            return cb(dbErr || "child token missing");
+                        }
+                        cb(null, doc.ttl, child);
+                    });
+                });
+        };
+
+        it('the child cannot be given a life its parent does not have', function(done) {
+            //ttl 0 is "never expires", so this is the widest ask there is
+            createChildAndReadTtl(0, function(err, ttl, child) {
+                if (err) {
+                    return done(err);
+                }
+                ttl.should.be.above(0);
+                ttl.should.be.belowOrEqual(3600);
+                deleteToken(child, done);
+            });
+        });
+
+        it('nor a longer one than its parent has left', function(done) {
+            createChildAndReadTtl(99999, function(err, ttl, child) {
+                if (err) {
+                    return done(err);
+                }
+                ttl.should.be.belowOrEqual(3600);
+                deleteToken(child, done);
+            });
+        });
+
+        it('but a shorter life than its parent is granted as asked', function(done) {
+            createChildAndReadTtl(30, function(err, ttl, child) {
+                if (err) {
+                    return done(err);
+                }
+                ttl.should.equal(30);
+                deleteToken(child, done);
+            });
+        });
+
         it('the limited token cannot be granted login permission', function(done) {
             //the permission the token already holds is supplied, so a narrowing child is the only
             //thing being asked for beyond login - what is refused here is the login grant itself
@@ -581,6 +633,28 @@ describe('Testing token manager', function() {
                         return done(err);
                     }
                     deleteToken(JSON.parse(res.text).result, done);
+                });
+        });
+
+        it('and is not capped by its own lifetime, being the owner\'s full authority', function(done) {
+            //the lifetime cap is for a credential narrower than its owner. The dashboard session
+            //token is not one, and capping it would stop the token manager UI - which creates
+            //through that session - from ever issuing a token that does not expire
+            request
+                .get('/i/token/create?auth_token=' + fullToken + '&purpose=child-never&multi=true&ttl=0')
+                .expect(200)
+                .end(function(err, res) {
+                    if (err) {
+                        return done(err);
+                    }
+                    var child = JSON.parse(res.text).result;
+                    testUtils.db.collection("auth_tokens").findOne({_id: child}, function(dbErr, doc) {
+                        if (dbErr || !doc) {
+                            return done(dbErr || "child token missing");
+                        }
+                        doc.ttl.should.equal(0);
+                        deleteToken(child, done);
+                    });
                 });
         });
 
@@ -1218,6 +1292,125 @@ describe('Testing token manager', function() {
             testUtils.db.collection("auth_tokens").remove({owner: memberId + ""}, function() {
                 testUtils.db.collection("members").remove({username: username}, function() {
                     done();
+                });
+            });
+        });
+    });
+
+
+    describe('A grant is bounded by what the owner reaches, not by what its permissions mention', function() {
+        // The permission editor writes an entry for every app it could see, so a member
+        // routinely carries empty c/r/u/d entries for apps it has no access to at all.
+        // Those entries are not access. Naming such an app as a user app in a token is,
+        // because validateUserForRead and validateUserForWrite authorize on membership
+        // alone - so accepting it would hand the token an app its own owner is refused on.
+        var memberId = "";
+        var memberKey = "";
+        var scopedToken = "";
+        var OTHER_APP_ID = "";
+        var username = "tokenreach" + Math.round(Math.random() * 100000);
+
+        it('setup: an app the member will not be given access to', function(done) {
+            var params = {name: "Token reach other app"};
+            request
+                .get('/i/apps/create?api_key=' + API_KEY_ADMIN + "&args=" + JSON.stringify(params))
+                .expect(200)
+                .end(function(err, res) {
+                    if (err) {
+                        return done(err);
+                    }
+                    OTHER_APP_ID = JSON.parse(res.text)._id;
+                    (OTHER_APP_ID !== "").should.equal(true);
+                    done();
+                });
+        });
+
+        it('setup: a member carrying an empty entry for it, the way the editor stores one', function(done) {
+            var permission = {_: {a: [], u: [[APP_ID]]}, c: {}, r: {}, u: {}, d: {}};
+            permission.r[APP_ID] = {all: false, allowed: {core: true}};
+            permission.r[OTHER_APP_ID] = {all: false, allowed: {}};
+            permission.c[OTHER_APP_ID] = {all: false, allowed: {}};
+            permission.u[OTHER_APP_ID] = {all: false, allowed: {}};
+            permission.d[OTHER_APP_ID] = {all: false, allowed: {}};
+            var params = {full_name: "Token Reach", username: username, password: testUtils.password, email: username + "@domain.com", permission: permission};
+            request
+                .get('/i/users/create?api_key=' + API_KEY_ADMIN + "&args=" + JSON.stringify(params))
+                .expect(200)
+                .end(function(err, res) {
+                    if (err) {
+                        return done(err);
+                    }
+                    var ob = JSON.parse(res.text);
+                    ob.should.have.property('api_key');
+                    memberId = ob._id;
+                    memberKey = ob.api_key;
+                    done();
+                });
+        });
+
+        it('the member itself is refused on that app', function(done) {
+            request
+                .get('/o/app_users/loyalty?app_id=' + OTHER_APP_ID + '&api_key=' + memberKey)
+                .expect(401)
+                .end(function(err) {
+                    done(err);
+                });
+        });
+
+        it('and cannot mint a token that is a member of it', function(done) {
+            var permission = {_: {a: [], u: [[OTHER_APP_ID]]}, c: {}, r: {}, u: {}, d: {}};
+            request
+                .get('/i/token/create?api_key=' + memberKey + '&multi=true&ttl=3600&permission=' + encodeURIComponent(JSON.stringify(permission)))
+                .expect(403)
+                .end(function(err) {
+                    done(err);
+                });
+        });
+
+        it('nor one that is a member of it alongside an app it does reach', function(done) {
+            var permission = {_: {a: [], u: [[APP_ID, OTHER_APP_ID]]}, c: {}, r: {}, u: {}, d: {}};
+            permission.r[APP_ID] = {all: false, allowed: {core: true}};
+            request
+                .get('/i/token/create?api_key=' + memberKey + '&multi=true&ttl=3600&permission=' + encodeURIComponent(JSON.stringify(permission)))
+                .expect(403)
+                .end(function(err) {
+                    done(err);
+                });
+        });
+
+        it('a token for the app the member does reach is still granted', function(done) {
+            var permission = {_: {a: [], u: [[APP_ID]]}, c: {}, r: {}, u: {}, d: {}};
+            permission.r[APP_ID] = {all: false, allowed: {core: true}};
+            request
+                .get('/i/token/create?api_key=' + memberKey + '&multi=true&ttl=3600&permission=' + encodeURIComponent(JSON.stringify(permission)))
+                .expect(200)
+                .end(function(err, res) {
+                    if (err) {
+                        return done(err);
+                    }
+                    scopedToken = JSON.parse(res.text).result;
+                    (scopedToken !== "").should.equal(true);
+                    done();
+                });
+        });
+
+        it('and reads on the app it names, as its owner does', function(done) {
+            request
+                .get('/o/app_users/loyalty?app_id=' + APP_ID + '&auth_token=' + scopedToken)
+                .expect(200)
+                .end(function(err) {
+                    done(err);
+                });
+        });
+
+        it('cleanup: remove the token, the member and the app', function(done) {
+            testUtils.db.collection("auth_tokens").remove({owner: memberId + ""}, function() {
+                testUtils.db.collection("members").remove({username: username}, function() {
+                    request
+                        .get('/i/apps/delete?api_key=' + API_KEY_ADMIN + '&args=' + JSON.stringify({app_id: OTHER_APP_ID}))
+                        .end(function() {
+                            done();
+                        });
                 });
             });
         });

--- a/test/unit-tests/api.login.token.mints.js
+++ b/test/unit-tests/api.login.token.mints.js
@@ -101,7 +101,8 @@ describe("tokens that open a dashboard session", function() {
                 if (!/\.(js|ts)$/.test(entry.name)) {
                     return;
                 }
-                var relative = path.relative(ROOT, full);
+                //MINTERS are written with forward slashes; path.relative uses the platform separator
+                var relative = path.relative(ROOT, full).split(path.sep).join("/");
                 if (allowed.indexOf(relative) !== -1) {
                     return;
                 }

--- a/test/unit-tests/api.login.token.mints.js
+++ b/test/unit-tests/api.login.token.mints.js
@@ -1,0 +1,121 @@
+require("should");
+var fs = require("fs");
+var path = require("path");
+
+// Login capability is a property of the token now, not of its purpose string, and it
+// defaults to false in authorizer.save. That closes the escalation, but it also means a
+// site that mints a session token and forgets to ask for it produces a credential that
+// /login/token refuses - the OIDC login token was exactly that until it was fixed.
+//
+// The set of places that legitimately mint a redeemable token is small and closed, so it
+// is asserted here by reading the source: any authorize.save whose purpose is one of the
+// login purposes has to carry can_login, and nothing else may.
+
+var ROOT = path.join(__dirname, "../..");
+
+var MINTERS = [
+    {file: "frontend/express/libs/members.js", what: "the password login session"},
+    {file: "plugins/oidc/frontend/app.js", what: "the OIDC login session"},
+    {file: "api/parts/mgmt/mail.js", what: "the ban warning mail link"},
+    {file: "api/utils/requestProcessor.js", what: "the /o/render headless session"},
+    {file: "plugins/dashboards/api/api.js", what: "the dashboard screenshot session"}
+];
+
+var LOGIN_PURPOSES = ["LoggedInAuth", "LoginAuthToken"];
+
+/**
+ * Every authorize.save({...}) options literal in a file, as source text.
+ * @param {string} src - file contents
+ * @returns {string[]} the source of each options object
+ */
+function saveCalls(src) {
+    var calls = [];
+    var marker = /authorize\.save\(\{/g;
+    var match;
+    while ((match = marker.exec(src)) !== null) {
+        var start = match.index + match[0].length - 1;
+        var depth = 0;
+        for (var i = start; i < src.length; i++) {
+            if (src[i] === "{") {
+                depth++;
+            }
+            else if (src[i] === "}") {
+                depth--;
+                if (depth === 0) {
+                    calls.push(src.slice(start, i + 1));
+                    break;
+                }
+            }
+        }
+    }
+    return calls;
+}
+
+/**
+ * Whether an options literal names one of the purposes /login/token honours.
+ * @param {string} options - the source of the options object
+ * @returns {boolean} true when it is a login token
+ */
+function isLoginPurpose(options) {
+    return LOGIN_PURPOSES.some(function(purpose) {
+        return new RegExp("purpose\\s*:\\s*[\"']" + purpose + "[\"']").test(options);
+    });
+}
+
+describe("tokens that open a dashboard session", function() {
+    MINTERS.forEach(function(minter) {
+        it("asks for login permission when minting " + minter.what, function() {
+            var full = path.join(ROOT, minter.file);
+            if (!fs.existsSync(full)) {
+                //a plugin this branch does not carry
+                return;
+            }
+            var login = saveCalls(fs.readFileSync(full, "utf8")).filter(isLoginPurpose);
+            login.length.should.be.above(0, minter.file + " no longer mints a login token");
+            login.forEach(function(options) {
+                options.should.match(/can_login\s*:\s*true/, minter.file + " mints a login token without can_login");
+            });
+        });
+    });
+
+    it("grants it nowhere else", function() {
+        var allowed = MINTERS.map(function(minter) {
+            return minter.file;
+        });
+        var offenders = [];
+        /**
+         * Walk a directory, checking every js/ts file that mints a token.
+         * @param {string} dir - directory to walk
+         * @returns {void}
+         */
+        function walk(dir) {
+            fs.readdirSync(dir, {withFileTypes: true}).forEach(function(entry) {
+                var full = path.join(dir, entry.name);
+                if (entry.isDirectory()) {
+                    if (entry.name === "node_modules" || entry.name === ".git" || entry.name === "tests" || entry.name === "test") {
+                        return;
+                    }
+                    walk(full);
+                    return;
+                }
+                if (!/\.(js|ts)$/.test(entry.name)) {
+                    return;
+                }
+                var relative = path.relative(ROOT, full);
+                if (allowed.indexOf(relative) !== -1) {
+                    return;
+                }
+                var src = fs.readFileSync(full, "utf8");
+                if (/can_login\s*:\s*true/.test(src) && saveCalls(src).some(function(options) {
+                    return /can_login\s*:\s*true/.test(options);
+                })) {
+                    offenders.push(relative);
+                }
+            });
+        }
+        ["api", "frontend", "plugins"].forEach(function(top) {
+            walk(path.join(ROOT, top));
+        });
+        offenders.should.eql([]);
+    });
+});

--- a/test/unit-tests/api.utils.authorizer.tokenFields.js
+++ b/test/unit-tests/api.utils.authorizer.tokenFields.js
@@ -18,7 +18,8 @@ function dbStub(tokens) {
         },
         collection: function(name) {
             return {
-                findOne: function(query, callback) {
+                findOne: function(query, projectionOrCallback, maybeCallback) {
+                    var callback = typeof projectionOrCallback === "function" ? projectionOrCallback : maybeCallback;
                     if (name === "members") {
                         return callback(null, {_id: OWNER});
                     }
@@ -32,7 +33,16 @@ function dbStub(tokens) {
                     callback(null, doc);
                 },
                 remove: function() { },
-                update: function() { },
+                update: function(query, change, callback) {
+                    stored.filter(function(doc) {
+                        return doc._id === query._id;
+                    }).forEach(function(doc) {
+                        Object.assign(doc, (change && change.$set) || {});
+                    });
+                    if (typeof callback === "function") {
+                        callback(null, {});
+                    }
+                },
                 findAndModify: function(rules, sort, update, callback) {
                     callback(null, null);
                 }
@@ -135,6 +145,72 @@ describe("authorizer token record", function() {
                     }
                 });
             }
+        });
+    });
+
+    describe("extend_token", function() {
+        it("never extends a bounded token past its bound", function(done) {
+            //the heatmap route extends a near-expiry token by ten minutes on every request. For a
+            //child bounded by its parent that would keep it alive indefinitely after the parent
+            //expired, so the bound is persisted and the extension clamps to it
+            var db = dbStub([]);
+            var now = Math.round(Date.now() / 1000);
+            var bound = now + 60;
+            authorizer.save({
+                db: db,
+                owner: OWNER,
+                ttl: 30,
+                maxEnds: bound,
+                token: "bounded",
+                callback: function() {
+                    db.stored[0].max_ends.should.equal(bound);
+                    authorizer.extend_token({
+                        db: db,
+                        token: "bounded",
+                        extendTill: Date.now() + 600000,
+                        callback: function(err, ok) {
+                            (!err).should.equal(true);
+                            ok.should.equal(true);
+                            db.stored[0].ends.should.equal(bound);
+                            db.stored[0].ttl.should.be.above(0);
+                            //extendBy 0 means "never expires"; the bound turns that into "until the bound"
+                            authorizer.extend_token({
+                                db: db,
+                                token: "bounded",
+                                extendBy: 0,
+                                callback: function() {
+                                    db.stored[0].ends.should.equal(bound);
+                                    db.stored[0].ttl.should.be.above(0);
+                                    done();
+                                }
+                            });
+                        }
+                    });
+                }
+            });
+        });
+
+        it("extends an unbounded token exactly as before", function(done) {
+            var db = dbStub([]);
+            authorizer.save({
+                db: db,
+                owner: OWNER,
+                ttl: 30,
+                token: "free",
+                callback: function() {
+                    (db.stored[0].max_ends === undefined).should.equal(true);
+                    var till = Date.now() + 600000;
+                    authorizer.extend_token({
+                        db: db,
+                        token: "free",
+                        extendTill: till,
+                        callback: function() {
+                            db.stored[0].ends.should.equal(Math.round(till / 1000));
+                            done();
+                        }
+                    });
+                }
+            });
         });
     });
 

--- a/test/unit-tests/api.utils.authorizer.tokenFields.js
+++ b/test/unit-tests/api.utils.authorizer.tokenFields.js
@@ -90,6 +90,54 @@ describe("authorizer token record", function() {
         });
     });
 
+    it("never lets ends pass an absolute bound, whatever ttl was asked for", function(done) {
+        //a scoped token minting a child hands over its own ends as the bound. The bound is applied
+        //here, at insertion, because the member lookup before it is asynchronous: a relative ttl
+        //computed by the caller would land ends later than the bound by the lookup's duration
+        var db = dbStub([]);
+        var now = Math.round(Date.now() / 1000);
+        var bound = now + 60;
+        authorizer.save({
+            db: db,
+            owner: OWNER,
+            ttl: 3600,
+            maxEnds: bound,
+            callback: function(err) {
+                (!err).should.equal(true);
+                db.stored[0].ends.should.be.belowOrEqual(bound);
+                db.stored[0].ends.should.be.above(now);
+                //the ttl asked for is kept as a record of the request; ends is what verify_token checks
+                db.stored[0].ttl.should.equal(3600);
+                done();
+            }
+        });
+    });
+
+    it("leaves ends alone when no bound is given, and for a token that never expires", function(done) {
+        var db = dbStub([]);
+        var now = Math.round(Date.now() / 1000);
+        authorizer.save({
+            db: db,
+            owner: OWNER,
+            ttl: 3600,
+            callback: function() {
+                db.stored[0].ends.should.be.aboveOrEqual(now + 3600);
+                authorizer.save({
+                    db: db,
+                    owner: OWNER,
+                    ttl: 0,
+                    maxEnds: now + 60,
+                    callback: function() {
+                        //ttl 0 is "never expires" and verify_token never reads ends for it; the
+                        //bound is not silently turned into an expiry the caller did not ask for
+                        db.stored[1].ttl.should.equal(0);
+                        done();
+                    }
+                });
+            }
+        });
+    });
+
     describe("verify_token", function() {
         var future = Math.round(Date.now() / 1000) + 3600;
 

--- a/test/unit-tests/api.utils.authorizer.tokenFields.js
+++ b/test/unit-tests/api.utils.authorizer.tokenFields.js
@@ -260,7 +260,11 @@ describe("authorizer token record", function() {
     });
 
     describe("the bound is enforced at every use", function() {
-        var now = Math.round(Date.now() / 1000);
+        //computed per case, not per file: the api-core run loads every test file first and then
+        //runs for minutes, so a bound set at load time to "a minute ahead" has already passed
+        var now = function() {
+            return Math.round(Date.now() / 1000);
+        };
 
         /**
         * A stored token document with the given lifetime fields.
@@ -301,7 +305,7 @@ describe("authorizer token record", function() {
         it("refuses a token whose bound has passed, however far its ends was pushed", function(done) {
             //whatever moved ends - the session-timeout retiming of every LoggedInAuth token of a
             //member writes ends directly - the parent's bound is the end of this token's life
-            var db = dbStub([tokenDoc("pushed", {ttl: 3600, ends: now + 3600, max_ends: now - 5})]);
+            var db = dbStub([tokenDoc("pushed", {ttl: 3600, ends: now() + 3600, max_ends: now() - 5})]);
             verify(db, "pushed", function(valid) {
                 (!valid).should.equal(true);
                 //and consumed, as any other expired token is
@@ -311,7 +315,7 @@ describe("authorizer token record", function() {
         });
 
         it("refuses a never-expiring token once its bound has passed", function(done) {
-            var db = dbStub([tokenDoc("forever", {ttl: 0, ends: 0, max_ends: now - 5})]);
+            var db = dbStub([tokenDoc("forever", {ttl: 0, ends: 0, max_ends: now() - 5})]);
             verify(db, "forever", function(valid) {
                 (!valid).should.equal(true);
                 db.stored.length.should.equal(0);
@@ -320,7 +324,7 @@ describe("authorizer token record", function() {
         });
 
         it("accepts a bounded token while its bound is ahead", function(done) {
-            var db = dbStub([tokenDoc("alive", {ttl: 3600, ends: now + 3600, max_ends: now + 60})]);
+            var db = dbStub([tokenDoc("alive", {ttl: 3600, ends: now() + 3600, max_ends: now() + 3600})]);
             verify(db, "alive", function(valid) {
                 valid._id.should.equal("alive");
                 //a multi-use token within its bound is kept

--- a/test/unit-tests/api.utils.authorizer.tokenFields.js
+++ b/test/unit-tests/api.utils.authorizer.tokenFields.js
@@ -32,7 +32,16 @@ function dbStub(tokens) {
                     stored.push(doc);
                     callback(null, doc);
                 },
-                remove: function() { },
+                remove: function(query, callback) {
+                    for (var i = stored.length - 1; i >= 0; i--) {
+                        if (stored[i]._id === query._id) {
+                            stored.splice(i, 1);
+                        }
+                    }
+                    if (typeof callback === "function") {
+                        callback(null, {});
+                    }
+                },
                 update: function(query, change, callback) {
                     stored.filter(function(doc) {
                         return doc._id === query._id;
@@ -295,6 +304,8 @@ describe("authorizer token record", function() {
             var db = dbStub([tokenDoc("pushed", {ttl: 3600, ends: now + 3600, max_ends: now - 5})]);
             verify(db, "pushed", function(valid) {
                 (!valid).should.equal(true);
+                //and consumed, as any other expired token is
+                db.stored.length.should.equal(0);
                 done();
             });
         });
@@ -303,6 +314,7 @@ describe("authorizer token record", function() {
             var db = dbStub([tokenDoc("forever", {ttl: 0, ends: 0, max_ends: now - 5})]);
             verify(db, "forever", function(valid) {
                 (!valid).should.equal(true);
+                db.stored.length.should.equal(0);
                 done();
             });
         });
@@ -311,6 +323,8 @@ describe("authorizer token record", function() {
             var db = dbStub([tokenDoc("alive", {ttl: 3600, ends: now + 3600, max_ends: now + 60})]);
             verify(db, "alive", function(valid) {
                 valid._id.should.equal("alive");
+                //a multi-use token within its bound is kept
+                db.stored.length.should.equal(1);
                 done();
             });
         });

--- a/test/unit-tests/api.utils.authorizer.tokenFields.js
+++ b/test/unit-tests/api.utils.authorizer.tokenFields.js
@@ -173,12 +173,14 @@ describe("authorizer token record", function() {
                             ok.should.equal(true);
                             db.stored[0].ends.should.equal(bound);
                             db.stored[0].ttl.should.be.above(0);
-                            //extendBy 0 means "never expires"; the bound turns that into "until the bound"
+                            //the relative form is clamped the same way
                             authorizer.extend_token({
                                 db: db,
                                 token: "bounded",
-                                extendBy: 0,
-                                callback: function() {
+                                extendBy: 600000,
+                                callback: function(err2, ok2) {
+                                    (!err2).should.equal(true);
+                                    ok2.should.equal(true);
                                     db.stored[0].ends.should.equal(bound);
                                     db.stored[0].ttl.should.be.above(0);
                                     done();
@@ -186,6 +188,40 @@ describe("authorizer token record", function() {
                             });
                         }
                     });
+                }
+            });
+        });
+
+        it("fails closed when the bound cannot be read", function(done) {
+            //a transient read failure must not turn into an unbounded ten-minute extension
+            var db = dbStub([{
+                _id: "bounded",
+                ttl: 30,
+                ends: 1,
+                max_ends: 1,
+                multi: true
+            }]);
+            var findOne = db.collection("auth_tokens").findOne;
+            db.collection = function(name) {
+                var coll = dbStub(db.stored).collection(name);
+                if (name === "auth_tokens") {
+                    coll.findOne = function(query, projection, callback) {
+                        (callback || projection)(new Error("read failed"), null);
+                    };
+                }
+                return coll;
+            };
+            void findOne;
+            authorizer.extend_token({
+                db: db,
+                token: "bounded",
+                extendTill: Date.now() + 600000,
+                callback: function(err, ok) {
+                    (!!err).should.equal(true);
+                    (ok === null).should.equal(true);
+                    //nothing was written
+                    db.stored[0].ends.should.equal(1);
+                    done();
                 }
             });
         });
@@ -210,6 +246,84 @@ describe("authorizer token record", function() {
                         }
                     });
                 }
+            });
+        });
+    });
+
+    describe("the bound is enforced at every use", function() {
+        var now = Math.round(Date.now() / 1000);
+
+        /**
+        * A stored token document with the given lifetime fields.
+        * @param {string} id - token id
+        * @param {object} life - ttl, ends and max_ends
+        * @returns {object} document for the stub
+        */
+        function tokenDoc(id, life) {
+            return {
+                _id: id,
+                owner: OWNER,
+                ttl: life.ttl,
+                ends: life.ends,
+                max_ends: life.max_ends,
+                multi: true,
+                app: "",
+                endpoint: ""
+            };
+        }
+
+        /**
+        * Verify a token through the public entry point, handing back the document or false.
+        * @param {object} db - stub
+        * @param {string} id - token id
+        * @param {function} cb - called with the verify result
+        * @returns {void}
+        */
+        function verify(db, id, cb) {
+            authorizer.verify_return({
+                db: db,
+                token: id,
+                req_path: "",
+                return_data: true,
+                callback: cb
+            });
+        }
+
+        it("refuses a token whose bound has passed, however far its ends was pushed", function(done) {
+            //whatever moved ends - the session-timeout retiming of every LoggedInAuth token of a
+            //member writes ends directly - the parent's bound is the end of this token's life
+            var db = dbStub([tokenDoc("pushed", {ttl: 3600, ends: now + 3600, max_ends: now - 5})]);
+            verify(db, "pushed", function(valid) {
+                (!valid).should.equal(true);
+                done();
+            });
+        });
+
+        it("refuses a never-expiring token once its bound has passed", function(done) {
+            var db = dbStub([tokenDoc("forever", {ttl: 0, ends: 0, max_ends: now - 5})]);
+            verify(db, "forever", function(valid) {
+                (!valid).should.equal(true);
+                done();
+            });
+        });
+
+        it("accepts a bounded token while its bound is ahead", function(done) {
+            var db = dbStub([tokenDoc("alive", {ttl: 3600, ends: now + 3600, max_ends: now + 60})]);
+            verify(db, "alive", function(valid) {
+                valid._id.should.equal("alive");
+                done();
+            });
+        });
+
+        it("keeps session-timeout retiming away from bounded tokens", function() {
+            //plugins/plugins rewrites ttl and ends of every LoggedInAuth token a member owns when the
+            //session timeout changes. A bounded child is not a session token, whatever purpose it was
+            //given, so both updates leave bounded tokens alone
+            var src = require("fs").readFileSync(require("path").join(__dirname, "../../plugins/plugins/api/api.js"), "utf8");
+            var updates = src.match(/collection\("auth_tokens"\)\.update\(\{[^\n]*"purpose": "LoggedInAuth"[^\n]*\}/g) || [];
+            updates.length.should.equal(2);
+            updates.forEach(function(call) {
+                call.should.match(/"max_ends": \{\$exists: false\}/);
             });
         });
     });

--- a/test/unit-tests/api.utils.rights.tokenPermissions.js
+++ b/test/unit-tests/api.utils.rights.tokenPermissions.js
@@ -125,10 +125,12 @@ describe("token permissions", function() {
             };
             rights.isPermissionSubset(permission({adminApps: [APP_B]}), featuresOnly).should.equal(false);
             //the four all grants themselves are still passed on, since the ceiling does hold them
-            var allFour = permission({grants: [
-                {type: "c", app: APP_B, all: true}, {type: "r", app: APP_B, all: true},
-                {type: "u", app: APP_B, all: true}, {type: "d", app: APP_B, all: true}
-            ]});
+            var allFour = permission({
+                grants: [
+                    {type: "c", app: APP_B, all: true}, {type: "r", app: APP_B, all: true},
+                    {type: "u", app: APP_B, all: true}, {type: "d", app: APP_B, all: true}
+                ]
+            });
             rights.isPermissionSubset(allFour, featuresOnly).should.equal(true);
         });
 

--- a/test/unit-tests/api.utils.rights.tokenPermissions.js
+++ b/test/unit-tests/api.utils.rights.tokenPermissions.js
@@ -107,6 +107,31 @@ describe("token permissions", function() {
                 featureOnly).should.equal(true);
         });
 
+        it("refuses administering an app the ceiling holds every feature on but is not a member of", function() {
+            //four all:true entries satisfy hasAdminAccess, yet the app is absent from the member's
+            //own _.u/_.a. A child naming it under _.a would gain admin membership of an app its
+            //owner is not a member of - the same escalation as the user-app case, one level up
+            var featuresOnly = {
+                global_admin: false,
+                permission: permission({
+                    userApps: [APP_A],
+                    grants: [
+                        {type: "c", app: APP_B, all: true},
+                        {type: "r", app: APP_B, all: true},
+                        {type: "u", app: APP_B, all: true},
+                        {type: "d", app: APP_B, all: true}
+                    ]
+                })
+            };
+            rights.isPermissionSubset(permission({adminApps: [APP_B]}), featuresOnly).should.equal(false);
+            //the four all grants themselves are still passed on, since the ceiling does hold them
+            var allFour = permission({grants: [
+                {type: "c", app: APP_B, all: true}, {type: "r", app: APP_B, all: true},
+                {type: "u", app: APP_B, all: true}, {type: "d", app: APP_B, all: true}
+            ]});
+            rights.isPermissionSubset(allFour, featuresOnly).should.equal(true);
+        });
+
         it("refuses anything that is not a permission object", function() {
             rights.isPermissionSubset(undefined, member).should.equal(false);
             rights.isPermissionSubset([], member).should.equal(false);
@@ -176,6 +201,22 @@ describe("token permissions", function() {
             };
             ownerWithEmptyEntry.permission.r[APP_B] = {all: false, allowed: {}};
             var scoped = rights.intersectPermission(ownerWithEmptyEntry, permission({userApps: [APP_B]}));
+            rights.getUserApps(scoped).indexOf(APP_B).should.equal(-1);
+        });
+
+        it("does not turn four all grants into admin membership", function() {
+            var featuresOnly = {
+                global_admin: false,
+                permission: permission({
+                    userApps: [APP_A],
+                    grants: [
+                        {type: "c", app: APP_B, all: true}, {type: "r", app: APP_B, all: true},
+                        {type: "u", app: APP_B, all: true}, {type: "d", app: APP_B, all: true}
+                    ]
+                })
+            };
+            var scoped = rights.intersectPermission(featuresOnly, permission({adminApps: [APP_B]}));
+            rights.getAdminApps(scoped).indexOf(APP_B).should.equal(-1);
             rights.getUserApps(scoped).indexOf(APP_B).should.equal(-1);
         });
 

--- a/test/unit-tests/api.utils.rights.tokenPermissions.js
+++ b/test/unit-tests/api.utils.rights.tokenPermissions.js
@@ -77,6 +77,36 @@ describe("token permissions", function() {
             rights.isPermissionSubset(editorShaped, {permission: readCoreOnA}).should.equal(true);
         });
 
+        it("refuses membership of an app the ceiling merely has an empty entry for", function() {
+            //the permission editor writes an entry for every app it could see, so a member
+            //routinely carries empty entries for apps it has no access to at all. Naming one
+            //as a user app grants membership, and validateUserForRead authorizes on membership
+            //alone, so accepting this would hand the token an app its own owner is refused on
+            var ownerWithEmptyEntry = {
+                global_admin: false,
+                permission: permission({
+                    userApps: [APP_A],
+                    grants: [{type: "r", app: APP_A, allowed: {core: true}}]
+                })
+            };
+            ownerWithEmptyEntry.permission.r[APP_B] = {all: false, allowed: {}};
+            var membershipOfB = permission({userApps: [APP_B]});
+            rights.isPermissionSubset(membershipOfB, ownerWithEmptyEntry).should.equal(false);
+        });
+
+        it("refuses membership of an app the ceiling only holds one feature on", function() {
+            //holding a feature on an app is not the same as being a member of it
+            var featureOnly = {
+                global_admin: false,
+                permission: permission({grants: [{type: "r", app: APP_A, allowed: {core: true}}]})
+            };
+            rights.isPermissionSubset(permission({userApps: [APP_A]}), featureOnly).should.equal(false);
+            //the feature grant itself is still passed on, because that the ceiling does hold
+            rights.isPermissionSubset(
+                permission({grants: [{type: "r", app: APP_A, allowed: {core: true}}]}),
+                featureOnly).should.equal(true);
+        });
+
         it("refuses anything that is not a permission object", function() {
             rights.isPermissionSubset(undefined, member).should.equal(false);
             rights.isPermissionSubset([], member).should.equal(false);
@@ -132,6 +162,33 @@ describe("token permissions", function() {
             rights.hasAdminAccess(scoped, APP_A).should.equal(false);
             rights.hasReadRight("core", APP_A, scoped).should.equal(true);
             rights.hasDeleteRight("core", APP_A, scoped).should.equal(false);
+        });
+
+        it("never grants membership of an app the owner is not a member of", function() {
+            //enforcement side of the same rule: even a token that was somehow stored with a
+            //wider membership claim is bounded on every request by the owner's own membership
+            var ownerWithEmptyEntry = {
+                global_admin: false,
+                permission: permission({
+                    userApps: [APP_A],
+                    grants: [{type: "r", app: APP_A, allowed: {core: true}}]
+                })
+            };
+            ownerWithEmptyEntry.permission.r[APP_B] = {all: false, allowed: {}};
+            var scoped = rights.intersectPermission(ownerWithEmptyEntry, permission({userApps: [APP_B]}));
+            rights.getUserApps(scoped).indexOf(APP_B).should.equal(-1);
+        });
+
+        it("does not turn a feature grant into app membership", function() {
+            //the owner may read core on A without being a member of A, so a token carrying
+            //that same read must not come out a member of A either
+            var featureOnly = {
+                global_admin: false,
+                permission: permission({grants: [{type: "r", app: APP_A, allowed: {core: true}}]})
+            };
+            var scoped = rights.intersectPermission(featureOnly, readCoreOnA);
+            rights.hasReadRight("core", APP_A, scoped).should.equal(true);
+            rights.getUserApps(scoped).indexOf(APP_A).should.equal(-1);
         });
 
         it("reports only the apps the token reaches", function() {

--- a/test/unit-tests/frontend.token-manager.drawer.js
+++ b/test/unit-tests/frontend.token-manager.drawer.js
@@ -232,6 +232,28 @@ describe("token manager drawer", function() {
             permission.r.apponly.allowed.core.should.equal(true);
         });
 
+        it("derives the creator's membership from the legacy arrays when there is no permission object", function() {
+            //a member stored before permission objects existed has admin_of/user_of only, and the
+            //dashboard still serves them. Reading permission._.u would throw and no limited token
+            //could be created at all
+            var saved = loaded.sandbox.countlyGlobal.member;
+            loaded.sandbox.countlyGlobal.member = {global_admin: false, user_of: ["appone"], admin_of: ["apptwo"]};
+            try {
+                var vue = instance(loaded.drawer, FEATURES);
+                vue.tokenUsage = "1";
+                vue.permissionSet.r.allowed.core = true;
+                vue.setPermissionByFeature("r", "core");
+                loaded.created.length = 0;
+                vue.onSubmit({description: "d", checkboxMultipleTimes: true, selectApps: ["appone", "apptwo", "apponly"]});
+                var permission = loaded.created[0].permission;
+                should(JSON.parse(JSON.stringify(permission._.u))).eql([["appone", "apptwo"]]);
+                permission.r.apponly.allowed.core.should.equal(true);
+            }
+            finally {
+                loaded.sandbox.countlyGlobal.member = saved;
+            }
+        });
+
         it("grants every selected app the same permissions", function() {
             var vue = instance(loaded.drawer, FEATURES);
             vue.tokenUsage = "1";

--- a/test/unit-tests/frontend.token-manager.drawer.js
+++ b/test/unit-tests/frontend.token-manager.drawer.js
@@ -33,7 +33,8 @@ function loadDrawer() {
         window: {},
         console: console,
         $: jq,
-        countlyGlobal: {apps: {}, member: {}, defaultApp: {_id: "app"}},
+        //the member is a user of appone and apptwo; apponly it holds a feature on without membership
+        countlyGlobal: {apps: {appone: {}, apptwo: {}, apponly: {}}, member: {global_admin: false, permission: {_: {a: [], u: [["appone", "apptwo"]]}, c: {}, r: {}, u: {}, d: {}}}, defaultApp: {_id: "appone"}},
         countlyCommon: {API_URL: "", ACTIVE_APP_ID: "app"},
         CV: {
             T: function(name) {
@@ -212,6 +213,23 @@ describe("token manager drawer", function() {
             loaded.created.length = 0;
             vue.onSubmit({description: "d", checkboxMultipleTimes: false, checkboxCanLogin: false, selectApps: []});
             loaded.created[0].canLogin.should.equal(false);
+        });
+
+        it("names as user apps only the selected apps the creator is a member of", function() {
+            //the dashboard lists an app the creator holds one read grant on, with no membership.
+            //A token may carry that grant, but naming the app as a user app would be asking for
+            //membership the creator does not have, which the server refuses
+            var vue = instance(loaded.drawer, FEATURES);
+            vue.tokenUsage = "1";
+            vue.permissionSet.r.allowed.core = true;
+            vue.setPermissionByFeature("r", "core");
+            loaded.created.length = 0;
+            vue.onSubmit({description: "d", checkboxMultipleTimes: true, selectApps: ["appone", "apponly"]});
+            var permission = loaded.created[0].permission;
+            should(JSON.parse(JSON.stringify(permission._.u))).eql([["appone"]]);
+            //the feature grant travels to both, membership only to the one held
+            permission.r.appone.allowed.core.should.equal(true);
+            permission.r.apponly.allowed.core.should.equal(true);
         });
 
         it("grants every selected app the same permissions", function() {

--- a/test/unit-tests/frontend.token-manager.drawer.js
+++ b/test/unit-tests/frontend.token-manager.drawer.js
@@ -1,0 +1,248 @@
+var should = require("should");
+var fs = require("fs");
+var path = require("path");
+var vm = require("vm");
+
+// The token drawer decides what a token is asked for: which features it implies, what the
+// column headers report, and the permission object that reaches /i/token/create. That logic
+// is plain JavaScript inside the view file, so it is loaded here in a sandbox with the
+// globals the dashboard provides, and exercised directly - no browser, no Vue.
+
+var ROOT = path.join(__dirname, "../..");
+var AUTH = path.join(ROOT, "frontend/express/public/javascripts/countly/countly.auth.js");
+var VIEWS = path.join(ROOT, "frontend/express/public/core/token-manager/javascripts/countly.views.js");
+
+/**
+ * Load the view file with stubbed dashboard globals and hand back what it registered.
+ * @returns {object} {drawer, created} - the drawer component options and the create calls made
+ */
+function loadDrawer() {
+    var components = [];
+    var created = [];
+    var jq = function() {
+        return {};
+    };
+    jq.i18n = {map: {}};
+    jq.when = function() {
+        return {then: function() {}};
+    };
+    jq.ajax = function() {
+        return {};
+    };
+    var sandbox = {
+        window: {},
+        console: console,
+        $: jq,
+        countlyGlobal: {apps: {}, member: {}, defaultApp: {_id: "app"}},
+        countlyCommon: {API_URL: "", ACTIVE_APP_ID: "app"},
+        CV: {
+            T: function(name) {
+                return name;
+            },
+            i18n: function(key) {
+                return key;
+            }
+        },
+        CountlyHelpers: {alert: function() {}, confirm: function() {}},
+        countlyTokenManager: {
+            createTokenWithPermissions: function(options, callback) {
+                created.push(options);
+                callback(null, {});
+            },
+            deleteToken: function() {}
+        },
+        countlyUserManagement: {
+            fetchFeatures: function() {
+                return {};
+            },
+            getFeatures: function() {
+                return [];
+            }
+        },
+        countlyVue: {
+            views: {
+                create: function(options) {
+                    components.push(options);
+                    return options;
+                },
+                BackboneWrapper: function() {}
+            },
+            mixins: {auth: function() {}, i18n: {}, hasDrawers: function() {}},
+            container: {registerData: function() {}}
+        },
+        app: {route: function() {}, addPageScript: function() {}}
+    };
+    sandbox.window.countlyAuth = {};
+    sandbox.global = sandbox;
+    vm.createContext(sandbox);
+    vm.runInContext(fs.readFileSync(AUTH, "utf8"), sandbox, {filename: AUTH});
+    sandbox.countlyAuth = sandbox.window.countlyAuth;
+    vm.runInContext(fs.readFileSync(VIEWS, "utf8"), sandbox, {filename: VIEWS});
+    return {drawer: components[0], created: created, sandbox: sandbox};
+}
+
+/**
+ * A drawer instance: its own data, its methods, and the $set Vue would provide.
+ * @param {object} drawer - component options
+ * @param {string[]} features - the feature list the drawer loaded
+ * @returns {object} something the methods can be called on
+ */
+function instance(drawer, features) {
+    var self = drawer.data();
+    Object.keys(drawer.methods).forEach(function(name) {
+        self[name] = drawer.methods[name].bind(self);
+    });
+    self.$set = function(obj, key, value) {
+        obj[key] = value;
+    };
+    self.$emit = function() {};
+    self.features = features || [];
+    self.filteredFeatures = self.features;
+    return self;
+}
+
+/**
+ * Feature names allowed for one access type.
+ * @param {object} permissionSet - the drawer's permission set
+ * @param {string} type - access type
+ * @returns {string[]} allowed feature names, sorted
+ */
+function allowed(permissionSet, type) {
+    return Object.keys(permissionSet[type].allowed).filter(function(feature) {
+        return permissionSet[type].allowed[feature] === true;
+    }).sort();
+}
+
+var FEATURES = ["core", "events", "crashes"];
+
+describe("token manager drawer", function() {
+    var loaded = loadDrawer();
+
+    describe("feature permissions", function() {
+        it("grants read alongside anything else, since nothing is usable without it", function() {
+            var vue = instance(loaded.drawer, FEATURES);
+            vue.permissionSet.u.allowed.events = true;
+            vue.setPermissionByFeature("u", "events");
+            allowed(vue.permissionSet, "r").should.eql(["events"]);
+            allowed(vue.permissionSet, "u").should.eql(["events"]);
+        });
+
+        it("takes everything away with read, since nothing survives without it", function() {
+            var vue = instance(loaded.drawer, FEATURES);
+            vue.permissionSet.u.allowed.events = true;
+            vue.setPermissionByFeature("u", "events");
+            //the checkbox has already written false before the handler runs
+            vue.permissionSet.r.allowed.events = false;
+            vue.setPermissionByFeature("r", "events");
+            allowed(vue.permissionSet, "r").should.eql([]);
+            allowed(vue.permissionSet, "u").should.eql([]);
+        });
+    });
+
+    describe("column headers", function() {
+        it("apply to every feature when nothing is filtered out", function() {
+            var vue = instance(loaded.drawer, FEATURES);
+            vue.allByType.r = true;
+            vue.setPermissionByType("r");
+            allowed(vue.permissionSet, "r").should.eql(FEATURES.slice().sort());
+            //every feature is selected, so this may be sent as an "all" grant
+            vue.permissionSet.r.all.should.equal(true);
+            vue.allByType.r.should.equal(true);
+        });
+
+        it("apply only to the features on screen, and say so", function() {
+            //the regression: reading the header off the full list left it ticked after a
+            //filtered toggle, so the header claimed a whole column that was not granted
+            var vue = instance(loaded.drawer, FEATURES);
+            vue.filteredFeatures = ["events"];
+            vue.allByType.u = true;
+            vue.setPermissionByType("u");
+            allowed(vue.permissionSet, "u").should.eql(["events"]);
+            //the header describes what is on screen, and every row on screen is granted
+            vue.allByType.u.should.equal(true);
+            //but the grant is not "all", which would cover features that were never shown
+            vue.permissionSet.u.all.should.equal(false);
+        });
+
+        it("stop claiming a column once the filter that made it true is cleared", function() {
+            var vue = instance(loaded.drawer, FEATURES);
+            vue.searchQuery = "events";
+            vue.search();
+            vue.allByType.u = true;
+            vue.setPermissionByType("u");
+            vue.allByType.u.should.equal(true);
+            vue.clearSearch();
+            vue.allByType.u.should.equal(false);
+            allowed(vue.permissionSet, "u").should.eql(["events"]);
+        });
+    });
+
+    describe("what is sent to the server", function() {
+        it("asks for a permission object for a limited token, and never login with it", function() {
+            var vue = instance(loaded.drawer, FEATURES);
+            vue.tokenUsage = "1";
+            vue.permissionSet.r.allowed.core = true;
+            vue.setPermissionByFeature("r", "core");
+            loaded.created.length = 0;
+            vue.onSubmit({description: "d", checkboxMultipleTimes: true, checkboxCanLogin: true, selectApps: ["appone"]});
+            //objects built inside the sandbox carry the sandbox's prototypes, so they are
+            //asserted through should() and compared as plain data
+            var sent = loaded.created[0];
+            should(sent).have.property("permission");
+            //login is a property of an unlimited token only, so it is not even offered here
+            should(sent).not.have.property("canLogin");
+            should(JSON.parse(JSON.stringify(sent.permission._.u))).eql([["appone"]]);
+            sent.permission.r.appone.allowed.core.should.equal(true);
+            Object.keys(sent.permission).sort().should.eql(["_", "c", "d", "r", "u"]);
+        });
+
+        it("sends no permission for a token with the creator's own access, and passes login on", function() {
+            var vue = instance(loaded.drawer, FEATURES);
+            vue.tokenUsage = "0";
+            loaded.created.length = 0;
+            vue.onSubmit({description: "d", checkboxMultipleTimes: false, checkboxCanLogin: true, selectApps: []});
+            var sent = loaded.created[0];
+            should(sent).not.have.property("permission");
+            sent.canLogin.should.equal(true);
+        });
+
+        it("does not ask for login unless it was ticked", function() {
+            var vue = instance(loaded.drawer, FEATURES);
+            vue.tokenUsage = "0";
+            loaded.created.length = 0;
+            vue.onSubmit({description: "d", checkboxMultipleTimes: false, checkboxCanLogin: false, selectApps: []});
+            loaded.created[0].canLogin.should.equal(false);
+        });
+
+        it("grants every selected app the same permissions", function() {
+            var vue = instance(loaded.drawer, FEATURES);
+            vue.tokenUsage = "1";
+            vue.permissionSet.d.allowed.crashes = true;
+            vue.setPermissionByFeature("d", "crashes");
+            loaded.created.length = 0;
+            vue.onSubmit({description: "d", checkboxMultipleTimes: true, selectApps: ["appone", "apptwo"]});
+            var permission = loaded.created[0].permission;
+            permission.d.appone.allowed.crashes.should.equal(true);
+            permission.d.apptwo.allowed.crashes.should.equal(true);
+            //delete implied read, and the implication travelled to both apps
+            permission.r.apptwo.allowed.crashes.should.equal(true);
+        });
+    });
+
+    describe("closing the drawer", function() {
+        it("leaves nothing of the previous token behind", function() {
+            var vue = instance(loaded.drawer, FEATURES);
+            vue.tokenUsage = "1";
+            vue.searchQuery = "events";
+            vue.search();
+            vue.allByType.r = true;
+            vue.setPermissionByType("r");
+            vue.onClose();
+            vue.tokenUsage.should.equal("0");
+            vue.searchQuery.should.equal("");
+            should(JSON.parse(JSON.stringify(vue.filteredFeatures))).eql(FEATURES);
+            allowed(vue.permissionSet, "r").should.eql([]);
+            should(JSON.parse(JSON.stringify(vue.allByType))).eql({c: false, r: false, u: false, d: false});
+        });
+    });
+});


### PR DESCRIPTION
Follow-up to #7963 (merged 28 Aug). Same fix as Countly/countly-platform#1323, minus the OIDC item (CE has no `plugins/oidc`). Three defects found while reviewing that PR; the first is a privilege escalation and the reason for this PR.

## 1. A scoped token could reach an app its owner cannot

`isPermissionSubset` used `principalApps(ceiling)` as the set of apps a child may name. That counted every app id present anywhere in the owner's permission object — including `c/r/u/d` entries that grant nothing. A member carrying such an entry for an app outside their `_.u` could mint a token with `_.u: [[thatApp]]`; `intersectPermission` then granted the token *membership* of it.

`validateUserForRead` / `validateUserForWrite` authorize on membership alone, and `getUserApps` drives:

- `/o/apps/mine` → the app's **key, accepted keys and checksum salt**
- dbviewer's `getBaseAppFilter` / `dbUserHasAccessToCollection` → the app's `drill_events` / `events_data` rows
- `/o/app_users/loyalty`, `/o/app_users/download/:id`, and list filters in cohorts, dashboards, funnels, formulas, drill bookmarks, server-stats

Reproduced end to end on a dev instance: owner gets `401` on app B, a token the owner minted gets `200`.

**Precondition.** The owner needs a `c/r/u/d` entry for an app outside their own `_.u`/`_.a`. The user-management UI does not produce that shape (it writes entries only for selected apps and nulls removed ones — `countlyAuth.initializePermissions`, which would, is dead code). API-provisioned users with hand-built permission objects do. Writes are not reachable (`validateUserForWrite` still needs `hasAdminAccess`), and no feature permission on the target app is gained.

**Fix.** Membership is bounded separately from feature grants, on both the creation and enforcement sides:

- `principalMemberApps()` — the owner's own `_.u`/`_.a` (or legacy `admin_of`/`user_of`). `isPermissionSubset` refuses a child that names a user app outside it.
- `principalApps()` now means apps actually *reached* (`grantingApps`), so an empty entry is not a reachable app.
- `intersectPermission` only puts an app into the scoped member's `_.u` when the owner is itself a member of it. Feature grants are untouched — they were already intersected per feature.

Detection query for an install (read-only): walks `members`, reports any whose permission object could mint such a token.

<details><summary>detect.js</summary>

```js
var affected = [];
db.members.find({global_admin: {$ne: true}, permission: {$exists: true}}).forEach(function(m) {
    var p = m.permission || {}, own = {}, extra = {};
    ((p._ && p._.u) || []).forEach(function(g) { (g || []).forEach(function(a) { own[a] = 1; }); });
    ((p._ && p._.a) || []).forEach(function(a) { own[a] = 1; });
    ["c", "r", "u", "d"].forEach(function(t) {
        Object.keys(p[t] || {}).forEach(function(a) { if (a !== "global" && !own[a]) { extra[a] = 1; } });
    });
    if (Object.keys(extra).length) { affected.push({user: m.username, exposedApps: Object.keys(extra).length}); }
});
print("members that could escalate: " + affected.length);
affected.forEach(function(a) { print("  " + JSON.stringify(a)); });
```
</details>

## 2. A scoped token could mint a child that outlives it

`ttl: 0` means never expires, so a 60-second scoped token could produce a permanent one with the same scope. The child's ttl is now capped at the parent's remaining life — only for `token_permission`-scoped creators. An api_key and the unscoped dashboard session token are the owner's own authority and are not capped, so the token manager UI can still issue no-expiry tokens.

## 3. Token drawer

- The CRUD column-header checkbox stayed ticked after a filtered toggle: its value went `false → true → false` in one tick, so Vue saw nothing to patch and the browser's tick stood. Headers now describe the rows on screen and re-sync when the filter changes.
- "Limited access" with no app selected created a token that authorized nothing; Create Token is now disabled until an app is picked.

## Tests

- `test/unit-tests/api.utils.rights.tokenPermissions.js` — +4: membership refused for an empty-entry app and for a feature-only app, on both `isPermissionSubset` and `intersectPermission`
- `test/unit-tests/api.login.token.mints.js` — new: every login-token mint site asks for `can_login`, and nothing else does
- `test/unit-tests/frontend.token-manager.drawer.js` — new: the drawer logic run in a VM sandbox against the real `countly.auth.js`; fails if the header fix is reverted
- `test/2.api/16.token.manager.js` — +12: the membership escalation end to end, the ttl cap, and that a full-permission credential is not capped

Token unit suites: 62 passing. `eslint --rulesdir bin/eslint-rules` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Review follow-ups (e220835f964)**

- **Admin-app membership (Codex P1):** `_.a` grants are now bounded by the ceiling's own membership on both the creation and enforcement side, exactly as `_.u` is. Four `all:true` entries on an app absent from the owner's `_.u`/`_.a` no longer let a child become admin of it.
- **Child lifetime (Codex P2, both server PRs):** `authorizer.save` takes an absolute `maxEnds` and applies it at insertion, after the async member lookup, so a scoped child can never outlive its parent by the lookup's latency.
- **Feature-only apps in the drawer (Codex P2):** the dashboard lists apps a member holds a read grant on without membership; the drawer now names as user apps only the selected apps the creator is a member of, so such tokens are created with their feature grants instead of a 403.
- **Windows path separators in the mint test (Copilot):** normalised.

All four changes applied identically to countly-platform#1323, countly-server#8007 and countly-server#8008.

**Verified live** against a running stack built from this branch (api + dashboard, real MongoDB), 2 Sep:
- P1 admin-app bound: a member holding `all:true` ×4 on an app it is not a member of is refused a child naming that app under `_.a` (403); the four grants still pass on as a feature token, and that token is not a member of the app (`/o/apps/mine` omits it).
- Child lifetime: a 60s scoped parent minting a `ttl:0` child stores `child.ends === parent.ends` exactly; an api_key `ttl:0` token stays uncapped.
- Feature-only apps, through the real drawer: logged in as a member with a read grant on app B but membership of A only, the dashboard lists both apps; selecting both and granting Core→read stores a token with `_.u` = A only and `r` grants on A and B. That token reads core on both apps, is a member of A only, and is refused on membership-only endpoints for B.
- Original escalation (`_.u` naming an app with an empty entry) still refused.

**Second review round (3efc217e8b5)**

- **Extension bypass of the child cap (Codex P1):** the bound is persisted as `max_ends` and `extend_token` clamps to it, so `/o/actions` ten-minute extensions can no longer keep a scoped child alive past its parent. Unbounded tokens extend as before.
- **Legacy members in the drawer (Codex P2):** membership is derived from `admin_of`/`user_of` when the member has no permission object, instead of throwing.

Applied identically to all three PRs.

**CI fixes (3b5dc7e6b36)**

- `lint`: the admin-membership unit case used a one-line `{grants: [...]}` literal that `object-curly-newline` rejects; reformatted to the shape CI already accepted on 24.05. No behaviour change.
- `test-api-core` on 24.05: the owner-reach case proved "the owner is refused on the other app" through `/o/app_users/loyalty`, which is gated by `validateUserForRead` on master but plain `validateUser` on `release.24.05`, so a non-member gets 200 there. The case now proves membership through `/o/apps/mine`, built from `getUserApps` on every branch, keeping the test identical across the three PRs. Live-checked against a running stack.

**Third review round (85a757007f9)**

- **Fail closed on extension (Codex P2):** a failed `max_ends` read now aborts `extend_token` instead of writing an unbounded extension.
- **Bound enforced at verification (Codex P2, session-timeout bypass):** `verify_token` refuses and consumes any token whose `max_ends` has passed, whatever its `ends` — so no writer that ignores the bound can carry a scoped child past its parent. The two session-timeout bulk updates in `plugins/plugins` additionally skip bounded tokens.
- **Vacuous `extendBy: 0` test (Codex P2):** replaced with a reachable relative extension; `err`/`ok` asserted. Dead branch removed.

Applied identically to all three PRs. Codex has hit its review usage limit on these PRs, so further rounds need a human.

**CI note (server master):** `ui-tests (dashboard)` fails in `dashboards.cy.js` with `Promise.withResolvers is not a function` inside the `verifyPdf` Cypress task — a Node-version fault in the runner's PDF tooling, unrelated to this change (the PR touches no dashboards code or spec; no token-manager Cypress spec exists).
- **Amendment (2b577ceea3c):** the live check found that a token past its bound was refused but not removed (the consume step sat inside the block the bound guard skipped). It is now consumed on the first refusal, like any other expired token; the unit cases assert the removal. Verified live: refused (400), document gone, unbounded parent unaffected.

**Final CI round (b85f121c3aa)**

- `test-api-core` (master and 24.05): my bound tests read the clock at file load; api-core loads every file first and runs for minutes, so a "one minute ahead" bound had already passed. Each case now reads the clock itself. Test only.
- Not this PR: `ui-tests (dashboard)` fails in Cypress's `verifyPdf` task with `Promise.withResolvers is not a function` (runner Node version); 24.05 `test-api-plugins` failed once on the density plugin's date-bucket assertion, which this PR does not touch and which passed on the previous head.

**Final local verification** against a running stack on this head: session token — redeem, list tokens, read data, mint an unrestricted `ttl:0` token, still valid after (5/5); legacy `admin_of`/`user_of` member creates a limited token through the real drawer with membership from `user_of`; bounded child refused and consumed once past its bound; unbounded parent untouched.

**Final live verification (b85f121c3aa) — and one new fact about the precondition**

- Pre-existing token shapes, all without `max_ends`, behave exactly as before through the routes this PR touches: single-use consumed once; ttl-expired refused and consumed; `ttl:0` never-expiring works; a legacy app+endpoint-scoped token is allowed/refused as before and is still extended by `/o/actions`; `/session` keep-alive succeeds; dashboard session token redeems, lists, reads, mints, and stays valid (13/13).
- **The escalation precondition is producible through the product UI after all — via groups.** `rebuildUserPermissions` merges a group's permission into each member, and `mergePermissions` carries empty `c/r/u/d` entries with it: a group granting core on app B while carrying an empty entry for app C leaves each member with `r[C] = {allowed: {}}` and C absent from `_.u`. That is exactly the shape the original hole needed. Verified live: the group member reads B, is not a member of C, is refused a token naming C under `_.u` (403), and refused one naming an app the group never mentioned. Earlier I said the dashboard never creates this shape; that was true of the user editor, not of groups. It raises the chance that real installs carry the precondition — the `detect.js` query in the description is the way to know.
