### PR TITLE
build(deps): Bump qs to 6.16.0 via npm override (keep express 4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10850,12 +10850,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -11572,14 +11573,14 @@
       "license": "MIT"
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "xlsx-write-stream": "^1.0.0"
   },
   "overrides": {
+    "qs": "^6.16.0",
     "csurf": {
       "cookie": "^0.7.1"
     },


### PR DESCRIPTION
Alternative to #8011, which could only reach qs 6.16.0 by bumping express 4.22.2 → 5.2.1. We are not taking express 5 yet, so this gets the qs fix on its own.

## Why an override is required

`express@4.22.2` declares `qs: "~6.15.1"` (`>=6.15.1 <6.16.0`), so no amount of `npm update` reaches 6.16.0 — the range excludes it. That is exactly why dependabot proposed the express major. A root `overrides` entry forces the resolution instead, which the repo already does for `jimp`/`xml2js` and `csurf`/`cookie`.

## Change

```json
"overrides": {
  "qs": "^6.16.0",
  ...
}
```

plus the two lock entries npm resolves under it (`qs` 6.15.2 → 6.16.0, its dep `side-channel` 1.1.0 → 1.1.1). 20 lines, no express change.

Closes two open dependabot alerts (both medium, both first patched in 6.16.0):

| Advisory | Summary | Vulnerable |
|---|---|---|
| GHSA-4mjr-xmp4-gh2g | qs: DoS via attacker-controlled `isBuffer` | `>= 2.2.5, < 6.16.0` |
| GHSA-x5fp-wj9c-mxmx | qs array-limit bypass via bracket-key comma parsing | `>= 6.14.2, <= 6.15.3` |

## Verification

- The tree has a single hoisted `qs`. After the override it resolves to 6.16.0 for every consumer — `express@4.22.2`, `body-parser@1.20.6` (nested under express), `body-parser@2.3.0`, `formidable@2.1.3` — and no nested `qs` copy is created (`node_modules/express/node_modules/qs` absent).
- Behaviour parity 6.15.2 vs 6.16.0: `parse` over 14 Countly-shaped query strings (nested brackets, `events[0][key]`, `filter[$and][…]`, `$in` JSON payloads, comma groups, dot keys, arrayLimit boundary at 19/25, encoded values, valueless keys) × 5 option sets (default, `depth`, `allowPrototypes`, `arrayLimit`, `comma`), plus `stringify` on nested/array/Date/empty-array/null inputs — **zero differences**.
- End-to-end on express 4.22.2 with `query parser: extended` and `body-parser`: extended GET query, urlencoded POST body (`events[0][key]=login`), and JSON POST body all parse as before.

## Lockfile

Merged with latest `master`, which has since regenerated the lock and added several overrides of its own (`body-parser@^1.0.0`, `brace-expansion`, `js-yaml`) — same mechanism as this one. `npm ci` passes on the merged branch, installs qs 6.16.0, and leaves the lock untouched.

After this merges, #8011 can be closed (`@dependabot ignore this major version` on express keeps it from coming back), and express 5 can be evaluated on its own schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
