### PR TITLE
chore: sync merge shepherd — auto-merge-priority label

### DIFF
--- a/.github/scripts/merge-shepherd.js
+++ b/.github/scripts/merge-shepherd.js
@@ -12,6 +12,8 @@
 const CONFIG = {
     QUEUE_LABEL: 'auto-merge',
     FAILED_LABEL: 'auto-merge-failed',
+    // reorders the queue only — a PR still needs QUEUE_LABEL to be in it at all
+    PRIORITY_LABEL: 'auto-merge-priority',
     BATCH_SIZE: 3,
     MAX_RETRIES: 5,
     MERGE_METHOD: 'MERGE',
@@ -132,14 +134,20 @@ function buildStateCommentBody(state) {
 }
 
 /**
- * Selects the batch of PRs to shepherd this run
+ * Selects the batch of PRs to shepherd this run. Priority-labelled PRs go first (oldest
+ * first among themselves), then everything else oldest first.
  * @param {object[]} snapshots - PR snapshots (see Task 1 interface notes)
  * @param {number} [batchSize] - max PRs to admit into the batch (defaults to CONFIG.BATCH_SIZE)
  * @returns {{batch: object[], skipped: {number: number, reason: string}[]}} batch members and skipped PRs with reasons
  */
 function selectBatch(snapshots, batchSize) {
     const limit = typeof batchSize === 'number' ? batchSize : CONFIG.BATCH_SIZE;
-    const sorted = snapshots.slice().sort((a, b) => (a.createdAt < b.createdAt ? -1 : 1));
+    const sorted = snapshots.slice().sort((a, b) => {
+        if (!!a.isPriority !== !!b.isPriority) {
+            return a.isPriority ? -1 : 1;
+        }
+        return a.createdAt < b.createdAt ? -1 : 1;
+    });
     const batch = [];
     const skipped = [];
     for (const pr of sorted) {
@@ -299,6 +307,7 @@ query($owner: String!, $repo: String!) {
 function toSnapshot(node) {
     const commit = node.commits.nodes[0] && node.commits.nodes[0].commit;
     const rollupState = (commit && commit.statusCheckRollup) ? commit.statusCheckRollup.state : 'PENDING';
+    const labelNames = ((node.labels && node.labels.nodes) || []).map((l) => l.name);
     return {
         id: node.id,
         number: node.number,
@@ -311,7 +320,8 @@ function toSnapshot(node) {
         headSha: node.headRefOid,
         authorLogin: (node.author && node.author.login) || null,
         autoMergeEnabled: !!node.autoMergeRequest,
-        hasFailedLabel: ((node.labels && node.labels.nodes) || []).some((l) => l.name === CONFIG.FAILED_LABEL),
+        hasFailedLabel: labelNames.includes(CONFIG.FAILED_LABEL),
+        isPriority: labelNames.includes(CONFIG.PRIORITY_LABEL),
         checksFailed: rollupState === 'FAILURE' || rollupState === 'ERROR',
         checksPending: rollupState === 'PENDING' || rollupState === 'EXPECTED',
         mergeStateStatus: null,
@@ -408,6 +418,7 @@ async function preflightPermissionChecks(github, owner, repo, core) {
 const LABEL_SPECS = [
     { name: CONFIG.QUEUE_LABEL, color: '2ea44f', description: 'Opt this PR into the Merge Shepherd auto-merge queue' },
     { name: CONFIG.FAILED_LABEL, color: 'd73a4a', description: 'Merge Shepherd removed this PR from the queue after its checks failed repeatedly' },
+    { name: CONFIG.PRIORITY_LABEL, color: 'fbca04', description: 'Move this PR to the front of the Merge Shepherd queue (still needs the auto-merge label)' },
 ];
 
 /**
@@ -670,7 +681,7 @@ async function writeSummary(core, batch, skipped, actions, errors) {
     ]];
     for (const pr of batch) {
         const prActions = actions.filter((a) => a.number === pr.number);
-        rows.push(['#' + pr.number + ' ' + escapeHtml(pr.title), 'in batch', prActions.map((a) => a.type + (a.reason ? ' (' + a.reason + ')' : '')).join(', ') || 'none']);
+        rows.push(['#' + pr.number + ' ' + escapeHtml(pr.title), pr.isPriority ? 'in batch (priority)' : 'in batch', prActions.map((a) => a.type + (a.reason ? ' (' + a.reason + ')' : '')).join(', ') || 'none']);
     }
     for (const s of skipped) {
         rows.push(['#' + s.number, 'skipped', s.reason]);

--- a/.github/scripts/merge-shepherd.test.js
+++ b/.github/scripts/merge-shepherd.test.js
@@ -87,6 +87,38 @@ test('selectBatch honors a custom batchSize, taking only the oldest eligible PR'
     ]);
 });
 
+test('selectBatch puts priority PRs first, oldest first among themselves, then the rest oldest first', () => {
+    const prs = [
+        makePr({ number: 1, createdAt: '2026-07-01T00:00:00Z' }),
+        makePr({ number: 2, createdAt: '2026-07-02T00:00:00Z' }),
+        makePr({ number: 3, createdAt: '2026-07-03T00:00:00Z', isPriority: true }),
+        makePr({ number: 4, createdAt: '2026-07-04T00:00:00Z', isPriority: true }),
+    ];
+    const { batch, skipped } = shepherd.selectBatch(prs);
+    assert.deepStrictEqual(batch.map((p) => p.number), [3, 4, 1]);
+    assert.deepStrictEqual(skipped, [{ number: 2, reason: 'queued behind batch' }]);
+});
+
+test('selectBatch gives batch slots to priority PRs before older non-priority ones', () => {
+    const prs = [
+        makePr({ number: 1, createdAt: '2026-07-01T00:00:00Z' }),
+        makePr({ number: 2, createdAt: '2026-07-09T00:00:00Z', isPriority: true }),
+    ];
+    const { batch, skipped } = shepherd.selectBatch(prs, 1);
+    assert.deepStrictEqual(batch.map((p) => p.number), [2]);
+    assert.deepStrictEqual(skipped, [{ number: 1, reason: 'queued behind batch' }]);
+});
+
+test('selectBatch still skips an ineligible priority PR without letting it block others', () => {
+    const prs = [
+        makePr({ number: 1, createdAt: '2026-07-01T00:00:00Z' }),
+        makePr({ number: 2, createdAt: '2026-07-02T00:00:00Z', isPriority: true, reviewDecision: 'REVIEW_REQUIRED' }),
+    ];
+    const { batch, skipped } = shepherd.selectBatch(prs, 1);
+    assert.deepStrictEqual(batch.map((p) => p.number), [1]);
+    assert.deepStrictEqual(skipped, [{ number: 2, reason: 'not approved' }]);
+});
+
 test('conflicting PR is ejected', () => {
     const actions = shepherd.planForBatchMember(makePr({ mergeable: 'CONFLICTING' }));
     assert.deepStrictEqual(actions, [{ type: 'eject', number: 1, reason: 'conflict' }]);
@@ -1125,7 +1157,7 @@ test('run() fails the run when writing the job summary itself throws', async() =
     assert.ok(core.setFailedCalls.some((m) => /failed to write job summary/.test(m)));
 });
 
-test('run() ensures both the queue label and the failed-checks marker label exist', async() => {
+test('run() ensures the queue, failed-checks and priority labels exist', async() => {
     const { github, calls } = makeFakeGithub({
         nodes: [makeNode({})],
         pullsByNumber: { 1: { mergeable_state: 'clean' } },
@@ -1133,6 +1165,40 @@ test('run() ensures both the queue label and the failed-checks marker label exis
     await shepherd.run({ github, context: fakeContext, core: makeFakeCore(), dryRun: false });
     assert.ok(calls.includes('createLabel:auto-merge'));
     assert.ok(calls.includes('createLabel:auto-merge-failed'));
+    assert.ok(calls.includes('createLabel:auto-merge-priority'));
+});
+
+test('run() processes a newer priority-labelled PR ahead of an older one when the batch is full', async() => {
+    const nodes = [
+        makeNode({ id: 'PR_1', number: 1, createdAt: '2026-07-01T00:00:00Z' }),
+        makeNode({
+            id: 'PR_2',
+            number: 2,
+            createdAt: '2026-07-02T00:00:00Z',
+            labels: { nodes: [{ name: 'auto-merge' }, { name: 'auto-merge-priority' }] },
+        }),
+    ];
+    const { github, calls } = makeFakeGithub({
+        nodes,
+        pullsByNumber: { 1: { mergeable_state: 'behind' }, 2: { mergeable_state: 'behind' } },
+    });
+    await shepherd.run({ github, context: fakeContext, core: makeFakeCore(), dryRun: false, batchSize: 1 });
+    assert.ok(calls.includes('updateBranch:2'), 'priority PR takes the only batch slot');
+    assert.ok(!calls.includes('updateBranch:1'), 'older non-priority PR waits behind it');
+});
+
+test('run() does not enroll a PR that carries only the priority label', async() => {
+    // the queue query is filtered by the auto-merge label, so a priority-only PR never appears
+    // in the queue at all; this pins that the snapshot flag is read from the label list only
+    const nodes = [
+        makeNode({ labels: { nodes: [{ name: 'auto-merge' }] } }),
+    ];
+    const { github, calls } = makeFakeGithub({
+        nodes,
+        pullsByNumber: { 1: { mergeable_state: 'behind' } },
+    });
+    await shepherd.run({ github, context: fakeContext, core: makeFakeCore(), dryRun: false });
+    assert.ok(calls.includes('updateBranch:1'));
 });
 
 test('run() removes the stale auto-merge-failed label from both a batch member and a skipped-ineligible PR that still carry it', async() => {

--- a/docs/MERGE_SHEPHERD.md
+++ b/docs/MERGE_SHEPHERD.md
@@ -15,7 +15,11 @@ passing CI — every merge invalidates every other open PR.
 
 The queue is processed **oldest PR first**, up to **3 PRs at a time** (batch
 size is configurable via the repository Actions variable
-`MERGE_SHEPHERD_BATCH_SIZE`, default 3).
+`MERGE_SHEPHERD_BATCH_SIZE`, default 3). To jump the line, add the
+**`auto-merge-priority`** label as well: priority PRs are processed before
+everything else (oldest first among themselves) and take batch slots first.
+The priority label only reorders — a PR still needs `auto-merge` to be in the
+queue at all, and it must still meet the same eligibility rules.
 
 Your PR is **ejected from the queue** (label removed, comment explains why —
 and, if auto-merge was already armed on it, the comment says so too, since


### PR DESCRIPTION
## Summary

Propagates [countly-platform#1421](https://github.com/Countly/countly-platform/pull/1421) to this repo's Merge Shepherd, applied as a patch so repo-specific adaptations are preserved.

- New **`auto-merge-priority`** label: PRs carrying it (in addition to `auto-merge`) are processed **before every other queued PR** — oldest first among priority PRs, then everything else oldest first — and take batch slots first
- It only **reorders**: a PR still needs `auto-merge` to be in the queue, and the same eligibility rules apply (an unapproved priority PR is skipped and never blocks the queue)
- The bot creates the label on first run; the job summary marks members as `in batch (priority)`

## Test plan

- [x] Shepherd test suite run inside this repo's clone (see commit) — all passing
- [ ] Live: add `auto-merge-priority` to an approved queued PR and confirm it appears first / `in batch (priority)` in the next run's job summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)